### PR TITLE
NOISSUE - Add task metadata

### DIFF
--- a/examples/http-server/src/lib.rs
+++ b/examples/http-server/src/lib.rs
@@ -116,7 +116,7 @@ fn headers_response(request: IncomingRequest, response_out: ResponseOutparam) {
 
     let out_headers = Fields::new();
     out_headers
-        .set(&"content-type".to_string(), &[b"text/plain".to_vec()])
+        .set("content-type", &[b"text/plain".to_vec()])
         .unwrap();
     let response = OutgoingResponse::new(out_headers);
     response.set_status_code(200).unwrap();
@@ -152,9 +152,8 @@ fn read_body(request: IncomingRequest) -> Vec<u8> {
             Ok(chunk) => data.extend_from_slice(&chunk),
             Err(_) => break,
         }
-        match stream.read(0) {
-            Err(_) => break,
-            Ok(_) => {}
+        if stream.read(0).is_err() {
+            break;
         }
     }
     data

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -263,35 +263,25 @@ func stopJobEndpoint(svc manager.Service) endpoint.Endpoint {
 
 func listTasksEndpoint(svc manager.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request any) (any, error) {
-		switch req := request.(type) {
-		case listEntityReq:
-			if err := req.validate(); err != nil {
-				return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
-			}
-			tasks, err := svc.ListTasks(ctx, req.offset, req.limit)
-			if err != nil {
-				return listTaskResponse{}, err
-			}
-
-			return listTaskResponse{TaskPage: tasks}, nil
-		case listTasksReq:
-			if err := req.validate(); err != nil {
-				return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
-			}
-			pm := sdk.PageMetadata{
-				Offset:         req.offset,
-				Limit:          req.limit,
-				MetadataFilter: req.metadataFilter,
-			}
-			tasks, err := svc.ListTasksByFilter(ctx, pm)
-			if err != nil {
-				return listTaskResponse{}, err
-			}
-
-			return listTaskResponse{TaskPage: tasks}, nil
-		default:
+		req, ok := request.(listTasksReq)
+		if !ok {
 			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, pkgerrors.ErrInvalidData)
 		}
+		if err := req.validate(); err != nil {
+			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
+		}
+
+		pm := sdk.PageMetadata{
+			Offset:         req.offset,
+			Limit:          req.limit,
+			MetadataFilter: req.metadataFilter,
+		}
+		tasks, err := svc.ListTasks(ctx, pm)
+		if err != nil {
+			return listTaskResponse{}, err
+		}
+
+		return listTaskResponse{TaskPage: tasks}, nil
 	}
 }
 

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -7,6 +7,7 @@ import (
 	apiutil "github.com/absmach/magistrala/api/http/util"
 	"github.com/absmach/propeller/manager"
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
+	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/go-kit/kit/endpoint"
 )
 
@@ -262,22 +263,35 @@ func stopJobEndpoint(svc manager.Service) endpoint.Endpoint {
 
 func listTasksEndpoint(svc manager.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request any) (any, error) {
-		req, ok := request.(listEntityReq)
-		if !ok {
+		switch req := request.(type) {
+		case listEntityReq:
+			if err := req.validate(); err != nil {
+				return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
+			}
+			tasks, err := svc.ListTasks(ctx, req.offset, req.limit)
+			if err != nil {
+				return listTaskResponse{}, err
+			}
+
+			return listTaskResponse{TaskPage: tasks}, nil
+		case listTasksReq:
+			if err := req.validate(); err != nil {
+				return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
+			}
+			pm := sdk.PageMetadata{
+				Offset:         req.offset,
+				Limit:          req.limit,
+				MetadataFilter: req.metadataFilter,
+			}
+			tasks, err := svc.ListTasksByFilter(ctx, pm)
+			if err != nil {
+				return listTaskResponse{}, err
+			}
+
+			return listTaskResponse{TaskPage: tasks}, nil
+		default:
 			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, pkgerrors.ErrInvalidData)
 		}
-		if err := req.validate(); err != nil {
-			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
-		}
-
-		tasks, err := svc.ListTasks(ctx, req.offset, req.limit)
-		if err != nil {
-			return listTaskResponse{}, err
-		}
-
-		return listTaskResponse{
-			TaskPage: tasks,
-		}, nil
 	}
 }
 

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -272,9 +272,9 @@ func listTasksEndpoint(svc manager.Service) endpoint.Endpoint {
 		}
 
 		pm := sdk.PageMetadata{
-			Offset:         req.offset,
-			Limit:          req.limit,
-			MetadataFilter: req.metadataFilter,
+			Offset:   req.offset,
+			Limit:    req.limit,
+			Metadata: req.metadata,
 		}
 		tasks, err := svc.ListTasks(ctx, pm)
 		if err != nil {

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -7,7 +7,6 @@ import (
 	apiutil "github.com/absmach/magistrala/api/http/util"
 	"github.com/absmach/propeller/manager"
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
-	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/go-kit/kit/endpoint"
 )
 
@@ -271,7 +270,7 @@ func listTasksEndpoint(svc manager.Service) endpoint.Endpoint {
 			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
 		}
 
-		pm := sdk.PageMetadata{
+		pm := manager.PageMetadata{
 			Offset:   req.offset,
 			Limit:    req.limit,
 			Metadata: req.metadata,

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -15,7 +15,10 @@ import (
 
 var errStatusFilterUnsupported = errors.New("status filter is not supported")
 
-const maxMetadataBytes = 1048576
+const (
+	maxMetadataBytes = 1048576 // 1MB
+	maxLimitSize     = 100
+)
 
 type taskReq struct {
 	task.Task `json:",inline"`
@@ -161,6 +164,10 @@ type listTasksReq struct {
 }
 
 func (r *listTasksReq) validate() error {
+	if r.limit > maxLimitSize || r.limit < 1 {
+		return apiutil.ErrLimitSize
+	}
+
 	return nil
 }
 

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -161,7 +161,7 @@ type listTasksReq struct {
 	metadata task.Metadata
 }
 
-func (r *listTasksReq) validate() error {
+func (r listTasksReq) validate() error {
 	if r.limit > api.MaxLimitSize || r.limit < 1 {
 		return apiutil.ErrLimitSize
 	}

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -158,7 +158,7 @@ func (e listEntityReq) validate() error {
 type listTasksReq struct {
 	offset   uint64
 	limit    uint64
-	metadata map[string]any
+	metadata task.Metadata
 }
 
 func (r *listTasksReq) validate() error {

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -15,7 +15,7 @@ import (
 
 var errStatusFilterUnsupported = errors.New("status filter is not supported")
 
-const maxMetadataBytes = 65536
+const maxMetadataBytes = 1048576
 
 type taskReq struct {
 	task.Task `json:",inline"`
@@ -50,7 +50,7 @@ func (t *taskReq) validate() error {
 			return fmt.Errorf("invalid metadata: %w", err)
 		}
 		if len(b) > maxMetadataBytes {
-			return errors.New("metadata exceeds 64KB limit")
+			return errors.New("metadata exceeds 1MB limit")
 		}
 	}
 

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	apiutil "github.com/absmach/magistrala/api/http/util"
+	"github.com/absmach/propeller/pkg/api"
 	"github.com/absmach/propeller/pkg/cron"
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
 	"github.com/absmach/propeller/pkg/proplet"
@@ -15,10 +16,7 @@ import (
 
 var errStatusFilterUnsupported = errors.New("status filter is not supported")
 
-const (
-	maxMetadataBytes = 1048576 // 1MB
-	maxLimitSize     = 100
-)
+const maxMetadataBytes = 1048576 // 1MB
 
 type taskReq struct {
 	task.Task `json:",inline"`
@@ -164,7 +162,7 @@ type listTasksReq struct {
 }
 
 func (r *listTasksReq) validate() error {
-	if r.limit > maxLimitSize || r.limit < 1 {
+	if r.limit > api.MaxLimitSize || r.limit < 1 {
 		return apiutil.ErrLimitSize
 	}
 

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -13,6 +14,8 @@ import (
 )
 
 var errStatusFilterUnsupported = errors.New("status filter is not supported")
+
+const maxMetadataBytes = 65536
 
 type taskReq struct {
 	task.Task `json:",inline"`
@@ -39,6 +42,16 @@ func (t *taskReq) validate() error {
 
 	if t.Broadcast && t.PropletID != "" {
 		return fmt.Errorf("%w: broadcast and proplet_id are mutually exclusive", pkgerrors.ErrInvalidValue)
+	}
+
+	if len(t.Metadata) > 0 {
+		b, err := json.Marshal(t.Metadata)
+		if err != nil {
+			return fmt.Errorf("invalid metadata: %w", err)
+		}
+		if len(b) > maxMetadataBytes {
+			return errors.New("metadata exceeds 64KB limit")
+		}
 	}
 
 	return nil
@@ -139,6 +152,16 @@ func (e listEntityReq) validate() error {
 	default:
 		return pkgerrors.ErrInvalidValue
 	}
+}
+
+type listTasksReq struct {
+	offset         uint64
+	limit          uint64
+	metadataFilter map[string]string
+}
+
+func (r *listTasksReq) validate() error {
+	return nil
 }
 
 type metricsReq struct {

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -156,9 +156,9 @@ func (e listEntityReq) validate() error {
 }
 
 type listTasksReq struct {
-	offset         uint64
-	limit          uint64
-	metadataFilter map[string]string
+	offset   uint64
+	limit    uint64
+	metadata map[string]any
 }
 
 func (r *listTasksReq) validate() error {

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/absmach/magistrala"
@@ -82,7 +83,7 @@ func MakeHandler(svc manager.Service, logger *slog.Logger, instanceID string) ht
 		), "create-task").ServeHTTP)
 		r.Get("/", otelhttp.NewHandler(kithttp.NewServer(
 			listTasksEndpoint(svc),
-			decodeListEntityReq(withoutStatusFilter),
+			decodeListTasksReq,
 			api.EncodeResponse,
 			opts...,
 		), "list-tasks").ServeHTTP)
@@ -335,6 +336,42 @@ func decodeListEntityReq(statusFilter listEntityStatus) kithttp.DecodeRequestFun
 			statusFilter: statusFilter,
 		}, nil
 	}
+}
+
+var metadataKeyRe = regexp.MustCompile(`^[a-zA-Z0-9._/\-]+$`)
+
+func decodeListTasksReq(_ context.Context, r *http.Request) (any, error) {
+	o, err := apiutil.ReadNumQuery[uint64](r, api.OffsetKey, api.DefOffset)
+	if err != nil {
+		return nil, errors.Join(apiutil.ErrValidation, err)
+	}
+
+	l, err := apiutil.ReadNumQuery[uint64](r, api.LimitKey, api.DefLimit)
+	if err != nil {
+		return nil, errors.Join(apiutil.ErrValidation, err)
+	}
+
+	filter := map[string]string{}
+	for key, vals := range r.URL.Query() {
+		if !strings.HasPrefix(key, "metadata[") || !strings.HasSuffix(key, "]") {
+			continue
+		}
+		metaKey := key[len("metadata[") : len(key)-1]
+		if !metadataKeyRe.MatchString(metaKey) {
+			return nil, errors.Join(apiutil.ErrValidation, errors.New("metadata key contains invalid characters"))
+		}
+		filter[metaKey] = vals[0]
+	}
+
+	if len(filter) == 0 {
+		return listEntityReq{offset: o, limit: l}, nil
+	}
+
+	return listTasksReq{
+		offset:         o,
+		limit:          l,
+		metadataFilter: filter,
+	}, nil
 }
 
 func decodeMetricsReq(key string) kithttp.DecodeRequestFunc {

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/absmach/magistrala"
@@ -338,14 +337,6 @@ func decodeListEntityReq(statusFilter listEntityStatus) kithttp.DecodeRequestFun
 	}
 }
 
-const (
-	metadataQueryPrefix   = "metadata["
-	metadataQuerySuffix   = "]"
-	maxMetadataFilterKeys = 20
-)
-
-var metadataKeyRe = regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`)
-
 func decodeListTasksReq(_ context.Context, r *http.Request) (any, error) {
 	o, err := apiutil.ReadNumQuery[uint64](r, api.OffsetKey, api.DefOffset)
 	if err != nil {
@@ -357,26 +348,18 @@ func decodeListTasksReq(_ context.Context, r *http.Request) (any, error) {
 		return nil, errors.Join(apiutil.ErrValidation, err)
 	}
 
-	filter := map[string]string{}
-	for key, vals := range r.URL.Query() {
-		if !strings.HasPrefix(key, metadataQueryPrefix) || !strings.HasSuffix(key, metadataQuerySuffix) {
-			continue
-		}
-		if len(filter) >= maxMetadataFilterKeys {
-			return nil, errors.Join(apiutil.ErrValidation, errors.New("too many metadata filter keys"))
-		}
-		metaKey := key[len(metadataQueryPrefix) : len(key)-len(metadataQuerySuffix)]
-		if !metadataKeyRe.MatchString(metaKey) {
-			return nil, errors.Join(apiutil.ErrValidation, errors.New("metadata key contains invalid characters"))
-		}
-		if len(vals) > 1 {
-			return nil, errors.Join(apiutil.ErrValidation, errors.New("duplicate metadata filter key"))
-		}
-		filter[metaKey] = vals[0]
+	meta, err := apiutil.ReadMetadataQuery(r, api.MetadataKey, nil)
+	if err != nil {
+		return nil, errors.Join(apiutil.ErrValidation, err)
 	}
 
-	if len(filter) == 0 {
-		return listEntityReq{offset: o, limit: l}, nil
+	filter := make(map[string]string, len(meta))
+	for k, v := range meta {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		filter[k] = s
 	}
 
 	return listTasksReq{

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -339,8 +339,8 @@ func decodeListEntityReq(statusFilter listEntityStatus) kithttp.DecodeRequestFun
 }
 
 const (
-	metadataQueryPrefix = "metadata["
-	metadataQuerySuffix = "]"
+	metadataQueryPrefix   = "metadata["
+	metadataQuerySuffix   = "]"
 	maxMetadataFilterKeys = 20
 )
 

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -353,19 +353,10 @@ func decodeListTasksReq(_ context.Context, r *http.Request) (any, error) {
 		return nil, errors.Join(apiutil.ErrValidation, err)
 	}
 
-	filter := make(map[string]string, len(meta))
-	for k, v := range meta {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		filter[k] = s
-	}
-
 	return listTasksReq{
-		offset:         o,
-		limit:          l,
-		metadataFilter: filter,
+		offset:   o,
+		limit:    l,
+		metadata: meta,
 	}, nil
 }
 

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -338,7 +338,13 @@ func decodeListEntityReq(statusFilter listEntityStatus) kithttp.DecodeRequestFun
 	}
 }
 
-var metadataKeyRe = regexp.MustCompile(`^[a-zA-Z0-9._/\-]+$`)
+const (
+	metadataQueryPrefix = "metadata["
+	metadataQuerySuffix = "]"
+	maxMetadataFilterKeys = 20
+)
+
+var metadataKeyRe = regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`)
 
 func decodeListTasksReq(_ context.Context, r *http.Request) (any, error) {
 	o, err := apiutil.ReadNumQuery[uint64](r, api.OffsetKey, api.DefOffset)
@@ -353,12 +359,18 @@ func decodeListTasksReq(_ context.Context, r *http.Request) (any, error) {
 
 	filter := map[string]string{}
 	for key, vals := range r.URL.Query() {
-		if !strings.HasPrefix(key, "metadata[") || !strings.HasSuffix(key, "]") {
+		if !strings.HasPrefix(key, metadataQueryPrefix) || !strings.HasSuffix(key, metadataQuerySuffix) {
 			continue
 		}
-		metaKey := key[len("metadata[") : len(key)-1]
+		if len(filter) >= maxMetadataFilterKeys {
+			return nil, errors.Join(apiutil.ErrValidation, errors.New("too many metadata filter keys"))
+		}
+		metaKey := key[len(metadataQueryPrefix) : len(key)-len(metadataQuerySuffix)]
 		if !metadataKeyRe.MatchString(metaKey) {
 			return nil, errors.Join(apiutil.ErrValidation, errors.New("metadata key contains invalid characters"))
+		}
+		if len(vals) > 1 {
+			return nil, errors.Join(apiutil.ErrValidation, errors.New("duplicate metadata filter key"))
 		}
 		filter[metaKey] = vals[0]
 	}

--- a/manager/cron.go
+++ b/manager/cron.go
@@ -104,7 +104,23 @@ func (cs *cronScheduler) UnscheduleTask(ctx context.Context, taskID string) erro
 }
 
 func (cs *cronScheduler) listAllTasks(ctx context.Context) ([]task.Task, error) {
-	return listAllTasksFromRepo(ctx, cs.tasksDB)
+	const pageSize uint64 = 100
+	var allTasks []task.Task
+	var offset uint64
+
+	for {
+		tasks, total, err := cs.tasksDB.List(ctx, nil, offset, pageSize)
+		if err != nil {
+			return nil, err
+		}
+		allTasks = append(allTasks, tasks...)
+		offset += uint64(len(tasks))
+		if offset >= total || len(tasks) == 0 {
+			break
+		}
+	}
+
+	return allTasks, nil
 }
 
 func (cs *cronScheduler) processScheduledTasks(ctx context.Context) error {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
 )
 
@@ -24,6 +25,7 @@ type Service interface {
 	StartJob(ctx context.Context, jobID string) error
 	StopJob(ctx context.Context, jobID string) error
 	ListTasks(ctx context.Context, offset, limit uint64) (task.TaskPage, error)
+	ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error)
 	UpdateTask(ctx context.Context, task task.Task) (task.Task, error)
 	DeleteTask(ctx context.Context, taskID string) error
 	StartTask(ctx context.Context, taskID string) error

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -5,9 +5,14 @@ import (
 
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
-	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
 )
+
+type PageMetadata struct {
+	Offset   uint64        `json:"offset"`
+	Limit    uint64        `json:"limit"`
+	Metadata task.Metadata `json:"metadata,omitempty"`
+}
 
 type Service interface {
 	GetProplet(ctx context.Context, propletID string) (proplet.Proplet, error)
@@ -24,7 +29,7 @@ type Service interface {
 	ListJobs(ctx context.Context, offset, limit uint64, status string) (JobPage, error)
 	StartJob(ctx context.Context, jobID string) error
 	StopJob(ctx context.Context, jobID string) error
-	ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error)
+	ListTasks(ctx context.Context, pm PageMetadata) (task.TaskPage, error)
 	UpdateTask(ctx context.Context, task task.Task) (task.Task, error)
 	DeleteTask(ctx context.Context, taskID string) error
 	StartTask(ctx context.Context, taskID string) error

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -24,8 +24,7 @@ type Service interface {
 	ListJobs(ctx context.Context, offset, limit uint64, status string) (JobPage, error)
 	StartJob(ctx context.Context, jobID string) error
 	StopJob(ctx context.Context, jobID string) error
-	ListTasks(ctx context.Context, offset, limit uint64) (task.TaskPage, error)
-	ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error)
+	ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error)
 	UpdateTask(ctx context.Context, task task.Task) (task.Task, error)
 	DeleteTask(ctx context.Context, taskID string) error
 	StartTask(ctx context.Context, taskID string) error

--- a/manager/middleware/logging.go
+++ b/manager/middleware/logging.go
@@ -191,12 +191,12 @@ func (lm *loggingMiddleware) GetTask(ctx context.Context, id string) (resp task.
 	return lm.svc.GetTask(ctx, id)
 }
 
-func (lm *loggingMiddleware) ListTasks(ctx context.Context, offset, limit uint64) (resp task.TaskPage, err error) {
+func (lm *loggingMiddleware) ListTasks(ctx context.Context, pm sdk.PageMetadata) (resp task.TaskPage, err error) {
 	defer func(begin time.Time) {
 		args := []any{
 			slog.String("duration", time.Since(begin).String()),
-			slog.Uint64("offset", offset),
-			slog.Uint64("limit", limit),
+			slog.Uint64("offset", pm.Offset),
+			slog.Uint64("limit", pm.Limit),
 		}
 		if err != nil {
 			args = append(args, slog.Any("error", err))
@@ -207,26 +207,7 @@ func (lm *loggingMiddleware) ListTasks(ctx context.Context, offset, limit uint64
 		lm.logger.Info("List tasks completed successfully", args...)
 	}(time.Now())
 
-	return lm.svc.ListTasks(ctx, offset, limit)
-}
-
-func (lm *loggingMiddleware) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (resp task.TaskPage, err error) {
-	defer func(begin time.Time) {
-		args := []any{
-			slog.String("duration", time.Since(begin).String()),
-			slog.Uint64("offset", pm.Offset),
-			slog.Uint64("limit", pm.Limit),
-		}
-		if err != nil {
-			args = append(args, slog.Any("error", err))
-			lm.logger.Warn("List tasks by filter failed", args...)
-
-			return
-		}
-		lm.logger.Info("List tasks by filter completed successfully", args...)
-	}(time.Now())
-
-	return lm.svc.ListTasksByFilter(ctx, pm)
+	return lm.svc.ListTasks(ctx, pm)
 }
 
 func (lm *loggingMiddleware) UpdateTask(ctx context.Context, t task.Task) (resp task.Task, err error) {

--- a/manager/middleware/logging.go
+++ b/manager/middleware/logging.go
@@ -8,6 +8,7 @@ import (
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
 )
 
@@ -207,6 +208,25 @@ func (lm *loggingMiddleware) ListTasks(ctx context.Context, offset, limit uint64
 	}(time.Now())
 
 	return lm.svc.ListTasks(ctx, offset, limit)
+}
+
+func (lm *loggingMiddleware) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (resp task.TaskPage, err error) {
+	defer func(begin time.Time) {
+		args := []any{
+			slog.String("duration", time.Since(begin).String()),
+			slog.Uint64("offset", pm.Offset),
+			slog.Uint64("limit", pm.Limit),
+		}
+		if err != nil {
+			args = append(args, slog.Any("error", err))
+			lm.logger.Warn("List tasks by filter failed", args...)
+
+			return
+		}
+		lm.logger.Info("List tasks by filter completed successfully", args...)
+	}(time.Now())
+
+	return lm.svc.ListTasksByFilter(ctx, pm)
 }
 
 func (lm *loggingMiddleware) UpdateTask(ctx context.Context, t task.Task) (resp task.Task, err error) {

--- a/manager/middleware/logging.go
+++ b/manager/middleware/logging.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
-	"github.com/absmach/propeller/pkg/task"
 	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/absmach/propeller/pkg/task"
 )
 
 type loggingMiddleware struct {

--- a/manager/middleware/logging.go
+++ b/manager/middleware/logging.go
@@ -7,9 +7,8 @@ import (
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
-	"github.com/absmach/propeller/pkg/sdf"
-	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
+	"github.com/absmach/propeller/pkg/sdf"
 )
 
 type loggingMiddleware struct {
@@ -191,7 +190,7 @@ func (lm *loggingMiddleware) GetTask(ctx context.Context, id string) (resp task.
 	return lm.svc.GetTask(ctx, id)
 }
 
-func (lm *loggingMiddleware) ListTasks(ctx context.Context, pm sdk.PageMetadata) (resp task.TaskPage, err error) {
+func (lm *loggingMiddleware) ListTasks(ctx context.Context, pm manager.PageMetadata) (resp task.TaskPage, err error) {
 	defer func(begin time.Time) {
 		args := []any{
 			slog.String("duration", time.Since(begin).String()),

--- a/manager/middleware/metrics.go
+++ b/manager/middleware/metrics.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
-	"github.com/absmach/propeller/pkg/sdf"
-	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
+	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/go-kit/kit/metrics"
 )
 
@@ -100,7 +99,7 @@ func (mm *metricsMiddleware) GetTask(ctx context.Context, id string) (task.Task,
 	return mm.svc.GetTask(ctx, id)
 }
 
-func (mm *metricsMiddleware) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
+func (mm *metricsMiddleware) ListTasks(ctx context.Context, pm manager.PageMetadata) (task.TaskPage, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "list-tasks").Add(1)
 		mm.latency.With("method", "list-tasks").Observe(time.Since(begin).Seconds())

--- a/manager/middleware/metrics.go
+++ b/manager/middleware/metrics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
 	"github.com/go-kit/kit/metrics"
 )
@@ -106,6 +107,15 @@ func (mm *metricsMiddleware) ListTasks(ctx context.Context, offset, limit uint64
 	}(time.Now())
 
 	return mm.svc.ListTasks(ctx, offset, limit)
+}
+
+func (mm *metricsMiddleware) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "list-tasks-by-filter").Add(1)
+		mm.latency.With("method", "list-tasks-by-filter").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.ListTasksByFilter(ctx, pm)
 }
 
 func (mm *metricsMiddleware) UpdateTask(ctx context.Context, t task.Task) (task.Task, error) {

--- a/manager/middleware/metrics.go
+++ b/manager/middleware/metrics.go
@@ -100,22 +100,13 @@ func (mm *metricsMiddleware) GetTask(ctx context.Context, id string) (task.Task,
 	return mm.svc.GetTask(ctx, id)
 }
 
-func (mm *metricsMiddleware) ListTasks(ctx context.Context, offset, limit uint64) (task.TaskPage, error) {
+func (mm *metricsMiddleware) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "list-tasks").Add(1)
 		mm.latency.With("method", "list-tasks").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.ListTasks(ctx, offset, limit)
-}
-
-func (mm *metricsMiddleware) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
-	defer func(begin time.Time) {
-		mm.counter.With("method", "list-tasks-by-filter").Add(1)
-		mm.latency.With("method", "list-tasks-by-filter").Observe(time.Since(begin).Seconds())
-	}(time.Now())
-
-	return mm.svc.ListTasksByFilter(ctx, pm)
+	return mm.svc.ListTasks(ctx, pm)
 }
 
 func (mm *metricsMiddleware) UpdateTask(ctx context.Context, t task.Task) (task.Task, error) {

--- a/manager/middleware/metrics.go
+++ b/manager/middleware/metrics.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
-	"github.com/absmach/propeller/pkg/task"
 	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/absmach/propeller/pkg/task"
 	"github.com/go-kit/kit/metrics"
 )
 

--- a/manager/middleware/tracing.go
+++ b/manager/middleware/tracing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -110,6 +111,16 @@ func (tm *tracing) ListTasks(ctx context.Context, offset, limit uint64) (resp ta
 	defer span.End()
 
 	return tm.svc.ListTasks(ctx, offset, limit)
+}
+
+func (tm *tracing) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (resp task.TaskPage, err error) {
+	ctx, span := tm.tracer.Start(ctx, "list-tasks-by-filter", trace.WithAttributes(
+		attribute.Int64("offset", int64(pm.Offset)),
+		attribute.Int64("limit", int64(pm.Limit)),
+	))
+	defer span.End()
+
+	return tm.svc.ListTasksByFilter(ctx, pm)
 }
 
 func (tm *tracing) UpdateTask(ctx context.Context, t task.Task) (resp task.Task, err error) {

--- a/manager/middleware/tracing.go
+++ b/manager/middleware/tracing.go
@@ -103,24 +103,14 @@ func (tm *tracing) GetTask(ctx context.Context, id string) (resp task.Task, err 
 	return tm.svc.GetTask(ctx, id)
 }
 
-func (tm *tracing) ListTasks(ctx context.Context, offset, limit uint64) (resp task.TaskPage, err error) {
+func (tm *tracing) ListTasks(ctx context.Context, pm sdk.PageMetadata) (resp task.TaskPage, err error) {
 	ctx, span := tm.tracer.Start(ctx, "list-tasks", trace.WithAttributes(
-		attribute.Int64("offset", int64(offset)),
-		attribute.Int64("limit", int64(limit)),
-	))
-	defer span.End()
-
-	return tm.svc.ListTasks(ctx, offset, limit)
-}
-
-func (tm *tracing) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (resp task.TaskPage, err error) {
-	ctx, span := tm.tracer.Start(ctx, "list-tasks-by-filter", trace.WithAttributes(
 		attribute.Int64("offset", int64(pm.Offset)),
 		attribute.Int64("limit", int64(pm.Limit)),
 	))
 	defer span.End()
 
-	return tm.svc.ListTasksByFilter(ctx, pm)
+	return tm.svc.ListTasks(ctx, pm)
 }
 
 func (tm *tracing) UpdateTask(ctx context.Context, t task.Task) (resp task.Task, err error) {

--- a/manager/middleware/tracing.go
+++ b/manager/middleware/tracing.go
@@ -6,7 +6,6 @@ import (
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
-	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -103,7 +102,7 @@ func (tm *tracing) GetTask(ctx context.Context, id string) (resp task.Task, err 
 	return tm.svc.GetTask(ctx, id)
 }
 
-func (tm *tracing) ListTasks(ctx context.Context, pm sdk.PageMetadata) (resp task.TaskPage, err error) {
+func (tm *tracing) ListTasks(ctx context.Context, pm manager.PageMetadata) (resp task.TaskPage, err error) {
 	ctx, span := tm.tracer.Start(ctx, "list-tasks", trace.WithAttributes(
 		attribute.Int64("offset", int64(pm.Offset)),
 		attribute.Int64("limit", int64(pm.Limit)),

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -844,6 +844,7 @@ func (_c *MockService_GetPropletMetrics_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// GetPropletAliveHistory provides a mock function for the type MockService
 func (_mock *MockService) GetPropletAliveHistory(ctx context.Context, propletID string, offset uint64, limit uint64) (proplet.PropletAliveHistoryPage, error) {
 	ret := _mock.Called(ctx, propletID, offset, limit)
 
@@ -869,11 +870,17 @@ func (_mock *MockService) GetPropletAliveHistory(ctx context.Context, propletID 
 	return r0, r1
 }
 
+// MockService_GetPropletAliveHistory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPropletAliveHistory'
 type MockService_GetPropletAliveHistory_Call struct {
 	*mock.Call
 }
 
-func (_e *MockService_Expecter) GetPropletAliveHistory(ctx any, propletID any, offset any, limit any) *MockService_GetPropletAliveHistory_Call {
+// GetPropletAliveHistory is a helper method to define mock.On call
+//   - ctx context.Context
+//   - propletID string
+//   - offset uint64
+//   - limit uint64
+func (_e *MockService_Expecter) GetPropletAliveHistory(ctx interface{}, propletID interface{}, offset interface{}, limit interface{}) *MockService_GetPropletAliveHistory_Call {
 	return &MockService_GetPropletAliveHistory_Call{Call: _e.mock.On("GetPropletAliveHistory", ctx, propletID, offset, limit)}
 }
 
@@ -895,7 +902,12 @@ func (_c *MockService_GetPropletAliveHistory_Call) Run(run func(ctx context.Cont
 		if args[3] != nil {
 			arg3 = args[3].(uint64)
 		}
-		run(arg0, arg1, arg2, arg3)
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
 	})
 	return _c
 }

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
-	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -1357,7 +1356,7 @@ func (_c *MockService_ListProplets_Call) RunAndReturn(run func(ctx context.Conte
 }
 
 // ListTasks provides a mock function for the type MockService
-func (_mock *MockService) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
+func (_mock *MockService) ListTasks(ctx context.Context, pm manager.PageMetadata) (task.TaskPage, error) {
 	ret := _mock.Called(ctx, pm)
 
 	if len(ret) == 0 {
@@ -1366,15 +1365,15 @@ func (_mock *MockService) ListTasks(ctx context.Context, pm sdk.PageMetadata) (t
 
 	var r0 task.TaskPage
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, sdk.PageMetadata) (task.TaskPage, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, manager.PageMetadata) (task.TaskPage, error)); ok {
 		return returnFunc(ctx, pm)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, sdk.PageMetadata) task.TaskPage); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, manager.PageMetadata) task.TaskPage); ok {
 		r0 = returnFunc(ctx, pm)
 	} else {
 		r0 = ret.Get(0).(task.TaskPage)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, sdk.PageMetadata) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, manager.PageMetadata) error); ok {
 		r1 = returnFunc(ctx, pm)
 	} else {
 		r1 = ret.Error(1)
@@ -1389,20 +1388,20 @@ type MockService_ListTasks_Call struct {
 
 // ListTasks is a helper method to define mock.On call
 //   - ctx context.Context
-//   - pm sdk.PageMetadata
+//   - pm manager.PageMetadata
 func (_e *MockService_Expecter) ListTasks(ctx interface{}, pm interface{}) *MockService_ListTasks_Call {
 	return &MockService_ListTasks_Call{Call: _e.mock.On("ListTasks", ctx, pm)}
 }
 
-func (_c *MockService_ListTasks_Call) Run(run func(ctx context.Context, pm sdk.PageMetadata)) *MockService_ListTasks_Call {
+func (_c *MockService_ListTasks_Call) Run(run func(ctx context.Context, pm manager.PageMetadata)) *MockService_ListTasks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 sdk.PageMetadata
+		var arg1 manager.PageMetadata
 		if args[1] != nil {
-			arg1 = args[1].(sdk.PageMetadata)
+			arg1 = args[1].(manager.PageMetadata)
 		}
 		run(
 			arg0,
@@ -1417,7 +1416,7 @@ func (_c *MockService_ListTasks_Call) Return(taskPage task.TaskPage, err error) 
 	return _c
 }
 
-func (_c *MockService_ListTasks_Call) RunAndReturn(run func(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error)) *MockService_ListTasks_Call {
+func (_c *MockService_ListTasks_Call) RunAndReturn(run func(ctx context.Context, pm manager.PageMetadata) (task.TaskPage, error)) *MockService_ListTasks_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -1345,83 +1345,11 @@ func (_c *MockService_ListProplets_Call) RunAndReturn(run func(ctx context.Conte
 }
 
 // ListTasks provides a mock function for the type MockService
-func (_mock *MockService) ListTasks(ctx context.Context, offset uint64, limit uint64) (task.TaskPage, error) {
-	ret := _mock.Called(ctx, offset, limit)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListTasks")
-	}
-
-	var r0 task.TaskPage
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64) (task.TaskPage, error)); ok {
-		return returnFunc(ctx, offset, limit)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64) task.TaskPage); ok {
-		r0 = returnFunc(ctx, offset, limit)
-	} else {
-		r0 = ret.Get(0).(task.TaskPage)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uint64, uint64) error); ok {
-		r1 = returnFunc(ctx, offset, limit)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockService_ListTasks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListTasks'
-type MockService_ListTasks_Call struct {
-	*mock.Call
-}
-
-// ListTasks is a helper method to define mock.On call
-//   - ctx context.Context
-//   - offset uint64
-//   - limit uint64
-func (_e *MockService_Expecter) ListTasks(ctx interface{}, offset interface{}, limit interface{}) *MockService_ListTasks_Call {
-	return &MockService_ListTasks_Call{Call: _e.mock.On("ListTasks", ctx, offset, limit)}
-}
-
-func (_c *MockService_ListTasks_Call) Run(run func(ctx context.Context, offset uint64, limit uint64)) *MockService_ListTasks_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uint64
-		if args[1] != nil {
-			arg1 = args[1].(uint64)
-		}
-		var arg2 uint64
-		if args[2] != nil {
-			arg2 = args[2].(uint64)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockService_ListTasks_Call) Return(taskPage task.TaskPage, err error) *MockService_ListTasks_Call {
-	_c.Call.Return(taskPage, err)
-	return _c
-}
-
-func (_c *MockService_ListTasks_Call) RunAndReturn(run func(ctx context.Context, offset uint64, limit uint64) (task.TaskPage, error)) *MockService_ListTasks_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ListTasksByFilter provides a mock function for the type MockService
-func (_mock *MockService) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
+func (_mock *MockService) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
 	ret := _mock.Called(ctx, pm)
 
 	if len(ret) == 0 {
-		panic("no return value specified for ListTasksByFilter")
+		panic("no return value specified for ListTasks")
 	}
 
 	var r0 task.TaskPage
@@ -1442,19 +1370,19 @@ func (_mock *MockService) ListTasksByFilter(ctx context.Context, pm sdk.PageMeta
 	return r0, r1
 }
 
-// MockService_ListTasksByFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListTasksByFilter'
-type MockService_ListTasksByFilter_Call struct {
+// MockService_ListTasks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListTasks'
+type MockService_ListTasks_Call struct {
 	*mock.Call
 }
 
-// ListTasksByFilter is a helper method to define mock.On call
+// ListTasks is a helper method to define mock.On call
 //   - ctx context.Context
 //   - pm sdk.PageMetadata
-func (_e *MockService_Expecter) ListTasksByFilter(ctx interface{}, pm interface{}) *MockService_ListTasksByFilter_Call {
-	return &MockService_ListTasksByFilter_Call{Call: _e.mock.On("ListTasksByFilter", ctx, pm)}
+func (_e *MockService_Expecter) ListTasks(ctx interface{}, pm interface{}) *MockService_ListTasks_Call {
+	return &MockService_ListTasks_Call{Call: _e.mock.On("ListTasks", ctx, pm)}
 }
 
-func (_c *MockService_ListTasksByFilter_Call) Run(run func(ctx context.Context, pm sdk.PageMetadata)) *MockService_ListTasksByFilter_Call {
+func (_c *MockService_ListTasks_Call) Run(run func(ctx context.Context, pm sdk.PageMetadata)) *MockService_ListTasks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1472,12 +1400,12 @@ func (_c *MockService_ListTasksByFilter_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *MockService_ListTasksByFilter_Call) Return(taskPage task.TaskPage, err error) *MockService_ListTasksByFilter_Call {
+func (_c *MockService_ListTasks_Call) Return(taskPage task.TaskPage, err error) *MockService_ListTasks_Call {
 	_c.Call.Return(taskPage, err)
 	return _c
 }
 
-func (_c *MockService_ListTasksByFilter_Call) RunAndReturn(run func(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error)) *MockService_ListTasksByFilter_Call {
+func (_c *MockService_ListTasks_Call) RunAndReturn(run func(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error)) *MockService_ListTasks_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/task"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -1411,6 +1412,72 @@ func (_c *MockService_ListTasks_Call) Return(taskPage task.TaskPage, err error) 
 }
 
 func (_c *MockService_ListTasks_Call) RunAndReturn(run func(ctx context.Context, offset uint64, limit uint64) (task.TaskPage, error)) *MockService_ListTasks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListTasksByFilter provides a mock function for the type MockService
+func (_mock *MockService) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
+	ret := _mock.Called(ctx, pm)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListTasksByFilter")
+	}
+
+	var r0 task.TaskPage
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, sdk.PageMetadata) (task.TaskPage, error)); ok {
+		return returnFunc(ctx, pm)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, sdk.PageMetadata) task.TaskPage); ok {
+		r0 = returnFunc(ctx, pm)
+	} else {
+		r0 = ret.Get(0).(task.TaskPage)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, sdk.PageMetadata) error); ok {
+		r1 = returnFunc(ctx, pm)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockService_ListTasksByFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListTasksByFilter'
+type MockService_ListTasksByFilter_Call struct {
+	*mock.Call
+}
+
+// ListTasksByFilter is a helper method to define mock.On call
+//   - ctx context.Context
+//   - pm sdk.PageMetadata
+func (_e *MockService_Expecter) ListTasksByFilter(ctx interface{}, pm interface{}) *MockService_ListTasksByFilter_Call {
+	return &MockService_ListTasksByFilter_Call{Call: _e.mock.On("ListTasksByFilter", ctx, pm)}
+}
+
+func (_c *MockService_ListTasksByFilter_Call) Run(run func(ctx context.Context, pm sdk.PageMetadata)) *MockService_ListTasksByFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 sdk.PageMetadata
+		if args[1] != nil {
+			arg1 = args[1].(sdk.PageMetadata)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_ListTasksByFilter_Call) Return(taskPage task.TaskPage, err error) *MockService_ListTasksByFilter_Call {
+	_c.Call.Return(taskPage, err)
+	return _c
+}
+
+func (_c *MockService_ListTasksByFilter_Call) RunAndReturn(run func(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error)) *MockService_ListTasksByFilter_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/manager/service.go
+++ b/manager/service.go
@@ -586,21 +586,7 @@ func (svc *service) GetTask(ctx context.Context, taskID string) (task.Task, erro
 }
 
 func (svc *service) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
-	if len(pm.Metadata) == 0 {
-		tasks, total, err := svc.taskRepo.List(ctx, pm.Offset, pm.Limit)
-		if err != nil {
-			return task.TaskPage{}, err
-		}
-
-		return task.TaskPage{
-			Offset: pm.Offset,
-			Limit:  pm.Limit,
-			Total:  total,
-			Tasks:  tasks,
-		}, nil
-	}
-
-	tasks, total, err := svc.taskRepo.ListByMetadataFilter(ctx, pm.Metadata, pm.Offset, pm.Limit)
+	tasks, total, err := svc.taskRepo.List(ctx, pm.Metadata, pm.Offset, pm.Limit)
 	if err != nil {
 		return task.TaskPage{}, err
 	}
@@ -1751,7 +1737,7 @@ func listAllTasksFromRepo(ctx context.Context, repo storage.TaskRepository) ([]t
 	var all []task.Task
 	var offset uint64
 	for {
-		page, total, err := repo.List(ctx, offset, pageSize)
+		page, total, err := repo.List(ctx, nil, offset, pageSize)
 		if err != nil {
 			return nil, err
 		}

--- a/manager/service.go
+++ b/manager/service.go
@@ -24,7 +24,6 @@ import (
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/scheduler"
 	"github.com/absmach/propeller/pkg/sdf"
-	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/storage"
 	"github.com/absmach/propeller/pkg/task"
 	"github.com/google/uuid"
@@ -585,7 +584,7 @@ func (svc *service) GetTask(ctx context.Context, taskID string) (task.Task, erro
 	return t, nil
 }
 
-func (svc *service) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
+func (svc *service) ListTasks(ctx context.Context, pm PageMetadata) (task.TaskPage, error) {
 	tasks, total, err := svc.taskRepo.List(ctx, pm.Metadata, pm.Offset, pm.Limit)
 	if err != nil {
 		return task.TaskPage{}, err
@@ -600,31 +599,61 @@ func (svc *service) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.Ta
 }
 
 func (svc *service) UpdateTask(ctx context.Context, t task.Task) (task.Task, error) {
-	t.UpdatedAt = time.Now()
+	dbT, err := svc.GetTask(ctx, t.ID)
+	if err != nil {
+		return task.Task{}, err
+	}
+	dbT.UpdatedAt = time.Now()
 
-	if t.Schedule != "" {
+	if t.Name != "" {
+		dbT.Name = t.Name
+	}
+	if t.Inputs != nil {
+		dbT.Inputs = t.Inputs
+	}
+	if t.File != nil {
+		dbT.File = t.File
+	}
+	if t.Priority != 0 {
+		dbT.Priority = t.Priority
+	}
+	if t.Metadata != nil {
+		dbT.Metadata = t.Metadata
+	}
+
+	scheduleChanged := false
+	if t.Schedule != "" && t.Schedule != dbT.Schedule {
 		schedule, err := cron.ParseCronExpression(t.Schedule)
 		if err != nil {
 			return task.Task{}, fmt.Errorf("invalid cron expression: %w", err)
 		}
 
-		if t.Timezone == "" {
-			t.Timezone = defaultTimezone
+		timezone := t.Timezone
+		if timezone == "" {
+			timezone = defaultTimezone
 		}
 
-		t.NextRun = cron.CalculateNextRun(schedule, time.Now(), t.Timezone)
-	} else {
-		t.NextRun = time.Time{}
-		t.IsRecurring = false
+		dbT.Schedule = t.Schedule
+		dbT.IsRecurring = t.IsRecurring
+		dbT.Timezone = timezone
+		dbT.NextRun = cron.CalculateNextRun(schedule, time.Now(), timezone)
+		scheduleChanged = true
+	} else if t.Schedule == "" && dbT.Schedule != "" {
+		dbT.Schedule = ""
+		dbT.NextRun = time.Time{}
+		dbT.IsRecurring = false
+		scheduleChanged = true
 	}
 
-	if err := svc.taskRepo.Update(ctx, t); err != nil {
+	if err := svc.taskRepo.Update(ctx, dbT); err != nil {
 		return task.Task{}, err
 	}
 
-	svc.updateCronTask(ctx, t)
+	if scheduleChanged {
+		svc.updateCronTask(ctx, dbT)
+	}
 
-	return t, nil
+	return dbT, nil
 }
 
 func (svc *service) DeleteTask(ctx context.Context, taskID string) error {
@@ -1778,7 +1807,7 @@ type startPayload struct {
 	Env               map[string]string          `json:"env,omitempty"`
 	Encrypted         bool                       `json:"encrypted"`
 	KBSResourcePath   string                     `json:"kbs_resource_path,omitempty"`
-	MonitoringProfile *proplet.MonitoringProfile `json:"monitoringProfile,omitempty"`
+	MonitoringProfile *proplet.MonitoringProfile `json:"monitoring_profile,omitempty"`
 	PropletID         string                     `json:"proplet_id,omitempty"`
 	ParentResults     map[string]any             `json:"parent_results,omitempty"`
 }

--- a/manager/service.go
+++ b/manager/service.go
@@ -1810,6 +1810,8 @@ type startPayload struct {
 	MonitoringProfile *proplet.MonitoringProfile `json:"monitoring_profile,omitempty"`
 	PropletID         string                     `json:"proplet_id,omitempty"`
 	ParentResults     map[string]any             `json:"parent_results,omitempty"`
+	// Metadata is intentionally excluded: it is a manager-side filtering field
+	// and is not needed by the proplet runtime.
 }
 
 func (svc *service) publishStart(ctx context.Context, t task.Task, propletID string) error {

--- a/manager/service.go
+++ b/manager/service.go
@@ -1773,6 +1773,7 @@ type startPayload struct {
 	File              []byte                     `json:"file,omitempty"`
 	Inputs            task.FlexStrings           `json:"inputs,omitempty"`
 	CLIArgs           []string                   `json:"cli_args"`
+	Broadcast         bool                       `json:"broadcast"`
 	Daemon            bool                       `json:"daemon"`
 	Env               map[string]string          `json:"env,omitempty"`
 	Encrypted         bool                       `json:"encrypted"`
@@ -1791,6 +1792,7 @@ func (svc *service) publishStart(ctx context.Context, t task.Task, propletID str
 		File:              t.File,
 		Inputs:            t.Inputs,
 		CLIArgs:           t.CLIArgs,
+		Broadcast:         t.Broadcast,
 		Daemon:            t.Daemon,
 		Env:               t.Env,
 		Encrypted:         t.Encrypted,

--- a/manager/service.go
+++ b/manager/service.go
@@ -636,19 +636,27 @@ func (svc *service) UpdateTask(ctx context.Context, t task.Task) (task.Task, err
 		return task.Task{}, err
 	}
 
-	if svc.cronScheduler != nil {
-		if t.Schedule != "" {
-			if err := svc.cronScheduler.ScheduleTask(ctx, t.ID); err != nil {
-				svc.logger.WarnContext(ctx, "failed to reschedule task in cron scheduler", "error", err, "task_id", t.ID)
-			}
-		} else {
-			if err := svc.cronScheduler.UnscheduleTask(ctx, t.ID); err != nil {
-				svc.logger.WarnContext(ctx, "failed to unschedule task in cron scheduler", "error", err, "task_id", t.ID)
-			}
-		}
-	}
+	svc.updateCronTask(ctx, t)
 
 	return t, nil
+}
+
+func (svc *service) updateCronTask(ctx context.Context, t task.Task) {
+	if svc.cronScheduler == nil {
+		return
+	}
+
+	if t.Schedule != "" {
+		if err := svc.cronScheduler.ScheduleTask(ctx, t.ID); err != nil {
+			svc.logger.WarnContext(ctx, "failed to reschedule task in cron scheduler", "error", err, "task_id", t.ID)
+		}
+
+		return
+	}
+
+	if err := svc.cronScheduler.UnscheduleTask(ctx, t.ID); err != nil {
+		svc.logger.WarnContext(ctx, "failed to unschedule task in cron scheduler", "error", err, "task_id", t.ID)
+	}
 }
 
 func (svc *service) DeleteTask(ctx context.Context, taskID string) error {

--- a/manager/service.go
+++ b/manager/service.go
@@ -641,24 +641,6 @@ func (svc *service) UpdateTask(ctx context.Context, t task.Task) (task.Task, err
 	return t, nil
 }
 
-func (svc *service) updateCronTask(ctx context.Context, t task.Task) {
-	if svc.cronScheduler == nil {
-		return
-	}
-
-	if t.Schedule != "" {
-		if err := svc.cronScheduler.ScheduleTask(ctx, t.ID); err != nil {
-			svc.logger.WarnContext(ctx, "failed to reschedule task in cron scheduler", "error", err, "task_id", t.ID)
-		}
-
-		return
-	}
-
-	if err := svc.cronScheduler.UnscheduleTask(ctx, t.ID); err != nil {
-		svc.logger.WarnContext(ctx, "failed to unschedule task in cron scheduler", "error", err, "task_id", t.ID)
-	}
-}
-
 func (svc *service) DeleteTask(ctx context.Context, taskID string) error {
 	if svc.cronScheduler != nil {
 		if err := svc.cronScheduler.UnscheduleTask(ctx, taskID); err != nil {
@@ -1043,6 +1025,24 @@ func (svc *service) RecoverInterruptedTasks(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (svc *service) updateCronTask(ctx context.Context, t task.Task) {
+	if svc.cronScheduler == nil {
+		return
+	}
+
+	if t.Schedule != "" {
+		if err := svc.cronScheduler.ScheduleTask(ctx, t.ID); err != nil {
+			svc.logger.WarnContext(ctx, "failed to reschedule task in cron scheduler", "error", err, "task_id", t.ID)
+		}
+
+		return
+	}
+
+	if err := svc.cronScheduler.UnscheduleTask(ctx, t.ID); err != nil {
+		svc.logger.WarnContext(ctx, "failed to unschedule task in cron scheduler", "error", err, "task_id", t.ID)
+	}
 }
 
 func (svc *service) listAllStoredJobs(ctx context.Context) ([]job.Job, error) {

--- a/manager/service.go
+++ b/manager/service.go
@@ -1800,8 +1800,39 @@ func (svc *service) persistTaskBeforeStart(ctx context.Context, t *task.Task) er
 	return svc.taskRepo.Update(ctx, *t)
 }
 
+type startPayload struct {
+	ID                string                     `json:"id"`
+	Name              string                     `json:"name"`
+	State             task.State                 `json:"state"`
+	ImageURL          string                     `json:"image_url,omitempty"`
+	File              []byte                     `json:"file,omitempty"`
+	Inputs            task.FlexStrings           `json:"inputs,omitempty"`
+	CLIArgs           []string                   `json:"cli_args"`
+	Daemon            bool                       `json:"daemon"`
+	Env               map[string]string          `json:"env,omitempty"`
+	Encrypted         bool                       `json:"encrypted"`
+	KBSResourcePath   string                     `json:"kbs_resource_path,omitempty"`
+	MonitoringProfile *proplet.MonitoringProfile `json:"monitoringProfile,omitempty"`
+	PropletID         string                     `json:"proplet_id,omitempty"`
+	ParentResults     map[string]any             `json:"parent_results,omitempty"`
+}
+
 func (svc *service) publishStart(ctx context.Context, t task.Task, propletID string) error {
-	t.PropletID = propletID
+	payload := startPayload{
+		ID:                t.ID,
+		Name:              t.Name,
+		State:             t.State,
+		ImageURL:          t.ImageURL,
+		File:              t.File,
+		Inputs:            t.Inputs,
+		CLIArgs:           t.CLIArgs,
+		Daemon:            t.Daemon,
+		Env:               t.Env,
+		Encrypted:         t.Encrypted,
+		KBSResourcePath:   t.KBSResourcePath,
+		MonitoringProfile: t.MonitoringProfile,
+		PropletID:         propletID,
+	}
 
 	if len(t.DependsOn) > 0 {
 		parentResults, err := svc.GetParentResults(ctx, t.ID)
@@ -1809,12 +1840,12 @@ func (svc *service) publishStart(ctx context.Context, t task.Task, propletID str
 			svc.logger.WarnContext(ctx, "failed to get parent results", "task_id", t.ID, "error", err)
 			parentResults = make(map[string]any)
 		}
-		t.Results = parentResults
+		payload.ParentResults = parentResults
 	}
 
 	topic := svc.baseTopic + "/control/manager/start"
 
-	return svc.pubsub.Publish(ctx, topic, t)
+	return svc.pubsub.Publish(ctx, topic, payload)
 }
 
 func (svc *service) bumpPropletTaskCount(ctx context.Context, p proplet.Proplet, delta int64) error {

--- a/manager/service.go
+++ b/manager/service.go
@@ -586,7 +586,7 @@ func (svc *service) GetTask(ctx context.Context, taskID string) (task.Task, erro
 }
 
 func (svc *service) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
-	if len(pm.MetadataFilter) == 0 {
+	if len(pm.Metadata) == 0 {
 		tasks, total, err := svc.taskRepo.List(ctx, pm.Offset, pm.Limit)
 		if err != nil {
 			return task.TaskPage{}, err
@@ -600,7 +600,7 @@ func (svc *service) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.Ta
 		}, nil
 	}
 
-	tasks, total, err := svc.taskRepo.ListByMetadataFilter(ctx, pm.MetadataFilter, pm.Offset, pm.Limit)
+	tasks, total, err := svc.taskRepo.ListByMetadataFilter(ctx, pm.Metadata, pm.Offset, pm.Limit)
 	if err != nil {
 		return task.TaskPage{}, err
 	}

--- a/manager/service.go
+++ b/manager/service.go
@@ -585,21 +585,21 @@ func (svc *service) GetTask(ctx context.Context, taskID string) (task.Task, erro
 	return t, nil
 }
 
-func (svc *service) ListTasks(ctx context.Context, offset, limit uint64) (task.TaskPage, error) {
-	tasks, total, err := svc.taskRepo.List(ctx, offset, limit)
-	if err != nil {
-		return task.TaskPage{}, err
+func (svc *service) ListTasks(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
+	if len(pm.MetadataFilter) == 0 {
+		tasks, total, err := svc.taskRepo.List(ctx, pm.Offset, pm.Limit)
+		if err != nil {
+			return task.TaskPage{}, err
+		}
+
+		return task.TaskPage{
+			Offset: pm.Offset,
+			Limit:  pm.Limit,
+			Total:  total,
+			Tasks:  tasks,
+		}, nil
 	}
 
-	return task.TaskPage{
-		Offset: offset,
-		Limit:  limit,
-		Total:  total,
-		Tasks:  tasks,
-	}, nil
-}
-
-func (svc *service) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
 	tasks, total, err := svc.taskRepo.ListByMetadataFilter(ctx, pm.MetadataFilter, pm.Offset, pm.Limit)
 	if err != nil {
 		return task.TaskPage{}, err
@@ -614,70 +614,41 @@ func (svc *service) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) 
 }
 
 func (svc *service) UpdateTask(ctx context.Context, t task.Task) (task.Task, error) {
-	dbT, err := svc.GetTask(ctx, t.ID)
-	if err != nil {
-		return task.Task{}, err
-	}
-	dbT.UpdatedAt = time.Now()
+	t.UpdatedAt = time.Now()
 
-	if t.Name != "" {
-		dbT.Name = t.Name
-	}
-	if t.Inputs != nil {
-		dbT.Inputs = t.Inputs
-	}
-	if t.File != nil {
-		dbT.File = t.File
-	}
-	if t.Priority != 0 {
-		dbT.Priority = t.Priority
-	}
-
-	scheduleChanged := false
-	if t.Schedule != "" && t.Schedule != dbT.Schedule {
+	if t.Schedule != "" {
 		schedule, err := cron.ParseCronExpression(t.Schedule)
 		if err != nil {
 			return task.Task{}, fmt.Errorf("invalid cron expression: %w", err)
 		}
 
-		timezone := t.Timezone
-		if timezone == "" {
-			timezone = defaultTimezone
+		if t.Timezone == "" {
+			t.Timezone = defaultTimezone
 		}
 
-		dbT.Schedule = t.Schedule
-		dbT.IsRecurring = t.IsRecurring
-		dbT.Timezone = timezone
-		dbT.NextRun = cron.CalculateNextRun(schedule, time.Now(), timezone)
-		scheduleChanged = true
-	} else if t.Schedule == "" && dbT.Schedule != "" {
-		dbT.Schedule = ""
-		dbT.NextRun = time.Time{}
-		dbT.IsRecurring = false
-		scheduleChanged = true
+		t.NextRun = cron.CalculateNextRun(schedule, time.Now(), t.Timezone)
+	} else {
+		t.NextRun = time.Time{}
+		t.IsRecurring = false
 	}
 
-	if err := svc.taskRepo.Update(ctx, dbT); err != nil {
+	if err := svc.taskRepo.Update(ctx, t); err != nil {
 		return task.Task{}, err
 	}
 
-	if !scheduleChanged || svc.cronScheduler == nil {
-		return dbT, nil
-	}
-
-	if dbT.Schedule != "" {
-		if err := svc.cronScheduler.ScheduleTask(ctx, dbT.ID); err != nil {
-			svc.logger.WarnContext(ctx, "failed to reschedule task in cron scheduler", "error", err, "task_id", dbT.ID)
+	if svc.cronScheduler != nil {
+		if t.Schedule != "" {
+			if err := svc.cronScheduler.ScheduleTask(ctx, t.ID); err != nil {
+				svc.logger.WarnContext(ctx, "failed to reschedule task in cron scheduler", "error", err, "task_id", t.ID)
+			}
+		} else {
+			if err := svc.cronScheduler.UnscheduleTask(ctx, t.ID); err != nil {
+				svc.logger.WarnContext(ctx, "failed to unschedule task in cron scheduler", "error", err, "task_id", t.ID)
+			}
 		}
-
-		return dbT, nil
 	}
 
-	if err := svc.cronScheduler.UnscheduleTask(ctx, dbT.ID); err != nil {
-		svc.logger.WarnContext(ctx, "failed to unschedule task in cron scheduler", "error", err, "task_id", dbT.ID)
-	}
-
-	return dbT, nil
+	return t, nil
 }
 
 func (svc *service) DeleteTask(ctx context.Context, taskID string) error {

--- a/manager/service.go
+++ b/manager/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/scheduler"
 	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/absmach/propeller/pkg/sdk"
 	"github.com/absmach/propeller/pkg/storage"
 	"github.com/absmach/propeller/pkg/task"
 	"github.com/google/uuid"
@@ -593,6 +594,20 @@ func (svc *service) ListTasks(ctx context.Context, offset, limit uint64) (task.T
 	return task.TaskPage{
 		Offset: offset,
 		Limit:  limit,
+		Total:  total,
+		Tasks:  tasks,
+	}, nil
+}
+
+func (svc *service) ListTasksByFilter(ctx context.Context, pm sdk.PageMetadata) (task.TaskPage, error) {
+	tasks, total, err := svc.taskRepo.ListByMetadataFilter(ctx, pm.MetadataFilter, pm.Offset, pm.Limit)
+	if err != nil {
+		return task.TaskPage{}, err
+	}
+
+	return task.TaskPage{
+		Offset: pm.Offset,
+		Limit:  pm.Limit,
 		Total:  total,
 		Tasks:  tasks,
 	}, nil
@@ -1786,24 +1801,7 @@ func (svc *service) persistTaskBeforeStart(ctx context.Context, t *task.Task) er
 }
 
 func (svc *service) publishStart(ctx context.Context, t task.Task, propletID string) error {
-	payload := map[string]any{
-		"id":                 t.ID,
-		"name":               t.Name,
-		"state":              t.State,
-		"image_url":          t.ImageURL,
-		"file":               t.File,
-		"inputs":             t.Inputs,
-		"cli_args":           t.CLIArgs,
-		"daemon":             t.Daemon,
-		"env":                t.Env,
-		"encrypted":          t.Encrypted,
-		"kbs_resource_path":  t.KBSResourcePath,
-		"monitoring_profile": t.MonitoringProfile,
-		"broadcast":          t.Broadcast,
-	}
-	if propletID != "" {
-		payload["proplet_id"] = propletID
-	}
+	t.PropletID = propletID
 
 	if len(t.DependsOn) > 0 {
 		parentResults, err := svc.GetParentResults(ctx, t.ID)
@@ -1811,12 +1809,12 @@ func (svc *service) publishStart(ctx context.Context, t task.Task, propletID str
 			svc.logger.WarnContext(ctx, "failed to get parent results", "task_id", t.ID, "error", err)
 			parentResults = make(map[string]any)
 		}
-		payload["parent_results"] = parentResults
+		t.Results = parentResults
 	}
 
 	topic := svc.baseTopic + "/control/manager/start"
 
-	return svc.pubsub.Publish(ctx, topic, payload)
+	return svc.pubsub.Publish(ctx, topic, t)
 }
 
 func (svc *service) bumpPropletTaskCount(ctx context.Context, p proplet.Proplet, delta int64) error {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	OffsetKey = "offset"
-	LimitKey  = "limit"
-	DefOffset = 0
-	DefLimit  = 100
+	OffsetKey   = "offset"
+	LimitKey    = "limit"
+	MetadataKey = "metadata"
+	DefOffset   = 0
+	DefLimit    = 100
 
 	ContentType = "application/json"
 

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -15,8 +15,8 @@ import (
 const CTJSON string = "application/json"
 
 type PageMetadata struct {
-	Offset         uint64            `json:"offset"`
-	Limit          uint64            `json:"limit"`
+	Offset   uint64        `json:"offset"`
+	Limit    uint64        `json:"limit"`
 	Metadata task.Metadata `json:"metadata,omitempty"`
 }
 

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/absmach/propeller/pkg/task"
 )
 
 const CTJSON string = "application/json"
@@ -16,7 +17,7 @@ const CTJSON string = "application/json"
 type PageMetadata struct {
 	Offset         uint64            `json:"offset"`
 	Limit          uint64            `json:"limit"`
-	Metadata map[string]any `json:"metadata,omitempty"`
+	Metadata task.Metadata `json:"metadata,omitempty"`
 }
 
 type SDK interface {

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -38,12 +38,12 @@ type SDK interface {
 	//  fmt.Println(task)
 	GetTask(id string) (Task, error)
 
-	// ListTasks lists tasks.
+	// ListTasks lists tasks with optional metadata filtering.
 	//
 	// example:
-	//  taskPage, _ := sdk.ListTasks(0, 10)
+	//  taskPage, _ := sdk.ListTasks(sdk.PageMetadata{Offset: 0, Limit: 10})
 	//  fmt.Println(taskPage)
-	ListTasks(offset uint64, limit uint64) (TaskPage, error)
+	ListTasks(pm PageMetadata) (TaskPage, error)
 
 	// UpdateTask updates a task.
 	//

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -16,7 +16,7 @@ const CTJSON string = "application/json"
 type PageMetadata struct {
 	Offset         uint64            `json:"offset"`
 	Limit          uint64            `json:"limit"`
-	MetadataFilter map[string]string `json:"metadata_filter,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 type SDK interface {

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -14,8 +14,9 @@ import (
 const CTJSON string = "application/json"
 
 type PageMetadata struct {
-	Offset uint64 `json:"offset"`
-	Limit  uint64 `json:"limit"`
+	Offset         uint64            `json:"offset"`
+	Limit          uint64            `json:"limit"`
+	MetadataFilter map[string]string `json:"metadata_filter,omitempty"`
 }
 
 type SDK interface {

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 	"strings"
 	"time"
 )
@@ -85,7 +85,7 @@ func (sdk *propSDK) ListTasks(pm PageMetadata) (TaskPage, error) {
 		if err != nil {
 			return TaskPage{}, fmt.Errorf("marshal metadata: %w", err)
 		}
-		queries = append(queries, "metadata="+url.QueryEscape(string(b)))
+		queries = append(queries, "metadata="+neturl.QueryEscape(string(b)))
 	}
 	query := ""
 	if len(queries) > 0 {

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -232,7 +232,7 @@ func (sdk *propSDK) ListJobs(offset, limit uint64, status string) (JobPage, erro
 		params = append(params, fmt.Sprintf("limit=%d", limit))
 	}
 	if status != "" {
-		params = append(params, "status="+url.QueryEscape(status))
+		params = append(params, "status="+neturl.QueryEscape(status))
 	}
 	query := ""
 	if len(params) > 0 {

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -72,13 +72,20 @@ func (sdk *propSDK) GetTask(id string) (Task, error) {
 	return t, nil
 }
 
-func (sdk *propSDK) ListTasks(offset, limit uint64) (TaskPage, error) {
+func (sdk *propSDK) ListTasks(pm PageMetadata) (TaskPage, error) {
 	queries := make([]string, 0)
-	if offset > 0 {
-		queries = append(queries, fmt.Sprintf("offset=%d", offset))
+	if pm.Offset > 0 {
+		queries = append(queries, fmt.Sprintf("offset=%d", pm.Offset))
 	}
-	if limit > 0 {
-		queries = append(queries, fmt.Sprintf("limit=%d", limit))
+	if pm.Limit > 0 {
+		queries = append(queries, fmt.Sprintf("limit=%d", pm.Limit))
+	}
+	if len(pm.Metadata) > 0 {
+		b, err := json.Marshal(pm.Metadata)
+		if err != nil {
+			return TaskPage{}, fmt.Errorf("marshal metadata: %w", err)
+		}
+		queries = append(queries, "metadata="+url.QueryEscape(string(b)))
 	}
 	query := ""
 	if len(queries) > 0 {

--- a/pkg/storage/badger/init.go
+++ b/pkg/storage/badger/init.go
@@ -45,6 +45,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/badger/init.go
+++ b/pkg/storage/badger/init.go
@@ -45,7 +45,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/badger/init.go
+++ b/pkg/storage/badger/init.go
@@ -44,8 +44,7 @@ type TaskRepository interface {
 	Create(ctx context.Context, t task.Task) (task.Task, error)
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
-	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
+	List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/badger/init.go
+++ b/pkg/storage/badger/init.go
@@ -45,7 +45,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/badger/init.go
+++ b/pkg/storage/badger/init.go
@@ -219,3 +219,11 @@ func (d *Database) countWithPrefix(prefix []byte) (uint64, error) {
 
 	return count, nil
 }
+
+func (d *Database) viewTxn(fn func(*badger.Txn) error) error {
+	return d.db.View(fn)
+}
+
+func (d *Database) updateTxn(fn func(*badger.Txn) error) error {
+	return d.db.Update(fn)
+}

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -99,6 +99,75 @@ func (r *taskRepo) List(ctx context.Context, filter task.Metadata, offset, limit
 	return r.listByMetadata(ctx, filter, offset, limit)
 }
 
+func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
+	return r.listBy(ctx, func(t task.Task) bool {
+		return t.WorkflowID == workflowID
+	})
+}
+
+func (r *taskRepo) ListByJobID(ctx context.Context, jobID string) ([]task.Task, error) {
+	return r.listBy(ctx, func(t task.Task) bool {
+		return t.JobID == jobID
+	})
+}
+
+func (r *taskRepo) Delete(ctx context.Context, id string) error {
+	key := []byte("task:" + id)
+	err := r.db.updateTxn(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(key)
+		if err != nil {
+			return txn.Delete(key)
+		}
+
+		val, err := item.ValueCopy(nil)
+		if err != nil {
+			return txn.Delete(key)
+		}
+
+		var t task.Task
+		if err := json.Unmarshal(val, &t); err == nil {
+			if err := r.deindexTaskTxn(txn, t); err != nil {
+				return err
+			}
+		}
+
+		return txn.Delete(key)
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrDelete, err)
+	}
+
+	return nil
+}
+
+func (r *taskRepo) indexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if err := txn.Set(metaIdxKey(k, s, t.ID), []byte{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *taskRepo) deindexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if err := txn.Delete(metaIdxKey(k, s, t.ID)); err != nil && !errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (r *taskRepo) listAll(_ context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
 	prefix := []byte("task:")
 	total, err := r.db.countWithPrefix(prefix)
@@ -187,75 +256,6 @@ func (r *taskRepo) filterIDsByMetadata(filter task.Metadata) (map[string]struct{
 	}
 
 	return matchIDs, nil
-}
-
-func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
-	return r.listBy(ctx, func(t task.Task) bool {
-		return t.WorkflowID == workflowID
-	})
-}
-
-func (r *taskRepo) ListByJobID(ctx context.Context, jobID string) ([]task.Task, error) {
-	return r.listBy(ctx, func(t task.Task) bool {
-		return t.JobID == jobID
-	})
-}
-
-func (r *taskRepo) Delete(ctx context.Context, id string) error {
-	key := []byte("task:" + id)
-	err := r.db.updateTxn(func(txn *badgerdb.Txn) error {
-		item, err := txn.Get(key)
-		if err != nil {
-			return txn.Delete(key)
-		}
-
-		val, err := item.ValueCopy(nil)
-		if err != nil {
-			return txn.Delete(key)
-		}
-
-		var t task.Task
-		if err := json.Unmarshal(val, &t); err == nil {
-			if err := r.deindexTaskTxn(txn, t); err != nil {
-				return err
-			}
-		}
-
-		return txn.Delete(key)
-	})
-	if err != nil {
-		return fmt.Errorf("%w: %w", ErrDelete, err)
-	}
-
-	return nil
-}
-
-func (r *taskRepo) indexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
-	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		if err := txn.Set(metaIdxKey(k, s, t.ID), []byte{}); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (r *taskRepo) deindexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
-	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		if err := txn.Delete(metaIdxKey(k, s, t.ID)); err != nil && !errors.Is(err, badgerdb.ErrKeyNotFound) {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (r *taskRepo) listBy(ctx context.Context, match func(task.Task) bool) ([]task.Task, error) {

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -91,31 +91,27 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 	return nil
 }
 
-func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
-	prefix := []byte("task:")
-	total, err := r.db.countWithPrefix(prefix)
-	if err != nil {
-		return nil, 0, err
-	}
-	values, err := r.db.listWithPrefix(prefix, offset, limit)
-	if err != nil {
-		return nil, 0, err
-	}
-	tasks := make([]task.Task, len(values))
-	for i, val := range values {
-		var t task.Task
-		if err := json.Unmarshal(val, &t); err != nil {
-			return nil, 0, fmt.Errorf("unmarshal error: %w", err)
-		}
-		tasks[i] = t
-	}
-
-	return tasks, total, nil
-}
-
-func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *taskRepo) List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	if len(filter) == 0 {
-		return r.List(ctx, offset, limit)
+		prefix := []byte("task:")
+		total, err := r.db.countWithPrefix(prefix)
+		if err != nil {
+			return nil, 0, err
+		}
+		values, err := r.db.listWithPrefix(prefix, offset, limit)
+		if err != nil {
+			return nil, 0, err
+		}
+		tasks := make([]task.Task, len(values))
+		for i, val := range values {
+			var t task.Task
+			if err := json.Unmarshal(val, &t); err != nil {
+				return nil, 0, fmt.Errorf("unmarshal error: %w", err)
+			}
+			tasks[i] = t
+		}
+
+		return tasks, total, nil
 	}
 
 	var matchIDs map[string]struct{}

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -1,10 +1,12 @@
 package badger
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/absmach/propeller/pkg/task"
 	badgerdb "github.com/dgraph-io/badger/v4"
@@ -212,6 +214,9 @@ func (r *taskRepo) listByMetadata(ctx context.Context, filter task.Metadata, off
 		}
 		tasks = append(tasks, t)
 	}
+	slices.SortFunc(tasks, func(a, b task.Task) int {
+		return cmp.Compare(a.ID, b.ID)
+	})
 
 	total := uint64(len(tasks))
 	if offset >= total {

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -65,11 +65,7 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 	err = r.db.updateTxn(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(key)
 		if err != nil {
-			if err := txn.Set(key, val); err != nil {
-				return err
-			}
-
-			return r.indexTaskTxn(txn, t)
+			return ErrTaskNotFound
 		}
 
 		oldVal, err := item.ValueCopy(nil)

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -93,27 +93,61 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 
 func (r *taskRepo) List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	if len(filter) == 0 {
-		prefix := []byte("task:")
-		total, err := r.db.countWithPrefix(prefix)
-		if err != nil {
-			return nil, 0, err
-		}
-		values, err := r.db.listWithPrefix(prefix, offset, limit)
-		if err != nil {
-			return nil, 0, err
-		}
-		tasks := make([]task.Task, len(values))
-		for i, val := range values {
-			var t task.Task
-			if err := json.Unmarshal(val, &t); err != nil {
-				return nil, 0, fmt.Errorf("unmarshal error: %w", err)
-			}
-			tasks[i] = t
-		}
-
-		return tasks, total, nil
+		return r.listAll(ctx, offset, limit)
 	}
 
+	return r.listByMetadata(ctx, filter, offset, limit)
+}
+
+func (r *taskRepo) listAll(_ context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
+	prefix := []byte("task:")
+	total, err := r.db.countWithPrefix(prefix)
+	if err != nil {
+		return nil, 0, err
+	}
+	values, err := r.db.listWithPrefix(prefix, offset, limit)
+	if err != nil {
+		return nil, 0, err
+	}
+	tasks := make([]task.Task, len(values))
+	for i, val := range values {
+		var t task.Task
+		if err := json.Unmarshal(val, &t); err != nil {
+			return nil, 0, fmt.Errorf("unmarshal error: %w", err)
+		}
+		tasks[i] = t
+	}
+
+	return tasks, total, nil
+}
+
+func (r *taskRepo) listByMetadata(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
+	matchIDs, err := r.filterIDsByMetadata(filter)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(matchIDs) == 0 {
+		return []task.Task{}, 0, nil
+	}
+
+	tasks := make([]task.Task, 0, len(matchIDs))
+	for id := range matchIDs {
+		t, err := r.Get(ctx, id)
+		if err != nil {
+			continue
+		}
+		tasks = append(tasks, t)
+	}
+
+	total := uint64(len(tasks))
+	if offset >= total {
+		return []task.Task{}, total, nil
+	}
+
+	return tasks[offset:min(offset+limit, total)], total, nil
+}
+
+func (r *taskRepo) filterIDsByMetadata(filter task.Metadata) (map[string]struct{}, error) {
 	var matchIDs map[string]struct{}
 	err := r.db.viewTxn(func(txn *badgerdb.Txn) error {
 		opts := badgerdb.DefaultIteratorOptions
@@ -128,8 +162,7 @@ func (r *taskRepo) List(ctx context.Context, filter task.Metadata, offset, limit
 			ids := make(map[string]struct{})
 			for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
 				key := it.Item().KeyCopy(nil)
-				taskID := string(key[len(prefix):])
-				ids[taskID] = struct{}{}
+				ids[string(key[len(prefix):])] = struct{}{}
 			}
 			it.Close()
 
@@ -150,29 +183,10 @@ func (r *taskRepo) List(ctx context.Context, filter task.Metadata, offset, limit
 		return nil
 	})
 	if err != nil {
-		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+		return nil, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 
-	if len(matchIDs) == 0 {
-		return []task.Task{}, 0, nil
-	}
-
-	tasks := make([]task.Task, 0, len(matchIDs))
-	for id := range matchIDs {
-		t, err := r.Get(ctx, id)
-		if err != nil {
-			continue
-		}
-		tasks = append(tasks, t)
-	}
-
-	total := uint64(len(tasks))
-	if offset >= total {
-		return []task.Task{}, total, nil
-	}
-	end := min(offset+limit, total)
-
-	return tasks[offset:end], total, nil
+	return matchIDs, nil
 }
 
 func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -113,7 +113,7 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 	return tasks, total, nil
 }
 
-func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	if len(filter) == 0 {
 		return r.List(ctx, offset, limit)
 	}

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -22,34 +22,6 @@ func metaIdxKey(k, v, id string) []byte {
 	return []byte("meta-idx\x00" + k + "\x00" + v + "\x00" + id)
 }
 
-func (r *taskRepo) indexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
-	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		if err := txn.Set(metaIdxKey(k, s, t.ID), []byte{}); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (r *taskRepo) deindexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
-	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		if err := txn.Delete(metaIdxKey(k, s, t.ID)); err != nil && !errors.Is(err, badgerdb.ErrKeyNotFound) {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (r *taskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
 	key := []byte("task:" + t.ID)
 	val, err := json.Marshal(t)
@@ -92,17 +64,24 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 	}
 	err = r.db.updateTxn(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(key)
+		if err != nil {
+			if err := txn.Set(key, val); err != nil {
+				return err
+			}
+
+			return r.indexTaskTxn(txn, t)
+		}
+
+		oldVal, err := item.ValueCopy(nil)
 		if err == nil {
-			oldVal, err := item.ValueCopy(nil)
-			if err == nil {
-				var old task.Task
-				if err := json.Unmarshal(oldVal, &old); err == nil {
-					if err := r.deindexTaskTxn(txn, old); err != nil {
-						return err
-					}
+			var old task.Task
+			if err := json.Unmarshal(oldVal, &old); err == nil {
+				if err := r.deindexTaskTxn(txn, old); err != nil {
+					return err
 				}
 			}
 		}
+
 		if err := txn.Set(key, val); err != nil {
 			return err
 		}
@@ -216,15 +195,19 @@ func (r *taskRepo) Delete(ctx context.Context, id string) error {
 	key := []byte("task:" + id)
 	err := r.db.updateTxn(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(key)
-		if err == nil {
-			val, err := item.ValueCopy(nil)
-			if err == nil {
-				var t task.Task
-				if err := json.Unmarshal(val, &t); err == nil {
-					if err := r.deindexTaskTxn(txn, t); err != nil {
-						return err
-					}
-				}
+		if err != nil {
+			return txn.Delete(key)
+		}
+
+		val, err := item.ValueCopy(nil)
+		if err != nil {
+			return txn.Delete(key)
+		}
+
+		var t task.Task
+		if err := json.Unmarshal(val, &t); err == nil {
+			if err := r.deindexTaskTxn(txn, t); err != nil {
+				return err
 			}
 		}
 
@@ -232,6 +215,34 @@ func (r *taskRepo) Delete(ctx context.Context, id string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrDelete, err)
+	}
+
+	return nil
+}
+
+func (r *taskRepo) indexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if err := txn.Set(metaIdxKey(k, s, t.ID), []byte{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *taskRepo) deindexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if err := txn.Delete(metaIdxKey(k, s, t.ID)); err != nil && !errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -79,6 +79,36 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 	return tasks, total, nil
 }
 
+func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+	all, err := r.listBy(ctx, func(t task.Task) bool {
+		if t.Metadata == nil {
+			return false
+		}
+		for k, v := range filter {
+			val, exists := t.Metadata[k]
+			if !exists {
+				return false
+			}
+			s, ok := val.(string)
+			if !ok || s != v {
+				return false
+			}
+		}
+
+		return true
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	total := uint64(len(all))
+	if offset >= total {
+		return []task.Task{}, total, nil
+	}
+	end := min(offset+limit, total)
+
+	return all[offset:end], total, nil
+}
+
 func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
 	return r.listBy(ctx, func(t task.Task) bool {
 		return t.WorkflowID == workflowID

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -113,7 +113,7 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 	return tasks, total, nil
 }
 
-func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
 	if len(filter) == 0 {
 		return r.List(ctx, offset, limit)
 	}
@@ -122,7 +122,11 @@ func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]s
 	err := r.db.viewTxn(func(txn *badgerdb.Txn) error {
 		opts := badgerdb.DefaultIteratorOptions
 		opts.PrefetchValues = false
-		for k, v := range filter {
+		for k, vAny := range filter {
+			v, ok := vAny.(string)
+			if !ok {
+				continue
+			}
 			prefix := []byte("meta-idx\x00" + k + "\x00" + v + "\x00")
 			it := txn.NewIterator(opts)
 			ids := make(map[string]struct{})

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -115,8 +115,11 @@ func (r *taskRepo) Delete(ctx context.Context, id string) error {
 	key := []byte("task:" + id)
 	err := r.db.updateTxn(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(key)
+		if errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return nil
+		}
 		if err != nil {
-			return txn.Delete(key)
+			return err
 		}
 
 		val, err := item.ValueCopy(nil)
@@ -142,10 +145,7 @@ func (r *taskRepo) Delete(ctx context.Context, id string) error {
 
 func (r *taskRepo) indexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
 	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
+		s := metaValueString(v)
 		if err := txn.Set(metaIdxKey(k, s, t.ID), []byte{}); err != nil {
 			return err
 		}
@@ -156,16 +156,21 @@ func (r *taskRepo) indexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
 
 func (r *taskRepo) deindexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
 	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
+		s := metaValueString(v)
 		if err := txn.Delete(metaIdxKey(k, s, t.ID)); err != nil && !errors.Is(err, badgerdb.ErrKeyNotFound) {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func metaValueString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+
+	return fmt.Sprint(v)
 }
 
 func (r *taskRepo) listAll(_ context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
@@ -222,10 +227,7 @@ func (r *taskRepo) filterIDsByMetadata(filter task.Metadata) (map[string]struct{
 		opts := badgerdb.DefaultIteratorOptions
 		opts.PrefetchValues = false
 		for k, vAny := range filter {
-			v, ok := vAny.(string)
-			if !ok {
-				continue
-			}
+			v := metaValueString(vAny)
 			prefix := []byte("meta-idx\x00" + k + "\x00" + v + "\x00")
 			it := txn.NewIterator(opts)
 			ids := make(map[string]struct{})

--- a/pkg/storage/badger/tasks.go
+++ b/pkg/storage/badger/tasks.go
@@ -3,6 +3,7 @@ package badger
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/absmach/propeller/pkg/task"
@@ -17,13 +18,52 @@ func NewTaskRepository(db *Database) TaskRepository {
 	return &taskRepo{db: db}
 }
 
+func metaIdxKey(k, v, id string) []byte {
+	return []byte("meta-idx\x00" + k + "\x00" + v + "\x00" + id)
+}
+
+func (r *taskRepo) indexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if err := txn.Set(metaIdxKey(k, s, t.ID), []byte{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *taskRepo) deindexTaskTxn(txn *badgerdb.Txn, t task.Task) error {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if err := txn.Delete(metaIdxKey(k, s, t.ID)); err != nil && !errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (r *taskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
 	key := []byte("task:" + t.ID)
 	val, err := json.Marshal(t)
 	if err != nil {
 		return task.Task{}, fmt.Errorf("marshal error: %w", err)
 	}
-	if err := r.db.set(key, val); err != nil {
+	err = r.db.updateTxn(func(txn *badgerdb.Txn) error {
+		if err := txn.Set(key, val); err != nil {
+			return err
+		}
+
+		return r.indexTaskTxn(txn, t)
+	})
+	if err != nil {
 		return task.Task{}, fmt.Errorf("%w: %w", ErrCreate, err)
 	}
 
@@ -50,7 +90,26 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 	if err != nil {
 		return fmt.Errorf("marshal error: %w", err)
 	}
-	if err := r.db.set(key, val); err != nil {
+	err = r.db.updateTxn(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(key)
+		if err == nil {
+			oldVal, err := item.ValueCopy(nil)
+			if err == nil {
+				var old task.Task
+				if err := json.Unmarshal(oldVal, &old); err == nil {
+					if err := r.deindexTaskTxn(txn, old); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		if err := txn.Set(key, val); err != nil {
+			return err
+		}
+
+		return r.indexTaskTxn(txn, t)
+	})
+	if err != nil {
 		return fmt.Errorf("%w: %w", ErrUpdate, err)
 	}
 
@@ -80,33 +139,65 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 }
 
 func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
-	all, err := r.listBy(ctx, func(t task.Task) bool {
-		if t.Metadata == nil {
-			return false
-		}
+	if len(filter) == 0 {
+		return r.List(ctx, offset, limit)
+	}
+
+	var matchIDs map[string]struct{}
+	err := r.db.viewTxn(func(txn *badgerdb.Txn) error {
+		opts := badgerdb.DefaultIteratorOptions
+		opts.PrefetchValues = false
 		for k, v := range filter {
-			val, exists := t.Metadata[k]
-			if !exists {
-				return false
+			prefix := []byte("meta-idx\x00" + k + "\x00" + v + "\x00")
+			it := txn.NewIterator(opts)
+			ids := make(map[string]struct{})
+			for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+				key := it.Item().KeyCopy(nil)
+				taskID := string(key[len(prefix):])
+				ids[taskID] = struct{}{}
 			}
-			s, ok := val.(string)
-			if !ok || s != v {
-				return false
+			it.Close()
+
+			if matchIDs == nil {
+				matchIDs = ids
+			} else {
+				for id := range matchIDs {
+					if _, ok := ids[id]; !ok {
+						delete(matchIDs, id)
+					}
+				}
+			}
+			if len(matchIDs) == 0 {
+				return nil
 			}
 		}
 
-		return true
+		return nil
 	})
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
-	total := uint64(len(all))
+
+	if len(matchIDs) == 0 {
+		return []task.Task{}, 0, nil
+	}
+
+	tasks := make([]task.Task, 0, len(matchIDs))
+	for id := range matchIDs {
+		t, err := r.Get(ctx, id)
+		if err != nil {
+			continue
+		}
+		tasks = append(tasks, t)
+	}
+
+	total := uint64(len(tasks))
 	if offset >= total {
 		return []task.Task{}, total, nil
 	}
 	end := min(offset+limit, total)
 
-	return all[offset:end], total, nil
+	return tasks[offset:end], total, nil
 }
 
 func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
@@ -123,8 +214,27 @@ func (r *taskRepo) ListByJobID(ctx context.Context, jobID string) ([]task.Task, 
 
 func (r *taskRepo) Delete(ctx context.Context, id string) error {
 	key := []byte("task:" + id)
+	err := r.db.updateTxn(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(key)
+		if err == nil {
+			val, err := item.ValueCopy(nil)
+			if err == nil {
+				var t task.Task
+				if err := json.Unmarshal(val, &t); err == nil {
+					if err := r.deindexTaskTxn(txn, t); err != nil {
+						return err
+					}
+				}
+			}
+		}
 
-	return r.db.delete(key)
+		return txn.Delete(key)
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrDelete, err)
+	}
+
+	return nil
 }
 
 func (r *taskRepo) listBy(ctx context.Context, match func(task.Task) bool) ([]task.Task, error) {

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -149,12 +149,8 @@ func (a *postgresTaskAdapter) Update(ctx context.Context, t task.Task) error {
 	return a.repo.Update(ctx, t)
 }
 
-func (a *postgresTaskAdapter) List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
-	return a.repo.List(ctx, offset, limit)
-}
-
-func (a *postgresTaskAdapter) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
-	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
+func (a *postgresTaskAdapter) List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
+	return a.repo.List(ctx, filter, offset, limit)
 }
 
 func (a *postgresTaskAdapter) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
@@ -309,12 +305,8 @@ func (a *sqliteTaskAdapter) Update(ctx context.Context, t task.Task) error {
 	return a.repo.Update(ctx, t)
 }
 
-func (a *sqliteTaskAdapter) List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
-	return a.repo.List(ctx, offset, limit)
-}
-
-func (a *sqliteTaskAdapter) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
-	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
+func (a *sqliteTaskAdapter) List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
+	return a.repo.List(ctx, filter, offset, limit)
 }
 
 func (a *sqliteTaskAdapter) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
@@ -469,12 +461,8 @@ func (a *badgerTaskAdapter) Update(ctx context.Context, t task.Task) error {
 	return a.repo.Update(ctx, t)
 }
 
-func (a *badgerTaskAdapter) List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
-	return a.repo.List(ctx, offset, limit)
-}
-
-func (a *badgerTaskAdapter) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
-	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
+func (a *badgerTaskAdapter) List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
+	return a.repo.List(ctx, filter, offset, limit)
 }
 
 func (a *badgerTaskAdapter) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -153,7 +153,7 @@ func (a *postgresTaskAdapter) List(ctx context.Context, offset, limit uint64) ([
 	return a.repo.List(ctx, offset, limit)
 }
 
-func (a *postgresTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
+func (a *postgresTaskAdapter) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
 }
 
@@ -313,7 +313,7 @@ func (a *sqliteTaskAdapter) List(ctx context.Context, offset, limit uint64) ([]t
 	return a.repo.List(ctx, offset, limit)
 }
 
-func (a *sqliteTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
+func (a *sqliteTaskAdapter) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
 }
 
@@ -473,7 +473,7 @@ func (a *badgerTaskAdapter) List(ctx context.Context, offset, limit uint64) ([]t
 	return a.repo.List(ctx, offset, limit)
 }
 
-func (a *badgerTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
+func (a *badgerTaskAdapter) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
 }
 

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -153,6 +153,10 @@ func (a *postgresTaskAdapter) List(ctx context.Context, offset, limit uint64) ([
 	return a.repo.List(ctx, offset, limit)
 }
 
+func (a *postgresTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
+}
+
 func (a *postgresTaskAdapter) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
 	return a.repo.ListByWorkflowID(ctx, workflowID)
 }
@@ -309,6 +313,10 @@ func (a *sqliteTaskAdapter) List(ctx context.Context, offset, limit uint64) ([]t
 	return a.repo.List(ctx, offset, limit)
 }
 
+func (a *sqliteTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
+}
+
 func (a *sqliteTaskAdapter) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
 	return a.repo.ListByWorkflowID(ctx, workflowID)
 }
@@ -463,6 +471,10 @@ func (a *badgerTaskAdapter) Update(ctx context.Context, t task.Task) error {
 
 func (a *badgerTaskAdapter) List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
 	return a.repo.List(ctx, offset, limit)
+}
+
+func (a *badgerTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
 }
 
 func (a *badgerTaskAdapter) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -153,7 +153,7 @@ func (a *postgresTaskAdapter) List(ctx context.Context, offset, limit uint64) ([
 	return a.repo.List(ctx, offset, limit)
 }
 
-func (a *postgresTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+func (a *postgresTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
 	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
 }
 
@@ -313,7 +313,7 @@ func (a *sqliteTaskAdapter) List(ctx context.Context, offset, limit uint64) ([]t
 	return a.repo.List(ctx, offset, limit)
 }
 
-func (a *sqliteTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+func (a *sqliteTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
 	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
 }
 
@@ -473,7 +473,7 @@ func (a *badgerTaskAdapter) List(ctx context.Context, offset, limit uint64) ([]t
 	return a.repo.List(ctx, offset, limit)
 }
 
-func (a *badgerTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+func (a *badgerTaskAdapter) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
 	return a.repo.ListByMetadataFilter(ctx, filter, offset, limit)
 }
 

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
@@ -16,16 +17,61 @@ const memoryScanPageSize uint64 = 100
 
 type memoryTaskRepo struct {
 	storage Storage
+	mu      sync.RWMutex
+	// metaIdx[key][value] → set of task IDs
+	metaIdx map[string]map[string]map[string]struct{}
 }
 
 func newMemoryTaskRepository(s Storage) TaskRepository {
-	return &memoryTaskRepo{storage: s}
+	return &memoryTaskRepo{
+		storage: s,
+		metaIdx: make(map[string]map[string]map[string]struct{}),
+	}
+}
+
+func (r *memoryTaskRepo) indexTask(t task.Task) {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if r.metaIdx[k] == nil {
+			r.metaIdx[k] = make(map[string]map[string]struct{})
+		}
+		if r.metaIdx[k][s] == nil {
+			r.metaIdx[k][s] = make(map[string]struct{})
+		}
+		r.metaIdx[k][s][t.ID] = struct{}{}
+	}
+}
+
+func (r *memoryTaskRepo) deindexTask(t task.Task) {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		ids, ok := r.metaIdx[k][s]
+		if !ok {
+			continue
+		}
+		delete(ids, t.ID)
+		if len(ids) == 0 {
+			delete(r.metaIdx[k], s)
+		}
+		if len(r.metaIdx[k]) == 0 {
+			delete(r.metaIdx, k)
+		}
+	}
 }
 
 func (r *memoryTaskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if err := r.storage.Create(ctx, t.ID, t); err != nil {
 		return task.Task{}, err
 	}
+	r.indexTask(t)
 
 	return t, nil
 }
@@ -44,7 +90,19 @@ func (r *memoryTaskRepo) Get(ctx context.Context, id string) (task.Task, error) 
 }
 
 func (r *memoryTaskRepo) Update(ctx context.Context, t task.Task) error {
-	return r.storage.Update(ctx, t.ID, t)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if old, err := r.storage.Get(ctx, t.ID); err == nil {
+		if oldTask, ok := old.(task.Task); ok {
+			r.deindexTask(oldTask)
+		}
+	}
+	if err := r.storage.Update(ctx, t.ID, t); err != nil {
+		return err
+	}
+	r.indexTask(t)
+
+	return nil
 }
 
 func (r *memoryTaskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
@@ -65,47 +123,62 @@ func (r *memoryTaskRepo) List(ctx context.Context, offset, limit uint64) ([]task
 }
 
 func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
-	data, _, err := r.storage.List(ctx, 0, maxMemoryFetch)
-	if err != nil {
-		return nil, 0, err
+	if len(filter) == 0 {
+		return r.List(ctx, offset, limit)
 	}
 
-	matched := make([]task.Task, 0)
-	for _, d := range data {
-		t, ok := d.(task.Task)
+	r.mu.RLock()
+	var matchIDs map[string]struct{}
+	for k, v := range filter {
+		vals, ok := r.metaIdx[k]
+		if !ok {
+			r.mu.RUnlock()
+			return []task.Task{}, 0, nil
+		}
+		taskIDs, ok := vals[v]
+		if !ok {
+			r.mu.RUnlock()
+			return []task.Task{}, 0, nil
+		}
+		if matchIDs == nil {
+			matchIDs = make(map[string]struct{}, len(taskIDs))
+			for id := range taskIDs {
+				matchIDs[id] = struct{}{}
+			}
+		} else {
+			for id := range matchIDs {
+				if _, ok := taskIDs[id]; !ok {
+					delete(matchIDs, id)
+				}
+			}
+		}
+		if len(matchIDs) == 0 {
+			r.mu.RUnlock()
+			return []task.Task{}, 0, nil
+		}
+	}
+	r.mu.RUnlock()
+
+	tasks := make([]task.Task, 0, len(matchIDs))
+	for id := range matchIDs {
+		data, err := r.storage.Get(ctx, id)
+		if err != nil {
+			continue
+		}
+		t, ok := data.(task.Task)
 		if !ok {
 			continue
 		}
-		if t.Metadata == nil {
-			continue
-		}
-		match := true
-		for k, v := range filter {
-			val, exists := t.Metadata[k]
-			if !exists {
-				match = false
-
-				break
-			}
-			s, ok := val.(string)
-			if !ok || s != v {
-				match = false
-
-				break
-			}
-		}
-		if match {
-			matched = append(matched, t)
-		}
+		tasks = append(tasks, t)
 	}
 
-	total := uint64(len(matched))
+	total := uint64(len(tasks))
 	if offset >= total {
 		return []task.Task{}, total, nil
 	}
 	end := min(offset+limit, total)
 
-	return matched[offset:end], total, nil
+	return tasks[offset:end], total, nil
 }
 
 func (r *memoryTaskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
@@ -149,6 +222,14 @@ func (r *memoryTaskRepo) ListByJobID(ctx context.Context, jobID string) ([]task.
 }
 
 func (r *memoryTaskRepo) Delete(ctx context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if old, err := r.storage.Get(ctx, id); err == nil {
+		if oldTask, ok := old.(task.Task); ok {
+			r.deindexTask(oldTask)
+		}
+	}
+
 	return r.storage.Delete(ctx, id)
 }
 

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -131,10 +131,7 @@ func (r *memoryTaskRepo) Delete(ctx context.Context, id string) error {
 
 func (r *memoryTaskRepo) indexTask(t task.Task) {
 	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
+		s := metaValueStr(v)
 		if r.metaIdx[k] == nil {
 			r.metaIdx[k] = make(map[string]map[string]struct{})
 		}
@@ -147,10 +144,7 @@ func (r *memoryTaskRepo) indexTask(t task.Task) {
 
 func (r *memoryTaskRepo) deindexTask(t task.Task) {
 	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
+		s := metaValueStr(v)
 		ids, ok := r.metaIdx[k][s]
 		if !ok {
 			continue
@@ -165,7 +159,18 @@ func (r *memoryTaskRepo) deindexTask(t task.Task) {
 	}
 }
 
+func metaValueStr(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+
+	return fmt.Sprint(v)
+}
+
 func (r *memoryTaskRepo) listAll(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	data, total, err := r.storage.List(ctx, offset, limit)
 	if err != nil {
 		return nil, 0, err
@@ -188,10 +193,7 @@ func (r *memoryTaskRepo) filterIDsByMetadata(filter task.Metadata) (map[string]s
 
 	var matchIDs map[string]struct{}
 	for k, v := range filter {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
+		s := metaValueStr(v)
 		vals, ok := r.metaIdx[k]
 		if !ok {
 			return nil, false

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -86,7 +86,7 @@ func (r *memoryTaskRepo) List(ctx context.Context, offset, limit uint64) ([]task
 	return tasks, total, nil
 }
 
-func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
 	if len(filter) == 0 {
 		return r.List(ctx, offset, limit)
 	}
@@ -94,13 +94,17 @@ func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter map[st
 	r.mu.RLock()
 	var matchIDs map[string]struct{}
 	for k, v := range filter {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
 		vals, ok := r.metaIdx[k]
 		if !ok {
 			r.mu.RUnlock()
 
 			return []task.Task{}, 0, nil
 		}
-		taskIDs, ok := vals[v]
+		taskIDs, ok := vals[s]
 		if !ok {
 			r.mu.RUnlock()
 

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -64,6 +64,50 @@ func (r *memoryTaskRepo) List(ctx context.Context, offset, limit uint64) ([]task
 	return tasks, total, nil
 }
 
+func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+	data, _, err := r.storage.List(ctx, 0, maxMemoryFetch)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	matched := make([]task.Task, 0)
+	for _, d := range data {
+		t, ok := d.(task.Task)
+		if !ok {
+			continue
+		}
+		if t.Metadata == nil {
+			continue
+		}
+		match := true
+		for k, v := range filter {
+			val, exists := t.Metadata[k]
+			if !exists {
+				match = false
+
+				break
+			}
+			s, ok := val.(string)
+			if !ok || s != v {
+				match = false
+
+				break
+			}
+		}
+		if match {
+			matched = append(matched, t)
+		}
+	}
+
+	total := uint64(len(matched))
+	if offset >= total {
+		return []task.Task{}, total, nil
+	}
+	end := min(offset+limit, total)
+
+	return matched[offset:end], total, nil
+}
+
 func (r *memoryTaskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
 	data, _, err := r.storage.List(ctx, 0, math.MaxUint64)
 	if err != nil {

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -69,26 +69,22 @@ func (r *memoryTaskRepo) Update(ctx context.Context, t task.Task) error {
 	return nil
 }
 
-func (r *memoryTaskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
-	data, total, err := r.storage.List(ctx, offset, limit)
-	if err != nil {
-		return nil, 0, err
-	}
-	tasks := make([]task.Task, len(data))
-	for i, d := range data {
-		t, ok := d.(task.Task)
-		if !ok {
-			return nil, 0, pkgerrors.ErrInvalidData
-		}
-		tasks[i] = t
-	}
-
-	return tasks, total, nil
-}
-
-func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *memoryTaskRepo) List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	if len(filter) == 0 {
-		return r.List(ctx, offset, limit)
+		data, total, err := r.storage.List(ctx, offset, limit)
+		if err != nil {
+			return nil, 0, err
+		}
+		tasks := make([]task.Task, len(data))
+		for i, d := range data {
+			t, ok := d.(task.Task)
+			if !ok {
+				return nil, 0, pkgerrors.ErrInvalidData
+			}
+			tasks[i] = t
+		}
+
+		return tasks, total, nil
 	}
 
 	r.mu.RLock()

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -29,42 +29,6 @@ func newMemoryTaskRepository(s Storage) TaskRepository {
 	}
 }
 
-func (r *memoryTaskRepo) indexTask(t task.Task) {
-	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		if r.metaIdx[k] == nil {
-			r.metaIdx[k] = make(map[string]map[string]struct{})
-		}
-		if r.metaIdx[k][s] == nil {
-			r.metaIdx[k][s] = make(map[string]struct{})
-		}
-		r.metaIdx[k][s][t.ID] = struct{}{}
-	}
-}
-
-func (r *memoryTaskRepo) deindexTask(t task.Task) {
-	for k, v := range t.Metadata {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		ids, ok := r.metaIdx[k][s]
-		if !ok {
-			continue
-		}
-		delete(ids, t.ID)
-		if len(ids) == 0 {
-			delete(r.metaIdx[k], s)
-		}
-		if len(r.metaIdx[k]) == 0 {
-			delete(r.metaIdx, k)
-		}
-	}
-}
-
 func (r *memoryTaskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -133,11 +97,13 @@ func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter map[st
 		vals, ok := r.metaIdx[k]
 		if !ok {
 			r.mu.RUnlock()
+
 			return []task.Task{}, 0, nil
 		}
 		taskIDs, ok := vals[v]
 		if !ok {
 			r.mu.RUnlock()
+
 			return []task.Task{}, 0, nil
 		}
 		if matchIDs == nil {
@@ -154,6 +120,7 @@ func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter map[st
 		}
 		if len(matchIDs) == 0 {
 			r.mu.RUnlock()
+
 			return []task.Task{}, 0, nil
 		}
 	}
@@ -231,6 +198,42 @@ func (r *memoryTaskRepo) Delete(ctx context.Context, id string) error {
 	}
 
 	return r.storage.Delete(ctx, id)
+}
+
+func (r *memoryTaskRepo) indexTask(t task.Task) {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if r.metaIdx[k] == nil {
+			r.metaIdx[k] = make(map[string]map[string]struct{})
+		}
+		if r.metaIdx[k][s] == nil {
+			r.metaIdx[k][s] = make(map[string]struct{})
+		}
+		r.metaIdx[k][s][t.ID] = struct{}{}
+	}
+}
+
+func (r *memoryTaskRepo) deindexTask(t task.Task) {
+	for k, v := range t.Metadata {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		ids, ok := r.metaIdx[k][s]
+		if !ok {
+			continue
+		}
+		delete(ids, t.ID)
+		if len(ids) == 0 {
+			delete(r.metaIdx[k], s)
+		}
+		if len(r.metaIdx[k]) == 0 {
+			delete(r.metaIdx, k)
+		}
+	}
 }
 
 type memoryPropletRepo struct {

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -86,7 +86,7 @@ func (r *memoryTaskRepo) List(ctx context.Context, offset, limit uint64) ([]task
 	return tasks, total, nil
 }
 
-func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *memoryTaskRepo) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	if len(filter) == 0 {
 		return r.List(ctx, offset, limit)
 	}

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -1,9 +1,11 @@
 package storage
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -240,6 +242,9 @@ func (r *memoryTaskRepo) listByMetadata(ctx context.Context, filter task.Metadat
 		}
 		tasks = append(tasks, t)
 	}
+	slices.SortFunc(tasks, func(a, b task.Task) int {
+		return cmp.Compare(a.ID, b.ID)
+	})
 
 	total := uint64(len(tasks))
 	if offset >= total {

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -71,81 +71,10 @@ func (r *memoryTaskRepo) Update(ctx context.Context, t task.Task) error {
 
 func (r *memoryTaskRepo) List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	if len(filter) == 0 {
-		data, total, err := r.storage.List(ctx, offset, limit)
-		if err != nil {
-			return nil, 0, err
-		}
-		tasks := make([]task.Task, len(data))
-		for i, d := range data {
-			t, ok := d.(task.Task)
-			if !ok {
-				return nil, 0, pkgerrors.ErrInvalidData
-			}
-			tasks[i] = t
-		}
-
-		return tasks, total, nil
+		return r.listAll(ctx, offset, limit)
 	}
 
-	r.mu.RLock()
-	var matchIDs map[string]struct{}
-	for k, v := range filter {
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		vals, ok := r.metaIdx[k]
-		if !ok {
-			r.mu.RUnlock()
-
-			return []task.Task{}, 0, nil
-		}
-		taskIDs, ok := vals[s]
-		if !ok {
-			r.mu.RUnlock()
-
-			return []task.Task{}, 0, nil
-		}
-		if matchIDs == nil {
-			matchIDs = make(map[string]struct{}, len(taskIDs))
-			for id := range taskIDs {
-				matchIDs[id] = struct{}{}
-			}
-		} else {
-			for id := range matchIDs {
-				if _, ok := taskIDs[id]; !ok {
-					delete(matchIDs, id)
-				}
-			}
-		}
-		if len(matchIDs) == 0 {
-			r.mu.RUnlock()
-
-			return []task.Task{}, 0, nil
-		}
-	}
-	r.mu.RUnlock()
-
-	tasks := make([]task.Task, 0, len(matchIDs))
-	for id := range matchIDs {
-		data, err := r.storage.Get(ctx, id)
-		if err != nil {
-			continue
-		}
-		t, ok := data.(task.Task)
-		if !ok {
-			continue
-		}
-		tasks = append(tasks, t)
-	}
-
-	total := uint64(len(tasks))
-	if offset >= total {
-		return []task.Task{}, total, nil
-	}
-	end := min(offset+limit, total)
-
-	return tasks[offset:end], total, nil
+	return r.listByMetadata(ctx, filter, offset, limit)
 }
 
 func (r *memoryTaskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
@@ -234,6 +163,88 @@ func (r *memoryTaskRepo) deindexTask(t task.Task) {
 			delete(r.metaIdx, k)
 		}
 	}
+}
+
+func (r *memoryTaskRepo) listAll(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
+	data, total, err := r.storage.List(ctx, offset, limit)
+	if err != nil {
+		return nil, 0, err
+	}
+	tasks := make([]task.Task, len(data))
+	for i, d := range data {
+		t, ok := d.(task.Task)
+		if !ok {
+			return nil, 0, pkgerrors.ErrInvalidData
+		}
+		tasks[i] = t
+	}
+
+	return tasks, total, nil
+}
+
+func (r *memoryTaskRepo) filterIDsByMetadata(filter task.Metadata) (map[string]struct{}, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var matchIDs map[string]struct{}
+	for k, v := range filter {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		vals, ok := r.metaIdx[k]
+		if !ok {
+			return nil, false
+		}
+		taskIDs, ok := vals[s]
+		if !ok {
+			return nil, false
+		}
+		if matchIDs == nil {
+			matchIDs = make(map[string]struct{}, len(taskIDs))
+			for id := range taskIDs {
+				matchIDs[id] = struct{}{}
+			}
+		} else {
+			for id := range matchIDs {
+				if _, ok := taskIDs[id]; !ok {
+					delete(matchIDs, id)
+				}
+			}
+		}
+		if len(matchIDs) == 0 {
+			return nil, false
+		}
+	}
+
+	return matchIDs, true
+}
+
+func (r *memoryTaskRepo) listByMetadata(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
+	matchIDs, ok := r.filterIDsByMetadata(filter)
+	if !ok || len(matchIDs) == 0 {
+		return []task.Task{}, 0, nil
+	}
+
+	tasks := make([]task.Task, 0, len(matchIDs))
+	for id := range matchIDs {
+		data, err := r.storage.Get(ctx, id)
+		if err != nil {
+			continue
+		}
+		t, ok := data.(task.Task)
+		if !ok {
+			continue
+		}
+		tasks = append(tasks, t)
+	}
+
+	total := uint64(len(tasks))
+	if offset >= total {
+		return []task.Task{}, total, nil
+	}
+
+	return tasks[offset:min(offset+limit, total)], total, nil
 }
 
 type memoryPropletRepo struct {

--- a/pkg/storage/mocks/proplet_repository.go
+++ b/pkg/storage/mocks/proplet_repository.go
@@ -434,6 +434,7 @@ func (_c *MockPropletRepository_Update_Call) RunAndReturn(run func(ctx context.C
 	return _c
 }
 
+// GetAliveHistory provides a mock function for the type MockPropletRepository
 func (_mock *MockPropletRepository) GetAliveHistory(ctx context.Context, id string, offset uint64, limit uint64) ([]time.Time, uint64, error) {
 	ret := _mock.Called(ctx, id, offset, limit)
 
@@ -467,10 +468,16 @@ func (_mock *MockPropletRepository) GetAliveHistory(ctx context.Context, id stri
 	return r0, r1, r2
 }
 
+// MockPropletRepository_GetAliveHistory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAliveHistory'
 type MockPropletRepository_GetAliveHistory_Call struct {
 	*mock.Call
 }
 
+// GetAliveHistory is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - offset uint64
+//   - limit uint64
 func (_e *MockPropletRepository_Expecter) GetAliveHistory(ctx interface{}, id interface{}, offset interface{}, limit interface{}) *MockPropletRepository_GetAliveHistory_Call {
 	return &MockPropletRepository_GetAliveHistory_Call{Call: _e.mock.On("GetAliveHistory", ctx, id, offset, limit)}
 }
@@ -493,7 +500,12 @@ func (_c *MockPropletRepository_GetAliveHistory_Call) Run(run func(ctx context.C
 		if args[3] != nil {
 			arg3 = args[3].(uint64)
 		}
-		run(arg0, arg1, arg2, arg3)
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
 	})
 	return _c
 }

--- a/pkg/storage/mocks/task_repository.go
+++ b/pkg/storage/mocks/task_repository.go
@@ -228,8 +228,8 @@ func (_c *MockTaskRepository_Get_Call) RunAndReturn(run func(ctx context.Context
 }
 
 // List provides a mock function for the type MockTaskRepository
-func (_mock *MockTaskRepository) List(ctx context.Context, offset uint64, limit uint64) ([]task.Task, uint64, error) {
-	ret := _mock.Called(ctx, offset, limit)
+func (_mock *MockTaskRepository) List(ctx context.Context, filter task.Metadata, offset uint64, limit uint64) ([]task.Task, uint64, error) {
+	ret := _mock.Called(ctx, filter, offset, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
@@ -238,23 +238,23 @@ func (_mock *MockTaskRepository) List(ctx context.Context, offset uint64, limit 
 	var r0 []task.Task
 	var r1 uint64
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64) ([]task.Task, uint64, error)); ok {
-		return returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, task.Metadata, uint64, uint64) ([]task.Task, uint64, error)); ok {
+		return returnFunc(ctx, filter, offset, limit)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64) []task.Task); ok {
-		r0 = returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, task.Metadata, uint64, uint64) []task.Task); ok {
+		r0 = returnFunc(ctx, filter, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]task.Task)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uint64, uint64) uint64); ok {
-		r1 = returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, task.Metadata, uint64, uint64) uint64); ok {
+		r1 = returnFunc(ctx, filter, offset, limit)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, uint64, uint64) error); ok {
-		r2 = returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, task.Metadata, uint64, uint64) error); ok {
+		r2 = returnFunc(ctx, filter, offset, limit)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -268,31 +268,32 @@ type MockTaskRepository_List_Call struct {
 
 // List is a helper method to define mock.On call
 //   - ctx context.Context
+//   - filter task.Metadata
 //   - offset uint64
 //   - limit uint64
-func (_e *MockTaskRepository_Expecter) List(ctx interface{}, offset interface{}, limit interface{}) *MockTaskRepository_List_Call {
-	return &MockTaskRepository_List_Call{Call: _e.mock.On("List", ctx, offset, limit)}
+func (_e *MockTaskRepository_Expecter) List(ctx interface{}, filter interface{}, offset interface{}, limit interface{}) *MockTaskRepository_List_Call {
+	return &MockTaskRepository_List_Call{Call: _e.mock.On("List", ctx, filter, offset, limit)}
 }
 
-func (_c *MockTaskRepository_List_Call) Run(run func(ctx context.Context, offset uint64, limit uint64)) *MockTaskRepository_List_Call {
+func (_c *MockTaskRepository_List_Call) Run(run func(ctx context.Context, filter task.Metadata, offset uint64, limit uint64)) *MockTaskRepository_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 uint64
+		var arg1 task.Metadata
 		if args[1] != nil {
-			arg1 = args[1].(uint64)
+			arg1 = args[1].(task.Metadata)
 		}
 		var arg2 uint64
 		if args[2] != nil {
 			arg2 = args[2].(uint64)
 		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
+		var arg3 uint64
+		if args[3] != nil {
+			arg3 = args[3].(uint64)
+		}
+		run(arg0, arg1, arg2, arg3)
 	})
 	return _c
 }
@@ -302,7 +303,7 @@ func (_c *MockTaskRepository_List_Call) Return(tasks []task.Task, v uint64, err 
 	return _c
 }
 
-func (_c *MockTaskRepository_List_Call) RunAndReturn(run func(ctx context.Context, offset uint64, limit uint64) ([]task.Task, uint64, error)) *MockTaskRepository_List_Call {
+func (_c *MockTaskRepository_List_Call) RunAndReturn(run func(ctx context.Context, filter task.Metadata, offset uint64, limit uint64) ([]task.Task, uint64, error)) *MockTaskRepository_List_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -375,91 +376,6 @@ func (_c *MockTaskRepository_ListByJobID_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
-// ListByMetadataFilter provides a mock function for the type MockTaskRepository
-func (_mock *MockTaskRepository) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset uint64, limit uint64) ([]task.Task, uint64, error) {
-	ret := _mock.Called(ctx, filter, offset, limit)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListByMetadataFilter")
-	}
-
-	var r0 []task.Task
-	var r1 uint64
-	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, task.Metadata, uint64, uint64) ([]task.Task, uint64, error)); ok {
-		return returnFunc(ctx, filter, offset, limit)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, task.Metadata, uint64, uint64) []task.Task); ok {
-		r0 = returnFunc(ctx, filter, offset, limit)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]task.Task)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, task.Metadata, uint64, uint64) uint64); ok {
-		r1 = returnFunc(ctx, filter, offset, limit)
-	} else {
-		r1 = ret.Get(1).(uint64)
-	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, task.Metadata, uint64, uint64) error); ok {
-		r2 = returnFunc(ctx, filter, offset, limit)
-	} else {
-		r2 = ret.Error(2)
-	}
-	return r0, r1, r2
-}
-
-// MockTaskRepository_ListByMetadataFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListByMetadataFilter'
-type MockTaskRepository_ListByMetadataFilter_Call struct {
-	*mock.Call
-}
-
-// ListByMetadataFilter is a helper method to define mock.On call
-//   - ctx context.Context
-//   - filter task.Metadata
-//   - offset uint64
-//   - limit uint64
-func (_e *MockTaskRepository_Expecter) ListByMetadataFilter(ctx interface{}, filter interface{}, offset interface{}, limit interface{}) *MockTaskRepository_ListByMetadataFilter_Call {
-	return &MockTaskRepository_ListByMetadataFilter_Call{Call: _e.mock.On("ListByMetadataFilter", ctx, filter, offset, limit)}
-}
-
-func (_c *MockTaskRepository_ListByMetadataFilter_Call) Run(run func(ctx context.Context, filter task.Metadata, offset uint64, limit uint64)) *MockTaskRepository_ListByMetadataFilter_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 task.Metadata
-		if args[1] != nil {
-			arg1 = args[1].(task.Metadata)
-		}
-		var arg2 uint64
-		if args[2] != nil {
-			arg2 = args[2].(uint64)
-		}
-		var arg3 uint64
-		if args[3] != nil {
-			arg3 = args[3].(uint64)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockTaskRepository_ListByMetadataFilter_Call) Return(tasks []task.Task, v uint64, err error) *MockTaskRepository_ListByMetadataFilter_Call {
-	_c.Call.Return(tasks, v, err)
-	return _c
-}
-
-func (_c *MockTaskRepository_ListByMetadataFilter_Call) RunAndReturn(run func(ctx context.Context, filter task.Metadata, offset uint64, limit uint64) ([]task.Task, uint64, error)) *MockTaskRepository_ListByMetadataFilter_Call {
-	_c.Call.Return(run)
-	return _c
-}
 
 // ListByWorkflowID provides a mock function for the type MockTaskRepository
 func (_mock *MockTaskRepository) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {

--- a/pkg/storage/mocks/task_repository.go
+++ b/pkg/storage/mocks/task_repository.go
@@ -376,7 +376,7 @@ func (_c *MockTaskRepository_ListByJobID_Call) RunAndReturn(run func(ctx context
 }
 
 // ListByMetadataFilter provides a mock function for the type MockTaskRepository
-func (_mock *MockTaskRepository) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset uint64, limit uint64) ([]task.Task, uint64, error) {
+func (_mock *MockTaskRepository) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset uint64, limit uint64) ([]task.Task, uint64, error) {
 	ret := _mock.Called(ctx, filter, offset, limit)
 
 	if len(ret) == 0 {
@@ -386,22 +386,22 @@ func (_mock *MockTaskRepository) ListByMetadataFilter(ctx context.Context, filte
 	var r0 []task.Task
 	var r1 uint64
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]any, uint64, uint64) ([]task.Task, uint64, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, task.Metadata, uint64, uint64) ([]task.Task, uint64, error)); ok {
 		return returnFunc(ctx, filter, offset, limit)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]any, uint64, uint64) []task.Task); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, task.Metadata, uint64, uint64) []task.Task); ok {
 		r0 = returnFunc(ctx, filter, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]task.Task)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string]any, uint64, uint64) uint64); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, task.Metadata, uint64, uint64) uint64); ok {
 		r1 = returnFunc(ctx, filter, offset, limit)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, map[string]any, uint64, uint64) error); ok {
+	if returnFunc, ok := ret.Get(2).(func(context.Context, task.Metadata, uint64, uint64) error); ok {
 		r2 = returnFunc(ctx, filter, offset, limit)
 	} else {
 		r2 = ret.Error(2)
@@ -416,22 +416,22 @@ type MockTaskRepository_ListByMetadataFilter_Call struct {
 
 // ListByMetadataFilter is a helper method to define mock.On call
 //   - ctx context.Context
-//   - filter map[string]any
+//   - filter task.Metadata
 //   - offset uint64
 //   - limit uint64
 func (_e *MockTaskRepository_Expecter) ListByMetadataFilter(ctx interface{}, filter interface{}, offset interface{}, limit interface{}) *MockTaskRepository_ListByMetadataFilter_Call {
 	return &MockTaskRepository_ListByMetadataFilter_Call{Call: _e.mock.On("ListByMetadataFilter", ctx, filter, offset, limit)}
 }
 
-func (_c *MockTaskRepository_ListByMetadataFilter_Call) Run(run func(ctx context.Context, filter map[string]any, offset uint64, limit uint64)) *MockTaskRepository_ListByMetadataFilter_Call {
+func (_c *MockTaskRepository_ListByMetadataFilter_Call) Run(run func(ctx context.Context, filter task.Metadata, offset uint64, limit uint64)) *MockTaskRepository_ListByMetadataFilter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 map[string]any
+		var arg1 task.Metadata
 		if args[1] != nil {
-			arg1 = args[1].(map[string]any)
+			arg1 = args[1].(task.Metadata)
 		}
 		var arg2 uint64
 		if args[2] != nil {
@@ -456,7 +456,7 @@ func (_c *MockTaskRepository_ListByMetadataFilter_Call) Return(tasks []task.Task
 	return _c
 }
 
-func (_c *MockTaskRepository_ListByMetadataFilter_Call) RunAndReturn(run func(ctx context.Context, filter map[string]any, offset uint64, limit uint64) ([]task.Task, uint64, error)) *MockTaskRepository_ListByMetadataFilter_Call {
+func (_c *MockTaskRepository_ListByMetadataFilter_Call) RunAndReturn(run func(ctx context.Context, filter task.Metadata, offset uint64, limit uint64) ([]task.Task, uint64, error)) *MockTaskRepository_ListByMetadataFilter_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/storage/mocks/task_repository.go
+++ b/pkg/storage/mocks/task_repository.go
@@ -376,7 +376,7 @@ func (_c *MockTaskRepository_ListByJobID_Call) RunAndReturn(run func(ctx context
 }
 
 // ListByMetadataFilter provides a mock function for the type MockTaskRepository
-func (_mock *MockTaskRepository) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset uint64, limit uint64) ([]task.Task, uint64, error) {
+func (_mock *MockTaskRepository) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset uint64, limit uint64) ([]task.Task, uint64, error) {
 	ret := _mock.Called(ctx, filter, offset, limit)
 
 	if len(ret) == 0 {
@@ -386,22 +386,22 @@ func (_mock *MockTaskRepository) ListByMetadataFilter(ctx context.Context, filte
 	var r0 []task.Task
 	var r1 uint64
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]string, uint64, uint64) ([]task.Task, uint64, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]any, uint64, uint64) ([]task.Task, uint64, error)); ok {
 		return returnFunc(ctx, filter, offset, limit)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]string, uint64, uint64) []task.Task); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]any, uint64, uint64) []task.Task); ok {
 		r0 = returnFunc(ctx, filter, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]task.Task)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string]string, uint64, uint64) uint64); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string]any, uint64, uint64) uint64); ok {
 		r1 = returnFunc(ctx, filter, offset, limit)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, map[string]string, uint64, uint64) error); ok {
+	if returnFunc, ok := ret.Get(2).(func(context.Context, map[string]any, uint64, uint64) error); ok {
 		r2 = returnFunc(ctx, filter, offset, limit)
 	} else {
 		r2 = ret.Error(2)
@@ -416,22 +416,22 @@ type MockTaskRepository_ListByMetadataFilter_Call struct {
 
 // ListByMetadataFilter is a helper method to define mock.On call
 //   - ctx context.Context
-//   - filter map[string]string
+//   - filter map[string]any
 //   - offset uint64
 //   - limit uint64
 func (_e *MockTaskRepository_Expecter) ListByMetadataFilter(ctx interface{}, filter interface{}, offset interface{}, limit interface{}) *MockTaskRepository_ListByMetadataFilter_Call {
 	return &MockTaskRepository_ListByMetadataFilter_Call{Call: _e.mock.On("ListByMetadataFilter", ctx, filter, offset, limit)}
 }
 
-func (_c *MockTaskRepository_ListByMetadataFilter_Call) Run(run func(ctx context.Context, filter map[string]string, offset uint64, limit uint64)) *MockTaskRepository_ListByMetadataFilter_Call {
+func (_c *MockTaskRepository_ListByMetadataFilter_Call) Run(run func(ctx context.Context, filter map[string]any, offset uint64, limit uint64)) *MockTaskRepository_ListByMetadataFilter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 map[string]string
+		var arg1 map[string]any
 		if args[1] != nil {
-			arg1 = args[1].(map[string]string)
+			arg1 = args[1].(map[string]any)
 		}
 		var arg2 uint64
 		if args[2] != nil {
@@ -456,7 +456,7 @@ func (_c *MockTaskRepository_ListByMetadataFilter_Call) Return(tasks []task.Task
 	return _c
 }
 
-func (_c *MockTaskRepository_ListByMetadataFilter_Call) RunAndReturn(run func(ctx context.Context, filter map[string]string, offset uint64, limit uint64) ([]task.Task, uint64, error)) *MockTaskRepository_ListByMetadataFilter_Call {
+func (_c *MockTaskRepository_ListByMetadataFilter_Call) RunAndReturn(run func(ctx context.Context, filter map[string]any, offset uint64, limit uint64) ([]task.Task, uint64, error)) *MockTaskRepository_ListByMetadataFilter_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/storage/mocks/task_repository.go
+++ b/pkg/storage/mocks/task_repository.go
@@ -375,6 +375,92 @@ func (_c *MockTaskRepository_ListByJobID_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// ListByMetadataFilter provides a mock function for the type MockTaskRepository
+func (_mock *MockTaskRepository) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset uint64, limit uint64) ([]task.Task, uint64, error) {
+	ret := _mock.Called(ctx, filter, offset, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListByMetadataFilter")
+	}
+
+	var r0 []task.Task
+	var r1 uint64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]string, uint64, uint64) ([]task.Task, uint64, error)); ok {
+		return returnFunc(ctx, filter, offset, limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]string, uint64, uint64) []task.Task); ok {
+		r0 = returnFunc(ctx, filter, offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]task.Task)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string]string, uint64, uint64) uint64); ok {
+		r1 = returnFunc(ctx, filter, offset, limit)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, map[string]string, uint64, uint64) error); ok {
+		r2 = returnFunc(ctx, filter, offset, limit)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockTaskRepository_ListByMetadataFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListByMetadataFilter'
+type MockTaskRepository_ListByMetadataFilter_Call struct {
+	*mock.Call
+}
+
+// ListByMetadataFilter is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filter map[string]string
+//   - offset uint64
+//   - limit uint64
+func (_e *MockTaskRepository_Expecter) ListByMetadataFilter(ctx interface{}, filter interface{}, offset interface{}, limit interface{}) *MockTaskRepository_ListByMetadataFilter_Call {
+	return &MockTaskRepository_ListByMetadataFilter_Call{Call: _e.mock.On("ListByMetadataFilter", ctx, filter, offset, limit)}
+}
+
+func (_c *MockTaskRepository_ListByMetadataFilter_Call) Run(run func(ctx context.Context, filter map[string]string, offset uint64, limit uint64)) *MockTaskRepository_ListByMetadataFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 map[string]string
+		if args[1] != nil {
+			arg1 = args[1].(map[string]string)
+		}
+		var arg2 uint64
+		if args[2] != nil {
+			arg2 = args[2].(uint64)
+		}
+		var arg3 uint64
+		if args[3] != nil {
+			arg3 = args[3].(uint64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTaskRepository_ListByMetadataFilter_Call) Return(tasks []task.Task, v uint64, err error) *MockTaskRepository_ListByMetadataFilter_Call {
+	_c.Call.Return(tasks, v, err)
+	return _c
+}
+
+func (_c *MockTaskRepository_ListByMetadataFilter_Call) RunAndReturn(run func(ctx context.Context, filter map[string]string, offset uint64, limit uint64) ([]task.Task, uint64, error)) *MockTaskRepository_ListByMetadataFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListByWorkflowID provides a mock function for the type MockTaskRepository
 func (_mock *MockTaskRepository) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
 	ret := _mock.Called(ctx, workflowID)

--- a/pkg/storage/postgres/init.go
+++ b/pkg/storage/postgres/init.go
@@ -47,7 +47,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/postgres/init.go
+++ b/pkg/storage/postgres/init.go
@@ -46,8 +46,7 @@ type TaskRepository interface {
 	Create(ctx context.Context, t task.Task) (task.Task, error)
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
-	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
+	List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/postgres/init.go
+++ b/pkg/storage/postgres/init.go
@@ -47,7 +47,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/postgres/init.go
+++ b/pkg/storage/postgres/init.go
@@ -47,6 +47,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error
@@ -259,6 +260,17 @@ func (db *Database) Migrate() error {
 				},
 				Down: []string{
 					`ALTER TABLE tasks DROP COLUMN IF EXISTS broadcast`,
+				},
+			},
+			{
+				Id: "5_add_task_metadata",
+				Up: []string{
+					`ALTER TABLE tasks ADD COLUMN IF NOT EXISTS metadata JSONB`,
+					`CREATE INDEX IF NOT EXISTS idx_tasks_metadata ON tasks USING GIN (metadata jsonb_path_ops)`,
+				},
+				Down: []string{
+					`DROP INDEX IF EXISTS idx_tasks_metadata`,
+					`ALTER TABLE tasks DROP COLUMN IF EXISTS metadata`,
 				},
 			},
 		},

--- a/pkg/storage/postgres/tasks.go
+++ b/pkg/storage/postgres/tasks.go
@@ -232,7 +232,10 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 }
 
 func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
-	whereClause, args := buildPostgresMetadataWhere(filter)
+	whereClause, args, nextIdx, err := buildPostgresMetadataWhere(filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
 	countArgs := args
 	args = append(args, limit, offset)
 
@@ -242,9 +245,8 @@ func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]s
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 
-	n := len(filter) + 1
 	query := `SELECT ` + taskColumns + ` FROM tasks` + whereClause +
-		fmt.Sprintf(` ORDER BY created_at DESC LIMIT $%d OFFSET $%d`, n, n+1)
+		fmt.Sprintf(` ORDER BY created_at DESC LIMIT $%d OFFSET $%d`, nextIdx, nextIdx+1)
 	tasks, err := r.scanTasks(ctx, query, args...)
 	if err != nil {
 		return nil, 0, err
@@ -253,9 +255,9 @@ func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]s
 	return tasks, total, nil
 }
 
-func buildPostgresMetadataWhere(filter map[string]string) (clause string, args []any) {
+func buildPostgresMetadataWhere(filter map[string]string) (clause string, args []any, nextIdx int, err error) {
 	if len(filter) == 0 {
-		return "", nil
+		return "", nil, 1, nil
 	}
 	var sb strings.Builder
 	sb.WriteString(" WHERE metadata IS NOT NULL")
@@ -265,13 +267,13 @@ func buildPostgresMetadataWhere(filter map[string]string) (clause string, args [
 		fmt.Fprintf(&sb, ` AND metadata @> $%d::jsonb`, i)
 		b, err := json.Marshal(map[string]string{k: v})
 		if err != nil {
-			return "", nil
+			return "", nil, 0, fmt.Errorf("failed to marshal metadata filter: %w", err)
 		}
 		args = append(args, string(b))
 		i++
 	}
 
-	return sb.String(), args
+	return sb.String(), args, i, nil
 }
 
 func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {

--- a/pkg/storage/postgres/tasks.go
+++ b/pkg/storage/postgres/tasks.go
@@ -220,24 +220,7 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 	return nil
 }
 
-func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
-	var total uint64
-	err := r.db.GetContext(ctx, &total, "SELECT COUNT(*) FROM tasks")
-	if err != nil {
-		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
-	}
-
-	query := `SELECT ` + taskColumns + ` FROM tasks ORDER BY created_at DESC LIMIT $1 OFFSET $2`
-
-	tasks, err := r.scanTasks(ctx, query, limit, offset)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return tasks, total, nil
-}
-
-func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *taskRepo) List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	whereClause, args, nextIdx, err := buildPostgresMetadataWhere(filter)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)

--- a/pkg/storage/postgres/tasks.go
+++ b/pkg/storage/postgres/tasks.go
@@ -184,7 +184,7 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 		return fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 
-	_, err = r.db.ExecContext(ctx, query,
+	res, err := r.db.ExecContext(ctx, query,
 		t.ID, t.Name, uint8(t.State),
 		nullString(t.ImageURL),
 		t.File,
@@ -209,6 +209,13 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 	)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrUpdate, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrUpdate, err)
+	}
+	if n < 1 {
+		return fmt.Errorf("%w: task not found", ErrUpdate)
 	}
 
 	return nil

--- a/pkg/storage/postgres/tasks.go
+++ b/pkg/storage/postgres/tasks.go
@@ -3,8 +3,10 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/absmach/propeller/pkg/task"
 )
@@ -44,15 +46,16 @@ type dbTask struct {
 	Kind              *string       `db:"kind"`
 	Mode              *string       `db:"mode"`
 	Broadcast         bool          `db:"broadcast"`
+	Metadata          []byte        `db:"metadata"`
 }
 
 const taskColumns = `id, name, state, image_url, file, cli_args, inputs, env, daemon, encrypted,
 	kbs_resource_path, proplet_id, results, error, monitoring_profile, start_time, finish_time,
-	created_at, updated_at, workflow_id, job_id, depends_on, run_if, kind, mode, broadcast`
+	created_at, updated_at, workflow_id, job_id, depends_on, run_if, kind, mode, broadcast, metadata`
 
 func (r *taskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
 	query := `INSERT INTO tasks (` + taskColumns + `)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)`
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)`
 
 	cliArgs, err := jsonBytes(t.CLIArgs)
 	if err != nil {
@@ -84,6 +87,11 @@ func (r *taskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
 		return task.Task{}, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 
+	metadata, err := jsonBytes(t.Metadata)
+	if err != nil {
+		return task.Task{}, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+
 	_, err = r.db.ExecContext(ctx, query,
 		t.ID, t.Name, uint8(t.State),
 		nullString(t.ImageURL),
@@ -107,6 +115,7 @@ func (r *taskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
 		nullString(string(t.Kind)),
 		nullString(string(t.Mode)),
 		t.Broadcast,
+		metadata,
 	)
 	if err != nil {
 		return task.Task{}, fmt.Errorf("%w: %w", ErrCreate, err)
@@ -137,7 +146,7 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 		env = $8, daemon = $9, encrypted = $10, kbs_resource_path = $11, proplet_id = $12,
 		results = $13, error = $14, monitoring_profile = $15, start_time = $16,
 		finish_time = $17, updated_at = $18, workflow_id = $19, job_id = $20,
-		depends_on = $21, run_if = $22, kind = $23, mode = $24, broadcast = $25
+		depends_on = $21, run_if = $22, kind = $23, mode = $24, broadcast = $25, metadata = $26
 		WHERE id = $1`
 
 	cliArgs, err := jsonBytes(t.CLIArgs)
@@ -170,6 +179,11 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 		return fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 
+	metadata, err := jsonBytes(t.Metadata)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+
 	_, err = r.db.ExecContext(ctx, query,
 		t.ID, t.Name, uint8(t.State),
 		nullString(t.ImageURL),
@@ -191,6 +205,7 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 		nullString(string(t.Kind)),
 		nullString(string(t.Mode)),
 		t.Broadcast,
+		metadata,
 	)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrUpdate, err)
@@ -214,6 +229,49 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 	}
 
 	return tasks, total, nil
+}
+
+func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+	whereClause, args := buildPostgresMetadataWhere(filter)
+	countArgs := args
+	args = append(args, limit, offset)
+
+	var total uint64
+	countQuery := "SELECT COUNT(*) FROM tasks" + whereClause
+	if err := r.db.GetContext(ctx, &total, countQuery, countArgs...); err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+
+	n := len(filter) + 1
+	query := `SELECT ` + taskColumns + ` FROM tasks` + whereClause +
+		fmt.Sprintf(` ORDER BY created_at DESC LIMIT $%d OFFSET $%d`, n, n+1)
+	tasks, err := r.scanTasks(ctx, query, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return tasks, total, nil
+}
+
+func buildPostgresMetadataWhere(filter map[string]string) (clause string, args []any) {
+	if len(filter) == 0 {
+		return "", nil
+	}
+	var sb strings.Builder
+	sb.WriteString(" WHERE metadata IS NOT NULL")
+	args = make([]any, 0, len(filter))
+	i := 1
+	for k, v := range filter {
+		fmt.Fprintf(&sb, ` AND metadata @> $%d::jsonb`, i)
+		b, err := json.Marshal(map[string]string{k: v})
+		if err != nil {
+			return "", nil
+		}
+		args = append(args, string(b))
+		i++
+	}
+
+	return sb.String(), args
 }
 
 func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
@@ -255,7 +313,7 @@ func (r *taskRepo) scanTasks(ctx context.Context, query string, args ...any) ([]
 			&dbt.Results, &dbt.Error, &dbt.MonitoringProfile,
 			&dbt.StartTime, &dbt.FinishTime, &dbt.CreatedAt, &dbt.UpdatedAt,
 			&dbt.WorkflowID, &dbt.JobID, &dbt.DependsOn, &dbt.RunIf,
-			&dbt.Kind, &dbt.Mode, &dbt.Broadcast,
+			&dbt.Kind, &dbt.Mode, &dbt.Broadcast, &dbt.Metadata,
 		); err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrDBScan, err)
 		}
@@ -339,6 +397,11 @@ func (r *taskRepo) toTask(dbt dbTask) (task.Task, error) {
 		t.Mode = task.Mode(*dbt.Mode)
 	}
 	t.Broadcast = dbt.Broadcast
+	if dbt.Metadata != nil {
+		if err := jsonUnmarshal(dbt.Metadata, &t.Metadata); err != nil {
+			return task.Task{}, err
+		}
+	}
 
 	return t, nil
 }

--- a/pkg/storage/postgres/tasks.go
+++ b/pkg/storage/postgres/tasks.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/absmach/propeller/pkg/task"
 )
@@ -238,7 +237,7 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 	return tasks, total, nil
 }
 
-func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	whereClause, args, nextIdx, err := buildPostgresMetadataWhere(filter)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
@@ -262,25 +261,16 @@ func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]a
 	return tasks, total, nil
 }
 
-func buildPostgresMetadataWhere(filter map[string]any) (clause string, args []any, nextIdx int, err error) {
+func buildPostgresMetadataWhere(filter task.Metadata) (clause string, args []any, nextIdx int, err error) {
 	if len(filter) == 0 {
 		return "", nil, 1, nil
 	}
-	var sb strings.Builder
-	sb.WriteString(" WHERE metadata IS NOT NULL")
-	args = make([]any, 0, len(filter))
-	i := 1
-	for k, v := range filter {
-		fmt.Fprintf(&sb, ` AND metadata @> $%d::jsonb`, i)
-		b, err := json.Marshal(map[string]any{k: v})
-		if err != nil {
-			return "", nil, 0, fmt.Errorf("failed to marshal metadata filter: %w", err)
-		}
-		args = append(args, string(b))
-		i++
+	b, err := json.Marshal(filter)
+	if err != nil {
+		return "", nil, 0, fmt.Errorf("failed to marshal metadata filter: %w", err)
 	}
 
-	return sb.String(), args, i, nil
+	return " WHERE metadata IS NOT NULL AND metadata @> $1::jsonb", []any{string(b)}, 2, nil
 }
 
 func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {

--- a/pkg/storage/postgres/tasks.go
+++ b/pkg/storage/postgres/tasks.go
@@ -238,7 +238,7 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 	return tasks, total, nil
 }
 
-func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
 	whereClause, args, nextIdx, err := buildPostgresMetadataWhere(filter)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
@@ -262,7 +262,7 @@ func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]s
 	return tasks, total, nil
 }
 
-func buildPostgresMetadataWhere(filter map[string]string) (clause string, args []any, nextIdx int, err error) {
+func buildPostgresMetadataWhere(filter map[string]any) (clause string, args []any, nextIdx int, err error) {
 	if len(filter) == 0 {
 		return "", nil, 1, nil
 	}
@@ -272,7 +272,7 @@ func buildPostgresMetadataWhere(filter map[string]string) (clause string, args [
 	i := 1
 	for k, v := range filter {
 		fmt.Fprintf(&sb, ` AND metadata @> $%d::jsonb`, i)
-		b, err := json.Marshal(map[string]string{k: v})
+		b, err := json.Marshal(map[string]any{k: v})
 		if err != nil {
 			return "", nil, 0, fmt.Errorf("failed to marshal metadata filter: %w", err)
 		}

--- a/pkg/storage/repository.go
+++ b/pkg/storage/repository.go
@@ -14,7 +14,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/repository.go
+++ b/pkg/storage/repository.go
@@ -14,7 +14,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/repository.go
+++ b/pkg/storage/repository.go
@@ -14,6 +14,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/repository.go
+++ b/pkg/storage/repository.go
@@ -13,8 +13,7 @@ type TaskRepository interface {
 	Create(ctx context.Context, t task.Task) (task.Task, error)
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
-	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
+	List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/sqlite/init.go
+++ b/pkg/storage/sqlite/init.go
@@ -47,7 +47,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/sqlite/init.go
+++ b/pkg/storage/sqlite/init.go
@@ -46,8 +46,7 @@ type TaskRepository interface {
 	Create(ctx context.Context, t task.Task) (task.Task, error)
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
-	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
+	List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/sqlite/init.go
+++ b/pkg/storage/sqlite/init.go
@@ -47,7 +47,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
-	ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error

--- a/pkg/storage/sqlite/init.go
+++ b/pkg/storage/sqlite/init.go
@@ -47,6 +47,7 @@ type TaskRepository interface {
 	Get(ctx context.Context, id string) (task.Task, error)
 	Update(ctx context.Context, t task.Task) error
 	List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error)
+	ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error)
 	ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error)
 	ListByJobID(ctx context.Context, jobID string) ([]task.Task, error)
 	Delete(ctx context.Context, id string) error
@@ -252,6 +253,17 @@ func (db *Database) Migrate() error {
 				},
 				Down: []string{
 					`ALTER TABLE tasks DROP COLUMN broadcast`,
+				},
+			},
+			{
+				Id: "5_add_task_metadata",
+				Up: []string{
+					`ALTER TABLE tasks ADD COLUMN metadata TEXT`,
+					`CREATE INDEX IF NOT EXISTS idx_tasks_metadata ON tasks (json_extract(metadata, '$'))`,
+				},
+				Down: []string{
+					`DROP INDEX IF EXISTS idx_tasks_metadata`,
+					`ALTER TABLE tasks DROP COLUMN metadata`,
 				},
 			},
 		},

--- a/pkg/storage/sqlite/init.go
+++ b/pkg/storage/sqlite/init.go
@@ -258,8 +258,10 @@ func (db *Database) Migrate() error {
 				Id: "5_add_task_metadata",
 				Up: []string{
 					`ALTER TABLE tasks ADD COLUMN metadata TEXT`,
+					`CREATE INDEX IF NOT EXISTS idx_tasks_metadata ON tasks(metadata) WHERE metadata IS NOT NULL`,
 				},
 				Down: []string{
+					`DROP INDEX IF EXISTS idx_tasks_metadata`,
 					`ALTER TABLE tasks DROP COLUMN metadata`,
 				},
 			},

--- a/pkg/storage/sqlite/init.go
+++ b/pkg/storage/sqlite/init.go
@@ -259,10 +259,8 @@ func (db *Database) Migrate() error {
 				Id: "5_add_task_metadata",
 				Up: []string{
 					`ALTER TABLE tasks ADD COLUMN metadata TEXT`,
-					`CREATE INDEX IF NOT EXISTS idx_tasks_metadata ON tasks (json_extract(metadata, '$'))`,
 				},
 				Down: []string{
-					`DROP INDEX IF EXISTS idx_tasks_metadata`,
 					`ALTER TABLE tasks DROP COLUMN metadata`,
 				},
 			},

--- a/pkg/storage/sqlite/init.go
+++ b/pkg/storage/sqlite/init.go
@@ -258,10 +258,8 @@ func (db *Database) Migrate() error {
 				Id: "5_add_task_metadata",
 				Up: []string{
 					`ALTER TABLE tasks ADD COLUMN metadata TEXT`,
-					`CREATE INDEX IF NOT EXISTS idx_tasks_metadata ON tasks(metadata) WHERE metadata IS NOT NULL`,
 				},
 				Down: []string{
-					`DROP INDEX IF EXISTS idx_tasks_metadata`,
 					`ALTER TABLE tasks DROP COLUMN metadata`,
 				},
 			},

--- a/pkg/storage/sqlite/tasks.go
+++ b/pkg/storage/sqlite/tasks.go
@@ -237,14 +237,10 @@ func buildSQLiteMetadataWhere(filter task.Metadata) (clause string, args []any, 
 		if !sqliteMetadataKeyRe.MatchString(k) {
 			return "", nil, fmt.Errorf("invalid metadata key: %q", k)
 		}
-		vJSON, err := json.Marshal(v)
-		if err != nil {
-			return "", nil, fmt.Errorf("invalid metadata value for key %q: %w", k, err)
-		}
 		sb.WriteString(` AND json_extract(metadata, '$."`)
 		sb.WriteString(k)
-		sb.WriteString(`"') = json(?)`)
-		args = append(args, string(vJSON))
+		sb.WriteString(`"') = ?`)
+		args = append(args, v)
 	}
 
 	return sb.String(), args, nil

--- a/pkg/storage/sqlite/tasks.go
+++ b/pkg/storage/sqlite/tasks.go
@@ -6,11 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/absmach/propeller/pkg/task"
 )
+
+var sqliteMetadataKeyRe = regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`)
 
 type taskRepo struct {
 	db *Database
@@ -213,7 +216,10 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 }
 
 func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
-	whereClause, args := buildSQLiteMetadataWhere(filter)
+	whereClause, args, err := buildSQLiteMetadataWhere(filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
 	countArgs := args
 	args = append(args, limit, offset)
 
@@ -231,21 +237,24 @@ func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]s
 	return tasks, total, nil
 }
 
-func buildSQLiteMetadataWhere(filter map[string]string) (clause string, args []any) {
+func buildSQLiteMetadataWhere(filter map[string]string) (clause string, args []any, err error) {
 	if len(filter) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
 	var sb strings.Builder
 	sb.WriteString(" WHERE metadata IS NOT NULL")
 	args = make([]any, 0, len(filter))
 	for k, v := range filter {
+		if !sqliteMetadataKeyRe.MatchString(k) {
+			return "", nil, fmt.Errorf("invalid metadata key: %q", k)
+		}
 		sb.WriteString(` AND json_extract(metadata, '$."`)
 		sb.WriteString(k)
 		sb.WriteString(`"') = ?`)
 		args = append(args, v)
 	}
 
-	return sb.String(), args
+	return sb.String(), args, nil
 }
 
 func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {

--- a/pkg/storage/sqlite/tasks.go
+++ b/pkg/storage/sqlite/tasks.go
@@ -215,7 +215,7 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 	return tasks, total, nil
 }
 
-func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	whereClause, args, err := buildSQLiteMetadataWhere(filter)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
@@ -237,7 +237,7 @@ func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]a
 	return tasks, total, nil
 }
 
-func buildSQLiteMetadataWhere(filter map[string]any) (clause string, args []any, err error) {
+func buildSQLiteMetadataWhere(filter task.Metadata) (clause string, args []any, err error) {
 	if len(filter) == 0 {
 		return "", nil, nil
 	}

--- a/pkg/storage/sqlite/tasks.go
+++ b/pkg/storage/sqlite/tasks.go
@@ -220,6 +220,12 @@ func (r *taskRepo) List(ctx context.Context, filter task.Metadata, offset, limit
 	return tasks, total, nil
 }
 
+// buildSQLiteMetadataWhere builds a WHERE clause for metadata filtering.
+// Keys are interpolated directly into the SQL because sqliteMetadataKeyRe
+// restricts them to [a-zA-Z0-9._\-]+, which contains no SQL metacharacters.
+// Values are always bound as parameters. Metadata filtering performs a full
+// table scan since SQLite does not support expression indexes on json_extract
+// for arbitrary key sets.
 func buildSQLiteMetadataWhere(filter task.Metadata) (clause string, args []any, err error) {
 	if len(filter) == 0 {
 		return "", nil, nil

--- a/pkg/storage/sqlite/tasks.go
+++ b/pkg/storage/sqlite/tasks.go
@@ -237,10 +237,14 @@ func buildSQLiteMetadataWhere(filter task.Metadata) (clause string, args []any, 
 		if !sqliteMetadataKeyRe.MatchString(k) {
 			return "", nil, fmt.Errorf("invalid metadata key: %q", k)
 		}
+		vJSON, err := json.Marshal(v)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid metadata value for key %q: %w", k, err)
+		}
 		sb.WriteString(` AND json_extract(metadata, '$."`)
 		sb.WriteString(k)
-		sb.WriteString(`"') = ?`)
-		args = append(args, v)
+		sb.WriteString(`"') = json(?)`)
+		args = append(args, string(vJSON))
 	}
 
 	return sb.String(), args, nil

--- a/pkg/storage/sqlite/tasks.go
+++ b/pkg/storage/sqlite/tasks.go
@@ -198,24 +198,7 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 	return nil
 }
 
-func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task, uint64, error) {
-	var total uint64
-	err := r.db.GetContext(ctx, &total, "SELECT COUNT(*) FROM tasks")
-	if err != nil {
-		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
-	}
-
-	query := `SELECT ` + taskColumns + ` FROM tasks ORDER BY created_at DESC LIMIT ? OFFSET ?`
-
-	tasks, err := r.scanTasks(ctx, query, limit, offset)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return tasks, total, nil
-}
-
-func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *taskRepo) List(ctx context.Context, filter task.Metadata, offset, limit uint64) ([]task.Task, uint64, error) {
 	whereClause, args, err := buildSQLiteMetadataWhere(filter)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)

--- a/pkg/storage/sqlite/tasks.go
+++ b/pkg/storage/sqlite/tasks.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/absmach/propeller/pkg/task"
@@ -46,15 +47,16 @@ type dbTask struct {
 	Kind              *string      `db:"kind"`
 	Mode              *string      `db:"mode"`
 	Broadcast         bool         `db:"broadcast"`
+	Metadata          []byte       `db:"metadata"`
 }
 
 const taskColumns = `id, name, state, image_url, file, cli_args, inputs, env, daemon, encrypted,
 	kbs_resource_path, proplet_id, results, error, monitoring_profile, start_time, finish_time,
-	created_at, updated_at, workflow_id, job_id, depends_on, run_if, kind, mode, broadcast`
+	created_at, updated_at, workflow_id, job_id, depends_on, run_if, kind, mode, broadcast, metadata`
 
 func (r *taskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
 	query := `INSERT INTO tasks (` + taskColumns + `)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	cliArgs, err := jsonBytes(t.CLIArgs)
 	if err != nil {
@@ -86,6 +88,11 @@ func (r *taskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
 		return task.Task{}, fmt.Errorf("marshal error: %w", err)
 	}
 
+	metadata, err := jsonBytes(t.Metadata)
+	if err != nil {
+		return task.Task{}, fmt.Errorf("marshal error: %w", err)
+	}
+
 	_, err = r.db.ExecContext(ctx, query,
 		t.ID, t.Name, uint8(t.State), nullString(t.ImageURL),
 		t.File, cliArgs, inputs, env,
@@ -98,6 +105,7 @@ func (r *taskRepo) Create(ctx context.Context, t task.Task) (task.Task, error) {
 		dependsOn, nullString(t.RunIf),
 		nullString(string(t.Kind)), nullString(string(t.Mode)),
 		t.Broadcast,
+		metadata,
 	)
 	if err != nil {
 		return task.Task{}, fmt.Errorf("%w: %w", ErrCreate, err)
@@ -128,7 +136,7 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 		env = ?, daemon = ?, encrypted = ?, kbs_resource_path = ?, proplet_id = ?,
 		results = ?, error = ?, monitoring_profile = ?, start_time = ?,
 		finish_time = ?, updated_at = ?, workflow_id = ?, job_id = ?,
-		depends_on = ?, run_if = ?, kind = ?, mode = ?, broadcast = ?
+		depends_on = ?, run_if = ?, kind = ?, mode = ?, broadcast = ?, metadata = ?
 	WHERE id = ?`
 
 	cliArgs, err := jsonBytes(t.CLIArgs)
@@ -161,6 +169,11 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 		return fmt.Errorf("marshal error: %w", err)
 	}
 
+	metadata, err := jsonBytes(t.Metadata)
+	if err != nil {
+		return fmt.Errorf("marshal error: %w", err)
+	}
+
 	_, err = r.db.ExecContext(ctx, query,
 		t.Name, uint8(t.State), nullString(t.ImageURL),
 		t.File, cliArgs, inputs, env,
@@ -172,6 +185,7 @@ func (r *taskRepo) Update(ctx context.Context, t task.Task) error {
 		dependsOn, nullString(t.RunIf),
 		nullString(string(t.Kind)), nullString(string(t.Mode)),
 		t.Broadcast,
+		metadata,
 		t.ID,
 	)
 	if err != nil {
@@ -196,6 +210,42 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 	}
 
 	return tasks, total, nil
+}
+
+func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+	whereClause, args := buildSQLiteMetadataWhere(filter)
+	countArgs := args
+	args = append(args, limit, offset)
+
+	var total uint64
+	if err := r.db.GetContext(ctx, &total, "SELECT COUNT(*) FROM tasks"+whereClause, countArgs...); err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+
+	query := `SELECT ` + taskColumns + ` FROM tasks` + whereClause + ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
+	tasks, err := r.scanTasks(ctx, query, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return tasks, total, nil
+}
+
+func buildSQLiteMetadataWhere(filter map[string]string) (clause string, args []any) {
+	if len(filter) == 0 {
+		return "", nil
+	}
+	var sb strings.Builder
+	sb.WriteString(" WHERE metadata IS NOT NULL")
+	args = make([]any, 0, len(filter))
+	for k, v := range filter {
+		sb.WriteString(` AND json_extract(metadata, '$."`)
+		sb.WriteString(k)
+		sb.WriteString(`"') = ?`)
+		args = append(args, v)
+	}
+
+	return sb.String(), args
 }
 
 func (r *taskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
@@ -237,7 +287,7 @@ func (r *taskRepo) scanTasks(ctx context.Context, query string, args ...any) ([]
 			&dbt.Results, &dbt.Error, &dbt.MonitoringProfile,
 			&dbt.StartTime, &dbt.FinishTime, &dbt.CreatedAt, &dbt.UpdatedAt,
 			&dbt.WorkflowID, &dbt.JobID, &dbt.DependsOn, &dbt.RunIf,
-			&dbt.Kind, &dbt.Mode, &dbt.Broadcast,
+			&dbt.Kind, &dbt.Mode, &dbt.Broadcast, &dbt.Metadata,
 		); err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrDBScan, err)
 		}
@@ -272,20 +322,14 @@ func (r *taskRepo) toTask(dbt dbTask) (task.Task, error) {
 	if dbt.ImageURL != nil {
 		t.ImageURL = *dbt.ImageURL
 	}
-	if dbt.CLIArgs != nil {
-		if err := jsonUnmarshal(dbt.CLIArgs, &t.CLIArgs); err != nil {
-			return task.Task{}, err
-		}
+	if err := jsonUnmarshal(dbt.CLIArgs, &t.CLIArgs); err != nil {
+		return task.Task{}, err
 	}
-	if dbt.Inputs != nil {
-		if err := jsonUnmarshal(dbt.Inputs, &t.Inputs); err != nil {
-			return task.Task{}, err
-		}
+	if err := jsonUnmarshal(dbt.Inputs, &t.Inputs); err != nil {
+		return task.Task{}, err
 	}
-	if dbt.Env != nil {
-		if err := jsonUnmarshal(dbt.Env, &t.Env); err != nil {
-			return task.Task{}, err
-		}
+	if err := jsonUnmarshal(dbt.Env, &t.Env); err != nil {
+		return task.Task{}, err
 	}
 	if dbt.KBSResourcePath != nil {
 		t.KBSResourcePath = *dbt.KBSResourcePath
@@ -293,18 +337,14 @@ func (r *taskRepo) toTask(dbt dbTask) (task.Task, error) {
 	if dbt.PropletID != nil {
 		t.PropletID = *dbt.PropletID
 	}
-	if dbt.Results != nil {
-		if err := jsonUnmarshal(dbt.Results, &t.Results); err != nil {
-			return task.Task{}, err
-		}
+	if err := jsonUnmarshal(dbt.Results, &t.Results); err != nil {
+		return task.Task{}, err
 	}
 	if dbt.Error != nil {
 		t.Error = *dbt.Error
 	}
-	if dbt.MonitoringProfile != nil {
-		if err := jsonUnmarshal(dbt.MonitoringProfile, &t.MonitoringProfile); err != nil {
-			return task.Task{}, err
-		}
+	if err := jsonUnmarshal(dbt.MonitoringProfile, &t.MonitoringProfile); err != nil {
+		return task.Task{}, err
 	}
 	if dbt.StartTime.Valid {
 		t.StartTime = dbt.StartTime.Time
@@ -318,10 +358,8 @@ func (r *taskRepo) toTask(dbt dbTask) (task.Task, error) {
 	if dbt.JobID != nil {
 		t.JobID = *dbt.JobID
 	}
-	if dbt.DependsOn != nil {
-		if err := jsonUnmarshal(dbt.DependsOn, &t.DependsOn); err != nil {
-			return task.Task{}, err
-		}
+	if err := jsonUnmarshal(dbt.DependsOn, &t.DependsOn); err != nil {
+		return task.Task{}, err
 	}
 	if dbt.RunIf != nil {
 		t.RunIf = *dbt.RunIf
@@ -333,6 +371,11 @@ func (r *taskRepo) toTask(dbt dbTask) (task.Task, error) {
 		t.Mode = task.Mode(*dbt.Mode)
 	}
 	t.Broadcast = dbt.Broadcast
+	if dbt.Metadata != nil {
+		if err := jsonUnmarshal(dbt.Metadata, &t.Metadata); err != nil {
+			return task.Task{}, err
+		}
+	}
 
 	return t, nil
 }

--- a/pkg/storage/sqlite/tasks.go
+++ b/pkg/storage/sqlite/tasks.go
@@ -215,7 +215,7 @@ func (r *taskRepo) List(ctx context.Context, offset, limit uint64) ([]task.Task,
 	return tasks, total, nil
 }
 
-func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]string, offset, limit uint64) ([]task.Task, uint64, error) {
+func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]any, offset, limit uint64) ([]task.Task, uint64, error) {
 	whereClause, args, err := buildSQLiteMetadataWhere(filter)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
@@ -237,7 +237,7 @@ func (r *taskRepo) ListByMetadataFilter(ctx context.Context, filter map[string]s
 	return tasks, total, nil
 }
 
-func buildSQLiteMetadataWhere(filter map[string]string) (clause string, args []any, err error) {
+func buildSQLiteMetadataWhere(filter map[string]any) (clause string, args []any, err error) {
 	if len(filter) == 0 {
 		return "", nil, nil
 	}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -154,6 +154,8 @@ func (s JobStatus) State() State {
 	}
 }
 
+type Metadata map[string]any
+
 type Task struct {
 	ID                string                     `json:"id"`
 	Name              string                     `json:"name"`
@@ -186,7 +188,7 @@ type Task struct {
 	Timezone          string                     `json:"timezone,omitempty"`
 	Broadcast         bool                       `json:"broadcast,omitempty"`
 	Priority          int                        `json:"priority,omitempty"`
-	Metadata          map[string]any             `json:"metadata,omitempty"`
+	Metadata          Metadata                   `json:"metadata,omitempty"`
 }
 
 type TaskPage struct {

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -186,6 +186,7 @@ type Task struct {
 	Timezone          string                     `json:"timezone,omitempty"`
 	Broadcast         bool                       `json:"broadcast,omitempty"`
 	Priority          int                        `json:"priority,omitempty"`
+	Metadata          map[string]any             `json:"metadata,omitempty"`
 }
 
 type TaskPage struct {


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

This is a feature that adds an optional `metadata` field to tasks.

## What does this do?

Adds a `metadata map[string]any` field to the `Task` struct. Metadata is persisted as JSON in Postgres, SQLite, and Badger.

Validates metadata on create/update: must be valid JSON and under 64KB.

Adds `ListByMetadataFilter` to the repository interface, letting callers filter tasks by key-value metadata pairs.

Adds `ListTasksByFilter` to the service and exposes it via the existing list-tasks HTTP endpoint using a new `listTasksReq` type.

Simplifies `publishStart` to publish the full task struct instead of a hand-built map.

## Which issue(s) does this PR fix/relate to?

N/A

## Have you included tests for your changes?

Yes, mocks and storage adapters are updated with the new method.

## Did you document any new/modified features?

Documented at https://github.com/absmach/propeller-website/pull/30

### Notes
