### PR TITLE
PROP-57 - Add status filter for proplets and jobs

### DIFF
--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -20,7 +20,7 @@ func listPropletsEndpoint(svc manager.Service) endpoint.Endpoint {
 			return listpropletResponse{}, errors.Join(apiutil.ErrValidation, err)
 		}
 
-		proplets, err := svc.ListProplets(ctx, req.offset, req.limit)
+		proplets, err := svc.ListProplets(ctx, req.offset, req.limit, req.status)
 		if err != nil {
 			return listpropletResponse{}, err
 		}
@@ -188,7 +188,7 @@ func listJobsEndpoint(svc manager.Service) endpoint.Endpoint {
 			return listJobResponse{}, errors.Join(apiutil.ErrValidation, err)
 		}
 
-		jobs, err := svc.ListJobs(ctx, req.offset, req.limit)
+		jobs, err := svc.ListJobs(ctx, req.offset, req.limit, req.status)
 		if err != nil {
 			return listJobResponse{}, err
 		}

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -250,6 +250,9 @@ func listTasksEndpoint(svc manager.Service) endpoint.Endpoint {
 		if err := req.validate(); err != nil {
 			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
 		}
+		if req.status != "" {
+			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, pkgerrors.ErrInvalidData)
+		}
 
 		tasks, err := svc.ListTasks(ctx, req.offset, req.limit)
 		if err != nil {

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -251,7 +251,7 @@ func listTasksEndpoint(svc manager.Service) endpoint.Endpoint {
 			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
 		}
 		if req.status != "" {
-			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, pkgerrors.ErrInvalidData)
+			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, pkgerrors.ErrInvalidValue)
 		}
 
 		tasks, err := svc.ListTasks(ctx, req.offset, req.limit)

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -250,9 +250,6 @@ func listTasksEndpoint(svc manager.Service) endpoint.Endpoint {
 		if err := req.validate(); err != nil {
 			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, err)
 		}
-		if req.status != "" {
-			return listTaskResponse{}, errors.Join(apiutil.ErrValidation, pkgerrors.ErrInvalidValue)
-		}
 
 		tasks, err := svc.ListTasks(ctx, req.offset, req.limit)
 		if err != nil {

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -1,13 +1,17 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 
 	apiutil "github.com/absmach/magistrala/api/http/util"
 	"github.com/absmach/propeller/pkg/cron"
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
+	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/task"
 )
+
+var errStatusFilterUnsupported = errors.New("status filter is not supported")
 
 type taskReq struct {
 	task.Task `json:",inline"`
@@ -97,13 +101,37 @@ func (e *entityReq) validate() error {
 	return nil
 }
 
+type listEntityStatus uint8
+
+const (
+	withoutStatusFilter listEntityStatus = iota
+	propletStatusFilter
+	jobStatusFilter
+)
+
 type listEntityReq struct {
 	offset, limit uint64
 	status        string
+	statusFilter  listEntityStatus
 }
 
-func (e *listEntityReq) validate() error {
-	return nil
+func (e listEntityReq) validate() error {
+	if e.status == "" {
+		return nil
+	}
+
+	switch e.statusFilter {
+	case withoutStatusFilter:
+		return errStatusFilterUnsupported
+	case propletStatusFilter:
+		_, err := proplet.ToStatus(e.status)
+		return err
+	case jobStatusFilter:
+		_, err := task.ToJobStatus(e.status)
+		return err
+	default:
+		return pkgerrors.ErrInvalidValue
+	}
 }
 
 type metricsReq struct {

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -125,9 +125,11 @@ func (e listEntityReq) validate() error {
 		return errStatusFilterUnsupported
 	case propletStatusFilter:
 		_, err := proplet.ToStatus(e.status)
+
 		return err
 	case jobStatusFilter:
 		_, err := task.ToJobStatus(e.status)
+
 		return err
 	default:
 		return pkgerrors.ErrInvalidValue

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -99,6 +99,7 @@ func (e *entityReq) validate() error {
 
 type listEntityReq struct {
 	offset, limit uint64
+	status        string
 }
 
 func (e *listEntityReq) validate() error {

--- a/manager/api/requests_internal_test.go
+++ b/manager/api/requests_internal_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/absmach/propeller/pkg/proplet"
@@ -10,6 +9,8 @@ import (
 )
 
 func TestListEntityReqValidate(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		desc string
 		req  listEntityReq
@@ -65,8 +66,10 @@ func TestListEntityReqValidate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
 			err := tc.req.validate()
-			assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %v got %v", tc.desc, tc.err, err))
+			assert.Equal(t, tc.err, err, "%s: expected %v got %v", tc.desc, tc.err, err)
 		})
 	}
 }

--- a/manager/api/requests_test.go
+++ b/manager/api/requests_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/task"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListEntityReqValidate(t *testing.T) {
+	cases := []struct {
+		desc string
+		req  listEntityReq
+		err  error
+	}{
+		{
+			desc: "empty status is allowed",
+			req: listEntityReq{
+				statusFilter: propletStatusFilter,
+			},
+			err: nil,
+		},
+		{
+			desc: "valid proplet status",
+			req: listEntityReq{
+				status:       proplet.ActiveStatus.String(),
+				statusFilter: propletStatusFilter,
+			},
+			err: nil,
+		},
+		{
+			desc: "valid job status",
+			req: listEntityReq{
+				status:       task.RunningStatus.String(),
+				statusFilter: jobStatusFilter,
+			},
+			err: nil,
+		},
+		{
+			desc: "tasks do not support status filtering",
+			req: listEntityReq{
+				status: task.PendingStatus.String(),
+			},
+			err: errStatusFilterUnsupported,
+		},
+		{
+			desc: "invalid proplet status",
+			req: listEntityReq{
+				status:       "mystery",
+				statusFilter: propletStatusFilter,
+			},
+			err: proplet.ErrInvalidStatus,
+		},
+		{
+			desc: "invalid job status",
+			req: listEntityReq{
+				status:       "mystery",
+				statusFilter: jobStatusFilter,
+			},
+			err: task.ErrInvalidJobStatus,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.req.validate()
+			assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %v got %v", tc.desc, tc.err, err))
+		})
+	}
+}

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -34,7 +34,7 @@ func MakeHandler(svc manager.Service, logger *slog.Logger, instanceID string) ht
 	mux.Route("/proplets", func(r chi.Router) {
 		r.Get("/", otelhttp.NewHandler(kithttp.NewServer(
 			listPropletsEndpoint(svc),
-			decodeListEntityReq,
+			decodeListEntityReq(propletStatusFilter),
 			api.EncodeResponse,
 			opts...,
 		), "list-proplets").ServeHTTP)
@@ -75,7 +75,7 @@ func MakeHandler(svc manager.Service, logger *slog.Logger, instanceID string) ht
 		), "create-task").ServeHTTP)
 		r.Get("/", otelhttp.NewHandler(kithttp.NewServer(
 			listTasksEndpoint(svc),
-			decodeListEntityReq,
+			decodeListEntityReq(withoutStatusFilter),
 			api.EncodeResponse,
 			opts...,
 		), "list-tasks").ServeHTTP)
@@ -211,7 +211,7 @@ func MakeHandler(svc manager.Service, logger *slog.Logger, instanceID string) ht
 		), "create-job").ServeHTTP)
 		r.Get("/", otelhttp.NewHandler(kithttp.NewServer(
 			listJobsEndpoint(svc),
-			decodeListEntityReq,
+			decodeListEntityReq(jobStatusFilter),
 			api.EncodeResponse,
 			opts...,
 		), "list-jobs").ServeHTTP)
@@ -301,22 +301,30 @@ func decodeUpdateTaskReq(_ context.Context, r *http.Request) (any, error) {
 	return req, nil
 }
 
-func decodeListEntityReq(_ context.Context, r *http.Request) (any, error) {
-	o, err := apiutil.ReadNumQuery[uint64](r, api.OffsetKey, api.DefOffset)
-	if err != nil {
-		return nil, errors.Join(apiutil.ErrValidation, err)
-	}
+func decodeListEntityReq(statusFilter listEntityStatus) kithttp.DecodeRequestFunc {
+	return func(_ context.Context, r *http.Request) (any, error) {
+		o, err := apiutil.ReadNumQuery[uint64](r, api.OffsetKey, api.DefOffset)
+		if err != nil {
+			return nil, errors.Join(apiutil.ErrValidation, err)
+		}
 
-	l, err := apiutil.ReadNumQuery[uint64](r, api.LimitKey, api.DefLimit)
-	if err != nil {
-		return nil, errors.Join(apiutil.ErrValidation, err)
-	}
+		l, err := apiutil.ReadNumQuery[uint64](r, api.LimitKey, api.DefLimit)
+		if err != nil {
+			return nil, errors.Join(apiutil.ErrValidation, err)
+		}
 
-	return listEntityReq{
-		offset: o,
-		limit:  l,
-		status: r.URL.Query().Get("status"),
-	}, nil
+		s, err := apiutil.ReadStringQuery(r, "status", "")
+		if err != nil {
+			return nil, errors.Join(apiutil.ErrValidation, err)
+		}
+
+		return listEntityReq{
+			offset:       o,
+			limit:        l,
+			status:       s,
+			statusFilter: statusFilter,
+		}, nil
+	}
 }
 
 func decodeMetricsReq(key string) kithttp.DecodeRequestFunc {

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -315,6 +315,7 @@ func decodeListEntityReq(_ context.Context, r *http.Request) (any, error) {
 	return listEntityReq{
 		offset: o,
 		limit:  l,
+		status: r.URL.Query().Get("status"),
 	}, nil
 }
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -9,7 +9,7 @@ import (
 
 type Service interface {
 	GetProplet(ctx context.Context, propletID string) (proplet.Proplet, error)
-	ListProplets(ctx context.Context, offset, limit uint64) (proplet.PropletPage, error)
+	ListProplets(ctx context.Context, offset, limit uint64, status string) (proplet.PropletPage, error)
 	SelectProplet(ctx context.Context, task task.Task) (proplet.Proplet, error)
 	DeleteProplet(ctx context.Context, propletID string) error
 
@@ -18,7 +18,7 @@ type Service interface {
 	CreateJob(ctx context.Context, name string, tasks []task.Task, executionMode string) (string, []task.Task, error)
 	GetTask(ctx context.Context, taskID string) (task.Task, error)
 	GetJob(ctx context.Context, jobID string) ([]task.Task, error)
-	ListJobs(ctx context.Context, offset, limit uint64) (JobPage, error)
+	ListJobs(ctx context.Context, offset, limit uint64, status string) (JobPage, error)
 	StartJob(ctx context.Context, jobID string) error
 	StopJob(ctx context.Context, jobID string) error
 	ListTasks(ctx context.Context, offset, limit uint64) (task.TaskPage, error)

--- a/manager/middleware/logging.go
+++ b/manager/middleware/logging.go
@@ -42,12 +42,13 @@ func (lm *loggingMiddleware) GetProplet(ctx context.Context, id string) (resp pr
 	return lm.svc.GetProplet(ctx, id)
 }
 
-func (lm *loggingMiddleware) ListProplets(ctx context.Context, offset, limit uint64) (resp proplet.PropletPage, err error) {
+func (lm *loggingMiddleware) ListProplets(ctx context.Context, offset, limit uint64, status string) (resp proplet.PropletPage, err error) {
 	defer func(begin time.Time) {
 		args := []any{
 			slog.String("duration", time.Since(begin).String()),
 			slog.Uint64("offset", offset),
 			slog.Uint64("limit", limit),
+			slog.String("status", status),
 		}
 		if err != nil {
 			args = append(args, slog.Any("error", err))
@@ -58,7 +59,7 @@ func (lm *loggingMiddleware) ListProplets(ctx context.Context, offset, limit uin
 		lm.logger.Info("List proplets completed successfully", args...)
 	}(time.Now())
 
-	return lm.svc.ListProplets(ctx, offset, limit)
+	return lm.svc.ListProplets(ctx, offset, limit, status)
 }
 
 func (lm *loggingMiddleware) SelectProplet(ctx context.Context, t task.Task) (w proplet.Proplet, err error) {
@@ -370,12 +371,13 @@ func (lm *loggingMiddleware) GetJob(ctx context.Context, jobID string) (resp []t
 	return lm.svc.GetJob(ctx, jobID)
 }
 
-func (lm *loggingMiddleware) ListJobs(ctx context.Context, offset, limit uint64) (resp manager.JobPage, err error) {
+func (lm *loggingMiddleware) ListJobs(ctx context.Context, offset, limit uint64, status string) (resp manager.JobPage, err error) {
 	defer func(begin time.Time) {
 		args := []any{
 			slog.String("duration", time.Since(begin).String()),
 			slog.Uint64("offset", offset),
 			slog.Uint64("limit", limit),
+			slog.String("status", status),
 		}
 		if err != nil {
 			args = append(args, slog.Any("error", err))
@@ -387,7 +389,7 @@ func (lm *loggingMiddleware) ListJobs(ctx context.Context, offset, limit uint64)
 		lm.logger.Info("List jobs completed successfully", args...)
 	}(time.Now())
 
-	return lm.svc.ListJobs(ctx, offset, limit)
+	return lm.svc.ListJobs(ctx, offset, limit, status)
 }
 
 func (lm *loggingMiddleware) StartJob(ctx context.Context, jobID string) (err error) {

--- a/manager/middleware/metrics.go
+++ b/manager/middleware/metrics.go
@@ -35,13 +35,13 @@ func (mm *metricsMiddleware) GetProplet(ctx context.Context, id string) (proplet
 	return mm.svc.GetProplet(ctx, id)
 }
 
-func (mm *metricsMiddleware) ListProplets(ctx context.Context, offset, limit uint64) (proplet.PropletPage, error) {
+func (mm *metricsMiddleware) ListProplets(ctx context.Context, offset, limit uint64, status string) (proplet.PropletPage, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "list-proplets").Add(1)
 		mm.latency.With("method", "list-proplets").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.ListProplets(ctx, offset, limit)
+	return mm.svc.ListProplets(ctx, offset, limit, status)
 }
 
 func (mm *metricsMiddleware) SelectProplet(ctx context.Context, t task.Task) (proplet.Proplet, error) {
@@ -179,13 +179,13 @@ func (mm *metricsMiddleware) GetJob(ctx context.Context, jobID string) ([]task.T
 	return mm.svc.GetJob(ctx, jobID)
 }
 
-func (mm *metricsMiddleware) ListJobs(ctx context.Context, offset, limit uint64) (manager.JobPage, error) {
+func (mm *metricsMiddleware) ListJobs(ctx context.Context, offset, limit uint64, status string) (manager.JobPage, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "list-jobs").Add(1)
 		mm.latency.With("method", "list-jobs").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.ListJobs(ctx, offset, limit)
+	return mm.svc.ListJobs(ctx, offset, limit, status)
 }
 
 func (mm *metricsMiddleware) StartJob(ctx context.Context, jobID string) error {

--- a/manager/middleware/tracing.go
+++ b/manager/middleware/tracing.go
@@ -30,14 +30,15 @@ func (tm *tracing) GetProplet(ctx context.Context, id string) (resp proplet.Prop
 	return tm.svc.GetProplet(ctx, id)
 }
 
-func (tm *tracing) ListProplets(ctx context.Context, offset, limit uint64) (resp proplet.PropletPage, err error) {
+func (tm *tracing) ListProplets(ctx context.Context, offset, limit uint64, status string) (resp proplet.PropletPage, err error) {
 	ctx, span := tm.tracer.Start(ctx, "list-proplets", trace.WithAttributes(
 		attribute.Int64("offset", int64(offset)),
 		attribute.Int64("limit", int64(limit)),
+		attribute.String("status", status),
 	))
 	defer span.End()
 
-	return tm.svc.ListProplets(ctx, offset, limit)
+	return tm.svc.ListProplets(ctx, offset, limit, status)
 }
 
 func (tm *tracing) SelectProplet(ctx context.Context, t task.Task) (resp proplet.Proplet, err error) {
@@ -189,14 +190,15 @@ func (tm *tracing) GetJob(ctx context.Context, jobID string) (resp []task.Task, 
 	return tm.svc.GetJob(ctx, jobID)
 }
 
-func (tm *tracing) ListJobs(ctx context.Context, offset, limit uint64) (resp manager.JobPage, err error) {
+func (tm *tracing) ListJobs(ctx context.Context, offset, limit uint64, status string) (resp manager.JobPage, err error) {
 	ctx, span := tm.tracer.Start(ctx, "list-jobs", trace.WithAttributes(
 		attribute.Int64("offset", int64(offset)),
 		attribute.Int64("limit", int64(limit)),
+		attribute.String("status", status),
 	))
 	defer span.End()
 
-	return tm.svc.ListJobs(ctx, offset, limit)
+	return tm.svc.ListJobs(ctx, offset, limit, status)
 }
 
 func (tm *tracing) StartJob(ctx context.Context, jobID string) (err error) {

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -1128,8 +1128,8 @@ func (_c *MockService_GetTaskResults_Call) RunAndReturn(run func(ctx context.Con
 }
 
 // ListJobs provides a mock function for the type MockService
-func (_mock *MockService) ListJobs(ctx context.Context, offset uint64, limit uint64) (manager.JobPage, error) {
-	ret := _mock.Called(ctx, offset, limit)
+func (_mock *MockService) ListJobs(ctx context.Context, offset uint64, limit uint64, status string) (manager.JobPage, error) {
+	ret := _mock.Called(ctx, offset, limit, status)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListJobs")
@@ -1137,16 +1137,16 @@ func (_mock *MockService) ListJobs(ctx context.Context, offset uint64, limit uin
 
 	var r0 manager.JobPage
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64) (manager.JobPage, error)); ok {
-		return returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64, string) (manager.JobPage, error)); ok {
+		return returnFunc(ctx, offset, limit, status)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64) manager.JobPage); ok {
-		r0 = returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64, string) manager.JobPage); ok {
+		r0 = returnFunc(ctx, offset, limit, status)
 	} else {
 		r0 = ret.Get(0).(manager.JobPage)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uint64, uint64) error); ok {
-		r1 = returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint64, uint64, string) error); ok {
+		r1 = returnFunc(ctx, offset, limit, status)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1162,11 +1162,12 @@ type MockService_ListJobs_Call struct {
 //   - ctx context.Context
 //   - offset uint64
 //   - limit uint64
-func (_e *MockService_Expecter) ListJobs(ctx interface{}, offset interface{}, limit interface{}) *MockService_ListJobs_Call {
-	return &MockService_ListJobs_Call{Call: _e.mock.On("ListJobs", ctx, offset, limit)}
+//   - status string
+func (_e *MockService_Expecter) ListJobs(ctx interface{}, offset interface{}, limit interface{}, status interface{}) *MockService_ListJobs_Call {
+	return &MockService_ListJobs_Call{Call: _e.mock.On("ListJobs", ctx, offset, limit, status)}
 }
 
-func (_c *MockService_ListJobs_Call) Run(run func(ctx context.Context, offset uint64, limit uint64)) *MockService_ListJobs_Call {
+func (_c *MockService_ListJobs_Call) Run(run func(ctx context.Context, offset uint64, limit uint64, status string)) *MockService_ListJobs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1180,10 +1181,15 @@ func (_c *MockService_ListJobs_Call) Run(run func(ctx context.Context, offset ui
 		if args[2] != nil {
 			arg2 = args[2].(uint64)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -1194,14 +1200,14 @@ func (_c *MockService_ListJobs_Call) Return(jobPage manager.JobPage, err error) 
 	return _c
 }
 
-func (_c *MockService_ListJobs_Call) RunAndReturn(run func(ctx context.Context, offset uint64, limit uint64) (manager.JobPage, error)) *MockService_ListJobs_Call {
+func (_c *MockService_ListJobs_Call) RunAndReturn(run func(ctx context.Context, offset uint64, limit uint64, status string) (manager.JobPage, error)) *MockService_ListJobs_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListProplets provides a mock function for the type MockService
-func (_mock *MockService) ListProplets(ctx context.Context, offset uint64, limit uint64) (proplet.PropletPage, error) {
-	ret := _mock.Called(ctx, offset, limit)
+func (_mock *MockService) ListProplets(ctx context.Context, offset uint64, limit uint64, status string) (proplet.PropletPage, error) {
+	ret := _mock.Called(ctx, offset, limit, status)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListProplets")
@@ -1209,16 +1215,16 @@ func (_mock *MockService) ListProplets(ctx context.Context, offset uint64, limit
 
 	var r0 proplet.PropletPage
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64) (proplet.PropletPage, error)); ok {
-		return returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64, string) (proplet.PropletPage, error)); ok {
+		return returnFunc(ctx, offset, limit, status)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64) proplet.PropletPage); ok {
-		r0 = returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64, string) proplet.PropletPage); ok {
+		r0 = returnFunc(ctx, offset, limit, status)
 	} else {
 		r0 = ret.Get(0).(proplet.PropletPage)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uint64, uint64) error); ok {
-		r1 = returnFunc(ctx, offset, limit)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint64, uint64, string) error); ok {
+		r1 = returnFunc(ctx, offset, limit, status)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1234,11 +1240,12 @@ type MockService_ListProplets_Call struct {
 //   - ctx context.Context
 //   - offset uint64
 //   - limit uint64
-func (_e *MockService_Expecter) ListProplets(ctx interface{}, offset interface{}, limit interface{}) *MockService_ListProplets_Call {
-	return &MockService_ListProplets_Call{Call: _e.mock.On("ListProplets", ctx, offset, limit)}
+//   - status string
+func (_e *MockService_Expecter) ListProplets(ctx interface{}, offset interface{}, limit interface{}, status interface{}) *MockService_ListProplets_Call {
+	return &MockService_ListProplets_Call{Call: _e.mock.On("ListProplets", ctx, offset, limit, status)}
 }
 
-func (_c *MockService_ListProplets_Call) Run(run func(ctx context.Context, offset uint64, limit uint64)) *MockService_ListProplets_Call {
+func (_c *MockService_ListProplets_Call) Run(run func(ctx context.Context, offset uint64, limit uint64, status string)) *MockService_ListProplets_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1252,10 +1259,15 @@ func (_c *MockService_ListProplets_Call) Run(run func(ctx context.Context, offse
 		if args[2] != nil {
 			arg2 = args[2].(uint64)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -1266,7 +1278,7 @@ func (_c *MockService_ListProplets_Call) Return(propletPage proplet.PropletPage,
 	return _c
 }
 
-func (_c *MockService_ListProplets_Call) RunAndReturn(run func(ctx context.Context, offset uint64, limit uint64) (proplet.PropletPage, error)) *MockService_ListProplets_Call {
+func (_c *MockService_ListProplets_Call) RunAndReturn(run func(ctx context.Context, offset uint64, limit uint64, status string) (proplet.PropletPage, error)) *MockService_ListProplets_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/manager/service.go
+++ b/manager/service.go
@@ -432,10 +432,6 @@ func (svc *service) ListJobs(ctx context.Context, offset, limit uint64, status s
 	})
 
 	if status != "" {
-		// ComputeJobState only ever returns Pending, Running, Completed, or Failed.
-		// Skipped and Interrupted task states are collapsed: Interrupted → Failed,
-		// Scheduled → Running, all-Skipped → Completed. No job summary can carry
-		// any other state, so the map below is exhaustive.
 		statusStateMap := map[string]task.State{
 			JobStatusPending:   task.Pending,
 			JobStatusRunning:   task.Running,

--- a/manager/service.go
+++ b/manager/service.go
@@ -126,7 +126,7 @@ func (svc *service) GetProplet(ctx context.Context, propletID string) (proplet.P
 
 func (svc *service) ListProplets(ctx context.Context, offset, limit uint64, status string) (proplet.PropletPage, error) {
 	if status != "" && status != PropletStatusActive && status != PropletStatusInactive {
-		return proplet.PropletPage{}, fmt.Errorf("invalid proplet status filter %q: must be %q, %q, or empty", status, PropletStatusActive, PropletStatusInactive)
+		return proplet.PropletPage{}, fmt.Errorf("%w: proplet status must be %q, %q, or empty, got %q", pkgerrors.ErrInvalidValue, PropletStatusActive, PropletStatusInactive, status)
 	}
 
 	if status == "" {
@@ -396,7 +396,7 @@ func (svc *service) GetJob(ctx context.Context, jobID string) ([]task.Task, erro
 
 func (svc *service) ListJobs(ctx context.Context, offset, limit uint64, status string) (JobPage, error) {
 	if status != "" && status != JobStatusPending && status != JobStatusRunning && status != JobStatusCompleted && status != JobStatusFailed {
-		return JobPage{}, errors.Join(apiutil.ErrValidation, fmt.Errorf("invalid job status filter %q: must be %q, %q, %q, %q, or empty", status, JobStatusPending, JobStatusRunning, JobStatusCompleted, JobStatusFailed))
+		return JobPage{}, fmt.Errorf("%w: job status must be %q, %q, %q, %q, or empty, got %q", pkgerrors.ErrInvalidValue, JobStatusPending, JobStatusRunning, JobStatusCompleted, JobStatusFailed, status)
 	}
 
 

--- a/manager/service.go
+++ b/manager/service.go
@@ -370,6 +370,9 @@ func (svc *service) GetJob(ctx context.Context, jobID string) ([]task.Task, erro
 	return svc.getJobTasks(ctx, jobID)
 }
 
+// ListJobs is O(total tasks): job state is derived in-memory from the full task
+// set, so a status filter does not reduce storage I/O — every task is fetched
+// and aggregated before the filtered slice is built.
 func (svc *service) ListJobs(ctx context.Context, offset, limit uint64, status string) (JobPage, error) {
 	var jobStatus task.JobStatus
 	if status != "" {

--- a/manager/service.go
+++ b/manager/service.go
@@ -39,6 +39,14 @@ const (
 	ExecutionModeConfigurable = "configurable"
 	EnvJobExecutionMode       = "JOB_EXECUTION_MODE"
 	shutdownTaskStopWait      = 200 * time.Millisecond
+
+	PropletStatusActive   = "active"
+	PropletStatusInactive = "inactive"
+
+	JobStatusPending   = "pending"
+	JobStatusRunning   = "running"
+	JobStatusCompleted = "completed"
+	JobStatusFailed    = "failed"
 )
 
 var (
@@ -116,25 +124,65 @@ func (svc *service) GetProplet(ctx context.Context, propletID string) (proplet.P
 	return w, nil
 }
 
-func (svc *service) ListProplets(ctx context.Context, offset, limit uint64) (proplet.PropletPage, error) {
-	proplets, total, err := svc.propletRepo.List(ctx, offset, limit)
+func (svc *service) ListProplets(ctx context.Context, offset, limit uint64, status string) (proplet.PropletPage, error) {
+	if status != "" && status != PropletStatusActive && status != PropletStatusInactive {
+		return proplet.PropletPage{}, fmt.Errorf("invalid proplet status filter %q: must be %q, %q, or empty", status, PropletStatusActive, PropletStatusInactive)
+	}
+
+	if status == "" {
+		proplets, total, err := svc.propletRepo.List(ctx, offset, limit)
+		if err != nil {
+			return proplet.PropletPage{}, err
+		}
+		for i := range proplets {
+			proplets[i].SetAlive()
+		}
+
+		return proplet.PropletPage{
+			Offset:   offset,
+			Limit:    limit,
+			Total:    total,
+			Proplets: proplets,
+		}, nil
+	}
+
+	all, err := svc.listAllProplets(ctx)
 	if err != nil {
 		return proplet.PropletPage{}, err
 	}
-	for i := range proplets {
-		proplets[i].SetAlive()
+
+	filtered := make([]proplet.Proplet, 0, len(all))
+	for i := range all {
+		all[i].SetAlive()
+		match := (status == PropletStatusActive && all[i].Alive) ||
+			(status == PropletStatusInactive && !all[i].Alive)
+		if match {
+			filtered = append(filtered, all[i])
+		}
 	}
+
+	total := uint64(len(filtered))
+	if offset >= total {
+		return proplet.PropletPage{
+			Offset:   offset,
+			Limit:    limit,
+			Total:    total,
+			Proplets: []proplet.Proplet{},
+		}, nil
+	}
+
+	end := min(offset+limit, total)
 
 	return proplet.PropletPage{
 		Offset:   offset,
 		Limit:    limit,
 		Total:    total,
-		Proplets: proplets,
+		Proplets: filtered[offset:end],
 	}, nil
 }
 
 func (svc *service) SelectProplet(ctx context.Context, t task.Task) (proplet.Proplet, error) {
-	proplets, err := svc.ListProplets(ctx, defOffset, defLimit)
+	proplets, err := svc.ListProplets(ctx, defOffset, defLimit, "")
 	if err != nil {
 		return proplet.Proplet{}, err
 	}
@@ -346,7 +394,12 @@ func (svc *service) GetJob(ctx context.Context, jobID string) ([]task.Task, erro
 	return svc.getJobTasks(ctx, jobID)
 }
 
-func (svc *service) ListJobs(ctx context.Context, offset, limit uint64) (JobPage, error) {
+func (svc *service) ListJobs(ctx context.Context, offset, limit uint64, status string) (JobPage, error) {
+	if status != "" && status != JobStatusPending && status != JobStatusRunning && status != JobStatusCompleted && status != JobStatusFailed {
+		return JobPage{}, errors.Join(apiutil.ErrValidation, fmt.Errorf("invalid job status filter %q: must be %q, %q, %q, %q, or empty", status, JobStatusPending, JobStatusRunning, JobStatusCompleted, JobStatusFailed))
+	}
+
+
 	allTasks, err := svc.listAllTasks(ctx)
 	if err != nil {
 		return JobPage{}, err
@@ -394,6 +447,23 @@ func (svc *service) ListJobs(ctx context.Context, offset, limit uint64) (JobPage
 			return strings.Compare(a.JobID, b.JobID)
 		}
 	})
+
+	if status != "" {
+		statusStateMap := map[string]task.State{
+			JobStatusPending:   task.Pending,
+			JobStatusRunning:   task.Running,
+			JobStatusCompleted: task.Completed,
+			JobStatusFailed:    task.Failed,
+		}
+		targetState := statusStateMap[status]
+		filtered := make([]JobSummary, 0, len(jobs))
+		for i := range jobs {
+			if jobs[i].State == targetState {
+				filtered = append(filtered, jobs[i])
+			}
+		}
+		jobs = filtered
+	}
 
 	total := uint64(len(jobs))
 	if offset >= total {
@@ -1703,6 +1773,26 @@ func (svc *service) listAllTasks(ctx context.Context) ([]task.Task, error) {
 	}
 
 	return allTasks, nil
+}
+
+func (svc *service) listAllProplets(ctx context.Context) ([]proplet.Proplet, error) {
+	const pageSize uint64 = 100
+	var allProplets []proplet.Proplet
+	var offset uint64
+
+	for {
+		proplets, total, err := svc.propletRepo.List(ctx, offset, pageSize)
+		if err != nil {
+			return nil, err
+		}
+		allProplets = append(allProplets, proplets...)
+		offset += uint64(len(proplets))
+		if offset >= total || len(proplets) == 0 {
+			break
+		}
+	}
+
+	return allProplets, nil
 }
 
 func (svc *service) pinTaskToProplet(ctx context.Context, taskID, propletID string) error {

--- a/manager/service.go
+++ b/manager/service.go
@@ -146,38 +146,21 @@ func (svc *service) ListProplets(ctx context.Context, offset, limit uint64, stat
 		}, nil
 	}
 
-	all, err := svc.listAllProplets(ctx)
+	alive := status == PropletStatusActive
+	since := time.Now().Add(-proplet.AliveTimeout)
+	proplets, total, err := svc.propletRepo.ListByAlive(ctx, offset, limit, alive, since)
 	if err != nil {
 		return proplet.PropletPage{}, err
 	}
-
-	filtered := make([]proplet.Proplet, 0, len(all))
-	for i := range all {
-		all[i].SetAlive()
-		match := (status == PropletStatusActive && all[i].Alive) ||
-			(status == PropletStatusInactive && !all[i].Alive)
-		if match {
-			filtered = append(filtered, all[i])
-		}
+	for i := range proplets {
+		proplets[i].SetAlive()
 	}
-
-	total := uint64(len(filtered))
-	if offset >= total {
-		return proplet.PropletPage{
-			Offset:   offset,
-			Limit:    limit,
-			Total:    total,
-			Proplets: []proplet.Proplet{},
-		}, nil
-	}
-
-	end := min(offset+limit, total)
 
 	return proplet.PropletPage{
 		Offset:   offset,
 		Limit:    limit,
 		Total:    total,
-		Proplets: filtered[offset:end],
+		Proplets: proplets,
 	}, nil
 }
 
@@ -1779,29 +1762,6 @@ func (svc *service) listAllTasks(ctx context.Context) ([]task.Task, error) {
 	return allTasks, nil
 }
 
-// listAllProplets fetches every proplet from storage into memory so callers can
-// apply in-process filters (e.g. liveness status). This is O(n) in proplet count.
-// If proplet counts grow large, consider adding a storage-level ListByStatus query
-// to push the filter down to the repository layer instead.
-func (svc *service) listAllProplets(ctx context.Context) ([]proplet.Proplet, error) {
-	const pageSize uint64 = 100
-	var allProplets []proplet.Proplet
-	var offset uint64
-
-	for {
-		proplets, total, err := svc.propletRepo.List(ctx, offset, pageSize)
-		if err != nil {
-			return nil, err
-		}
-		allProplets = append(allProplets, proplets...)
-		offset += uint64(len(proplets))
-		if offset >= total || len(proplets) == 0 {
-			break
-		}
-	}
-
-	return allProplets, nil
-}
 
 func (svc *service) pinTaskToProplet(ctx context.Context, taskID, propletID string) error {
 	return svc.taskPropletRepo.Create(ctx, taskID, propletID)

--- a/manager/service.go
+++ b/manager/service.go
@@ -449,6 +449,10 @@ func (svc *service) ListJobs(ctx context.Context, offset, limit uint64, status s
 	})
 
 	if status != "" {
+		// ComputeJobState only ever returns Pending, Running, Completed, or Failed.
+		// Skipped and Interrupted task states are collapsed: Interrupted → Failed,
+		// Scheduled → Running, all-Skipped → Completed. No job summary can carry
+		// any other state, so the map below is exhaustive.
 		statusStateMap := map[string]task.State{
 			JobStatusPending:   task.Pending,
 			JobStatusRunning:   task.Running,
@@ -1775,6 +1779,10 @@ func (svc *service) listAllTasks(ctx context.Context) ([]task.Task, error) {
 	return allTasks, nil
 }
 
+// listAllProplets fetches every proplet from storage into memory so callers can
+// apply in-process filters (e.g. liveness status). This is O(n) in proplet count.
+// If proplet counts grow large, consider adding a storage-level ListByStatus query
+// to push the filter down to the repository layer instead.
 func (svc *service) listAllProplets(ctx context.Context) ([]proplet.Proplet, error) {
 	const pageSize uint64 = 100
 	var allProplets []proplet.Proplet

--- a/manager/service.go
+++ b/manager/service.go
@@ -1762,7 +1762,6 @@ func (svc *service) listAllTasks(ctx context.Context) ([]task.Task, error) {
 	return allTasks, nil
 }
 
-
 func (svc *service) pinTaskToProplet(ctx context.Context, taskID, propletID string) error {
 	return svc.taskPropletRepo.Create(ctx, taskID, propletID)
 }

--- a/manager/service.go
+++ b/manager/service.go
@@ -39,14 +39,6 @@ const (
 	ExecutionModeConfigurable = "configurable"
 	EnvJobExecutionMode       = "JOB_EXECUTION_MODE"
 	shutdownTaskStopWait      = 200 * time.Millisecond
-
-	PropletStatusActive   = "active"
-	PropletStatusInactive = "inactive"
-
-	JobStatusPending   = "pending"
-	JobStatusRunning   = "running"
-	JobStatusCompleted = "completed"
-	JobStatusFailed    = "failed"
 )
 
 var (
@@ -125,10 +117,6 @@ func (svc *service) GetProplet(ctx context.Context, propletID string) (proplet.P
 }
 
 func (svc *service) ListProplets(ctx context.Context, offset, limit uint64, status string) (proplet.PropletPage, error) {
-	if status != "" && status != PropletStatusActive && status != PropletStatusInactive {
-		return proplet.PropletPage{}, fmt.Errorf("%w: proplet status must be %q, %q, or empty, got %q", pkgerrors.ErrInvalidValue, PropletStatusActive, PropletStatusInactive, status)
-	}
-
 	if status == "" {
 		proplets, total, err := svc.propletRepo.List(ctx, offset, limit)
 		if err != nil {
@@ -146,7 +134,12 @@ func (svc *service) ListProplets(ctx context.Context, offset, limit uint64, stat
 		}, nil
 	}
 
-	alive := status == PropletStatusActive
+	st, err := proplet.ToStatus(status)
+	if err != nil {
+		return proplet.PropletPage{}, fmt.Errorf("%w: %w", pkgerrors.ErrInvalidValue, err)
+	}
+
+	alive := st == proplet.ActiveStatus
 	since := time.Now().Add(-proplet.AliveTimeout)
 	proplets, total, err := svc.propletRepo.ListByAlive(ctx, offset, limit, alive, since)
 	if err != nil {
@@ -378,11 +371,17 @@ func (svc *service) GetJob(ctx context.Context, jobID string) ([]task.Task, erro
 }
 
 func (svc *service) ListJobs(ctx context.Context, offset, limit uint64, status string) (JobPage, error) {
-	if status != "" && status != JobStatusPending && status != JobStatusRunning && status != JobStatusCompleted && status != JobStatusFailed {
-		return JobPage{}, fmt.Errorf("%w: job status must be %q, %q, %q, %q, or empty, got %q", pkgerrors.ErrInvalidValue, JobStatusPending, JobStatusRunning, JobStatusCompleted, JobStatusFailed, status)
+	var jobStatus task.JobStatus
+	if status != "" {
+		var err error
+		jobStatus, err = task.ToJobStatus(status)
+		if err != nil {
+			return JobPage{}, fmt.Errorf("%w: %w", pkgerrors.ErrInvalidValue, err)
+		}
 	}
 
-
+	// Job state is derived from the current task set rather than stored independently,
+	// so filtering has to happen after we aggregate tasks into job summaries in memory.
 	allTasks, err := svc.listAllTasks(ctx)
 	if err != nil {
 		return JobPage{}, err
@@ -432,13 +431,7 @@ func (svc *service) ListJobs(ctx context.Context, offset, limit uint64, status s
 	})
 
 	if status != "" {
-		statusStateMap := map[string]task.State{
-			JobStatusPending:   task.Pending,
-			JobStatusRunning:   task.Running,
-			JobStatusCompleted: task.Completed,
-			JobStatusFailed:    task.Failed,
-		}
-		targetState := statusStateMap[status]
+		targetState := jobStatus.State()
 		filtered := make([]JobSummary, 0, len(jobs))
 		for i := range jobs {
 			if jobs[i].State == targetState {

--- a/manager/service_job_test.go
+++ b/manager/service_job_test.go
@@ -329,8 +329,8 @@ func TestListJobsFilterByStatus(t *testing.T) {
 			page, err := svc.ListJobs(ctx, 0, 100, tc.status)
 			if tc.err {
 				require.Error(t, err)
-				assert.ErrorIs(t, err, pkgerrors.ErrInvalidValue)
-				assert.ErrorIs(t, err, task.ErrInvalidJobStatus)
+				require.ErrorIs(t, err, pkgerrors.ErrInvalidValue)
+				require.ErrorIs(t, err, task.ErrInvalidJobStatus)
 
 				return
 			}

--- a/manager/service_job_test.go
+++ b/manager/service_job_test.go
@@ -66,7 +66,7 @@ func TestListJobs(t *testing.T) {
 	}, "sequential")
 	require.NoError(t, err)
 
-	page, err := svc.ListJobs(context.Background(), 0, 100)
+	page, err := svc.ListJobs(context.Background(), 0, 100, "")
 	require.NoError(t, err)
 	assert.Equal(t, uint64(2), page.Total)
 	assert.Len(t, page.Jobs, 2)
@@ -88,7 +88,7 @@ func TestListJobsIncludesLegacyTaskOnlyJob(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	page, err := svc.ListJobs(context.Background(), 0, 100)
+	page, err := svc.ListJobs(context.Background(), 0, 100, "")
 	require.NoError(t, err)
 	assert.Equal(t, uint64(2), page.Total)
 
@@ -198,12 +198,12 @@ func TestListJobsPagination(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	page, err := svc.ListJobs(context.Background(), 0, 3)
+	page, err := svc.ListJobs(context.Background(), 0, 3, "")
 	require.NoError(t, err)
 	assert.Equal(t, uint64(5), page.Total)
 	assert.Len(t, page.Jobs, 3)
 
-	page2, err := svc.ListJobs(context.Background(), 3, 3)
+	page2, err := svc.ListJobs(context.Background(), 3, 3, "")
 	require.NoError(t, err)
 	assert.Len(t, page2.Jobs, 2)
 }
@@ -264,4 +264,72 @@ func TestComputeJobState(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestListJobsFilterByStatus(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+
+	// Create jobs whose tasks have different states.
+	// Job1 — tasks stay Pending → job state = Pending
+	_, _, err := svc.CreateJob(context.Background(), "pending-job", []task.Task{
+		{Name: "p1", State: task.Pending},
+	}, "parallel")
+	require.NoError(t, err)
+
+	// Job2 — tasks are Running → job state = Running
+	_, _, err = svc.CreateJob(context.Background(), "running-job", []task.Task{
+		{Name: "r1", State: task.Running},
+	}, "parallel")
+	require.NoError(t, err)
+
+	// Job3 — tasks are Completed → job state = Completed
+	_, _, err = svc.CreateJob(context.Background(), "completed-job", []task.Task{
+		{Name: "c1", State: task.Completed},
+	}, "parallel")
+	require.NoError(t, err)
+
+	// Job4 — tasks are Failed → job state = Failed
+	_, _, err = svc.CreateJob(context.Background(), "failed-job", []task.Task{
+		{Name: "f1", State: task.Failed},
+	}, "parallel")
+	require.NoError(t, err)
+
+	// No filter — all 4 jobs
+	all, err := svc.ListJobs(context.Background(), 0, 100, "")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(4), all.Total)
+
+	// Filter by pending
+	page, err := svc.ListJobs(context.Background(), 0, 100, "pending")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), page.Total)
+	assert.Equal(t, task.Pending, page.Jobs[0].State)
+
+	// Filter by running
+	page, err = svc.ListJobs(context.Background(), 0, 100, "running")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), page.Total)
+	assert.Equal(t, task.Running, page.Jobs[0].State)
+
+	// Filter by completed
+	page, err = svc.ListJobs(context.Background(), 0, 100, "completed")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), page.Total)
+	assert.Equal(t, task.Completed, page.Jobs[0].State)
+
+	// Filter by failed
+	page, err = svc.ListJobs(context.Background(), 0, 100, "failed")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), page.Total)
+	assert.Equal(t, task.Failed, page.Jobs[0].State)
+}
+
+func TestListJobsInvalidStatusFilter(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+
+	_, err := svc.ListJobs(context.Background(), 0, 100, "invalid")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid job status filter")
 }

--- a/manager/service_job_test.go
+++ b/manager/service_job_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/absmach/propeller/manager"
+	pkgerrors "github.com/absmach/propeller/pkg/errors"
 	"github.com/absmach/propeller/pkg/task"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -283,25 +284,25 @@ func TestListJobsFilterByStatus(t *testing.T) {
 		},
 		{
 			desc:          "filter by pending",
-			status:        manager.JobStatusPending,
+			status:        task.PendingStatus.String(),
 			expectedTotal: 1,
 			expectedState: task.Pending,
 		},
 		{
 			desc:          "filter by running",
-			status:        manager.JobStatusRunning,
+			status:        task.RunningStatus.String(),
 			expectedTotal: 1,
 			expectedState: task.Running,
 		},
 		{
 			desc:          "filter by completed",
-			status:        manager.JobStatusCompleted,
+			status:        task.CompletedStatus.String(),
 			expectedTotal: 1,
 			expectedState: task.Completed,
 		},
 		{
 			desc:          "filter by failed",
-			status:        manager.JobStatusFailed,
+			status:        task.FailedStatus.String(),
 			expectedTotal: 1,
 			expectedState: task.Failed,
 		},
@@ -328,7 +329,8 @@ func TestListJobsFilterByStatus(t *testing.T) {
 			page, err := svc.ListJobs(ctx, 0, 100, tc.status)
 			if tc.err {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "invalid value provided")
+				assert.ErrorIs(t, err, pkgerrors.ErrInvalidValue)
+				assert.ErrorIs(t, err, task.ErrInvalidJobStatus)
 
 				return
 			}
@@ -353,13 +355,13 @@ func TestListJobsStateMapping(t *testing.T) {
 		{
 			desc:          "interrupted task maps to failed",
 			taskState:     task.Interrupted,
-			filterStatus:  manager.JobStatusFailed,
+			filterStatus:  task.FailedStatus.String(),
 			expectedTotal: 1,
 		},
 		{
 			desc:          "scheduled task maps to running",
 			taskState:     task.Scheduled,
-			filterStatus:  manager.JobStatusRunning,
+			filterStatus:  task.RunningStatus.String(),
 			expectedTotal: 1,
 		},
 	}

--- a/manager/service_job_test.go
+++ b/manager/service_job_test.go
@@ -269,56 +269,45 @@ func TestComputeJobState(t *testing.T) {
 func TestListJobsFilterByStatus(t *testing.T) {
 	t.Parallel()
 	svc := newService(t)
-
-	// Create jobs whose tasks have different states.
-	// Job1 — tasks stay Pending → job state = Pending
 	_, _, err := svc.CreateJob(context.Background(), "pending-job", []task.Task{
 		{Name: "p1", State: task.Pending},
 	}, "parallel")
 	require.NoError(t, err)
 
-	// Job2 — tasks are Running → job state = Running
 	_, _, err = svc.CreateJob(context.Background(), "running-job", []task.Task{
 		{Name: "r1", State: task.Running},
 	}, "parallel")
 	require.NoError(t, err)
 
-	// Job3 — tasks are Completed → job state = Completed
 	_, _, err = svc.CreateJob(context.Background(), "completed-job", []task.Task{
 		{Name: "c1", State: task.Completed},
 	}, "parallel")
 	require.NoError(t, err)
 
-	// Job4 — tasks are Failed → job state = Failed
 	_, _, err = svc.CreateJob(context.Background(), "failed-job", []task.Task{
 		{Name: "f1", State: task.Failed},
 	}, "parallel")
 	require.NoError(t, err)
 
-	// No filter — all 4 jobs
 	all, err := svc.ListJobs(context.Background(), 0, 100, "")
 	require.NoError(t, err)
 	assert.Equal(t, uint64(4), all.Total)
 
-	// Filter by pending
 	page, err := svc.ListJobs(context.Background(), 0, 100, "pending")
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), page.Total)
 	assert.Equal(t, task.Pending, page.Jobs[0].State)
 
-	// Filter by running
 	page, err = svc.ListJobs(context.Background(), 0, 100, "running")
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), page.Total)
 	assert.Equal(t, task.Running, page.Jobs[0].State)
 
-	// Filter by completed
 	page, err = svc.ListJobs(context.Background(), 0, 100, "completed")
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), page.Total)
 	assert.Equal(t, task.Completed, page.Jobs[0].State)
 
-	// Filter by failed
 	page, err = svc.ListJobs(context.Background(), 0, 100, "failed")
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), page.Total)

--- a/manager/service_job_test.go
+++ b/manager/service_job_test.go
@@ -320,5 +320,5 @@ func TestListJobsInvalidStatusFilter(t *testing.T) {
 
 	_, err := svc.ListJobs(context.Background(), 0, 100, "invalid")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid job status filter")
+	assert.Contains(t, err.Error(), "invalid value provided")
 }

--- a/manager/service_job_test.go
+++ b/manager/service_job_test.go
@@ -268,57 +268,114 @@ func TestComputeJobState(t *testing.T) {
 
 func TestListJobsFilterByStatus(t *testing.T) {
 	t.Parallel()
-	svc := newService(t)
-	_, _, err := svc.CreateJob(context.Background(), "pending-job", []task.Task{
-		{Name: "p1", State: task.Pending},
-	}, "parallel")
-	require.NoError(t, err)
 
-	_, _, err = svc.CreateJob(context.Background(), "running-job", []task.Task{
-		{Name: "r1", State: task.Running},
-	}, "parallel")
-	require.NoError(t, err)
+	cases := []struct {
+		desc          string
+		status        string
+		expectedTotal uint64
+		expectedState task.State
+		err           bool
+	}{
+		{
+			desc:          "list all jobs without filter",
+			status:        "",
+			expectedTotal: 4,
+		},
+		{
+			desc:          "filter by pending",
+			status:        manager.JobStatusPending,
+			expectedTotal: 1,
+			expectedState: task.Pending,
+		},
+		{
+			desc:          "filter by running",
+			status:        manager.JobStatusRunning,
+			expectedTotal: 1,
+			expectedState: task.Running,
+		},
+		{
+			desc:          "filter by completed",
+			status:        manager.JobStatusCompleted,
+			expectedTotal: 1,
+			expectedState: task.Completed,
+		},
+		{
+			desc:          "filter by failed",
+			status:        manager.JobStatusFailed,
+			expectedTotal: 1,
+			expectedState: task.Failed,
+		},
+		{
+			desc:   "invalid status returns error",
+			status: "invalid",
+			err:    true,
+		},
+	}
 
-	_, _, err = svc.CreateJob(context.Background(), "completed-job", []task.Task{
-		{Name: "c1", State: task.Completed},
-	}, "parallel")
-	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			svc := newService(t)
+			ctx := context.Background()
 
-	_, _, err = svc.CreateJob(context.Background(), "failed-job", []task.Task{
-		{Name: "f1", State: task.Failed},
-	}, "parallel")
-	require.NoError(t, err)
+			if !tc.err {
+				for _, s := range []task.State{task.Pending, task.Running, task.Completed, task.Failed} {
+					_, _, err := svc.CreateJob(ctx, "job", []task.Task{{Name: "t", State: s}}, "parallel")
+					require.NoError(t, err)
+				}
+			}
 
-	all, err := svc.ListJobs(context.Background(), 0, 100, "")
-	require.NoError(t, err)
-	assert.Equal(t, uint64(4), all.Total)
+			page, err := svc.ListJobs(ctx, 0, 100, tc.status)
+			if tc.err {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid value provided")
 
-	page, err := svc.ListJobs(context.Background(), 0, 100, "pending")
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1), page.Total)
-	assert.Equal(t, task.Pending, page.Jobs[0].State)
-
-	page, err = svc.ListJobs(context.Background(), 0, 100, "running")
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1), page.Total)
-	assert.Equal(t, task.Running, page.Jobs[0].State)
-
-	page, err = svc.ListJobs(context.Background(), 0, 100, "completed")
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1), page.Total)
-	assert.Equal(t, task.Completed, page.Jobs[0].State)
-
-	page, err = svc.ListJobs(context.Background(), 0, 100, "failed")
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1), page.Total)
-	assert.Equal(t, task.Failed, page.Jobs[0].State)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedTotal, page.Total)
+			if tc.status != "" && len(page.Jobs) > 0 {
+				assert.Equal(t, tc.expectedState, page.Jobs[0].State)
+			}
+		})
+	}
 }
 
-func TestListJobsInvalidStatusFilter(t *testing.T) {
+func TestListJobsStateMapping(t *testing.T) {
 	t.Parallel()
-	svc := newService(t)
 
-	_, err := svc.ListJobs(context.Background(), 0, 100, "invalid")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid value provided")
+	cases := []struct {
+		desc          string
+		taskState     task.State
+		filterStatus  string
+		expectedTotal uint64
+	}{
+		{
+			desc:          "interrupted task maps to failed",
+			taskState:     task.Interrupted,
+			filterStatus:  manager.JobStatusFailed,
+			expectedTotal: 1,
+		},
+		{
+			desc:          "scheduled task maps to running",
+			taskState:     task.Scheduled,
+			filterStatus:  manager.JobStatusRunning,
+			expectedTotal: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			svc := newService(t)
+			ctx := context.Background()
+
+			_, _, err := svc.CreateJob(ctx, "job", []task.Task{{Name: "t", State: tc.taskState}}, "parallel")
+			require.NoError(t, err)
+
+			page, err := svc.ListJobs(ctx, 0, 100, tc.filterStatus)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedTotal, page.Total)
+		})
+	}
 }

--- a/manager/service_proplet_test.go
+++ b/manager/service_proplet_test.go
@@ -95,8 +95,8 @@ func TestListPropletsFilterByStatus(t *testing.T) {
 			page, err := svc.ListProplets(ctx, 0, 100, tc.status)
 			if tc.err {
 				require.Error(t, err)
-				assert.ErrorIs(t, err, pkgerrors.ErrInvalidValue)
-				assert.ErrorIs(t, err, proplet.ErrInvalidStatus)
+				require.ErrorIs(t, err, pkgerrors.ErrInvalidValue)
+				require.ErrorIs(t, err, proplet.ErrInvalidStatus)
 
 				return
 			}

--- a/manager/service_proplet_test.go
+++ b/manager/service_proplet_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/scheduler"
 	"github.com/absmach/propeller/pkg/storage"
-	"github.com/absmach/propeller/pkg/task"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -36,97 +35,122 @@ func newServiceWithRepos(t *testing.T) (manager.Service, *storage.Repositories) 
 
 func TestListPropletsFilterByStatus(t *testing.T) {
 	t.Parallel()
-	svc, repos := newServiceWithRepos(t)
-	ctx := context.Background()
 
-	activeProplet := proplet.Proplet{
-		ID:           uuid.NewString(),
-		Name:         "active-proplet",
-		AliveHistory: []time.Time{time.Now()},
+	cases := []struct {
+		desc          string
+		status        string
+		expectedTotal uint64
+		expectedAlive *bool
+		err           bool
+	}{
+		{
+			desc:          "list all proplets without filter",
+			status:        "",
+			expectedTotal: 2,
+		},
+		{
+			desc:          "list active proplets",
+			status:        manager.PropletStatusActive,
+			expectedTotal: 1,
+			expectedAlive: boolPtr(true),
+		},
+		{
+			desc:          "list inactive proplets",
+			status:        manager.PropletStatusInactive,
+			expectedTotal: 1,
+			expectedAlive: boolPtr(false),
+		},
+		{
+			desc:   "invalid status returns error",
+			status: "unknown",
+			err:    true,
+		},
 	}
-	inactiveProplet := proplet.Proplet{
-		ID:           uuid.NewString(),
-		Name:         "inactive-proplet",
-		AliveHistory: []time.Time{time.Now().Add(-1 * time.Hour)},
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			svc, repos := newServiceWithRepos(t)
+			ctx := context.Background()
+
+			if !tc.err {
+				activeProplet := proplet.Proplet{
+					ID:           uuid.NewString(),
+					Name:         "active-proplet",
+					AliveHistory: []time.Time{time.Now()},
+				}
+				inactiveProplet := proplet.Proplet{
+					ID:           uuid.NewString(),
+					Name:         "inactive-proplet",
+					AliveHistory: []time.Time{time.Now().Add(-1 * time.Hour)},
+				}
+				require.NoError(t, repos.Proplets.Create(ctx, activeProplet))
+				require.NoError(t, repos.Proplets.Create(ctx, inactiveProplet))
+			}
+
+			page, err := svc.ListProplets(ctx, 0, 100, tc.status)
+			if tc.err {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid value provided")
+
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedTotal, page.Total)
+			if tc.expectedAlive != nil && len(page.Proplets) > 0 {
+				assert.Equal(t, *tc.expectedAlive, page.Proplets[0].Alive)
+			}
+		})
 	}
-	require.NoError(t, repos.Proplets.Create(ctx, activeProplet))
-	require.NoError(t, repos.Proplets.Create(ctx, inactiveProplet))
-
-	all, err := svc.ListProplets(ctx, 0, 100, "")
-	require.NoError(t, err)
-	assert.Equal(t, uint64(2), all.Total)
-
-	active, err := svc.ListProplets(ctx, 0, 100, manager.PropletStatusActive)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1), active.Total)
-	assert.True(t, active.Proplets[0].Alive)
-
-	inactive, err := svc.ListProplets(ctx, 0, 100, manager.PropletStatusInactive)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1), inactive.Total)
-	assert.False(t, inactive.Proplets[0].Alive)
-}
-
-func TestListPropletsInvalidStatus(t *testing.T) {
-	t.Parallel()
-	svc, _ := newServiceWithRepos(t)
-
-	_, err := svc.ListProplets(context.Background(), 0, 100, "unknown")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid value")
 }
 
 func TestListPropletsFilterPagination(t *testing.T) {
 	t.Parallel()
-	svc, repos := newServiceWithRepos(t)
-	ctx := context.Background()
 
-	for range 5 {
-		p := proplet.Proplet{
-			ID:           uuid.NewString(),
-			Name:         uuid.NewString(),
-			AliveHistory: []time.Time{time.Now()},
-		}
-		require.NoError(t, repos.Proplets.Create(ctx, p))
+	cases := []struct {
+		desc          string
+		offset        uint64
+		limit         uint64
+		expectedTotal uint64
+		expectedLen   int
+	}{
+		{
+			desc:          "first page",
+			offset:        0,
+			limit:         3,
+			expectedTotal: 5,
+			expectedLen:   3,
+		},
+		{
+			desc:          "second page",
+			offset:        3,
+			limit:         3,
+			expectedTotal: 5,
+			expectedLen:   2,
+		},
 	}
 
-	page, err := svc.ListProplets(ctx, 0, 3, manager.PropletStatusActive)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(5), page.Total)
-	assert.Len(t, page.Proplets, 3)
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			svc, repos := newServiceWithRepos(t)
+			ctx := context.Background()
 
-	page2, err := svc.ListProplets(ctx, 3, 3, manager.PropletStatusActive)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(5), page2.Total)
-	assert.Len(t, page2.Proplets, 2)
+			for range 5 {
+				p := proplet.Proplet{
+					ID:           uuid.NewString(),
+					Name:         uuid.NewString(),
+					AliveHistory: []time.Time{time.Now()},
+				}
+				require.NoError(t, repos.Proplets.Create(ctx, p))
+			}
+
+			page, err := svc.ListProplets(ctx, tc.offset, tc.limit, manager.PropletStatusActive)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedTotal, page.Total)
+			assert.Len(t, page.Proplets, tc.expectedLen)
+		})
+	}
 }
 
-func TestListJobsInterruptedMapsToFailed(t *testing.T) {
-	t.Parallel()
-	svc := newService(t)
-	ctx := context.Background()
-
-	_, _, err := svc.CreateJob(ctx, "interrupted-job", []task.Task{
-		{Name: "t1", State: task.Interrupted},
-	}, "parallel")
-	require.NoError(t, err)
-
-	page, err := svc.ListJobs(ctx, 0, 100, manager.JobStatusFailed)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1), page.Total, "interrupted job must appear under 'failed' filter")
-}
-
-func TestListJobsScheduledMapsToRunning(t *testing.T) {
-	t.Parallel()
-	svc := newService(t)
-	ctx := context.Background()
-
-	_, _, err := svc.CreateJob(ctx, "scheduled-job", []task.Task{
-		{Name: "t1", State: task.Scheduled},
-	}, "parallel")
-	require.NoError(t, err)
-
-	page, err := svc.ListJobs(ctx, 0, 100, manager.JobStatusRunning)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1), page.Total, "scheduled job must appear under 'running' filter")
-}
+func boolPtr(b bool) *bool { return &b }

--- a/manager/service_proplet_test.go
+++ b/manager/service_proplet_test.go
@@ -1,0 +1,132 @@
+package manager_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/absmach/propeller/manager"
+	mqttmocks "github.com/absmach/propeller/pkg/mqtt/mocks"
+	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/scheduler"
+	"github.com/absmach/propeller/pkg/storage"
+	"github.com/absmach/propeller/pkg/task"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newServiceWithRepos(t *testing.T) (manager.Service, *storage.Repositories) {
+	t.Helper()
+	repos, err := storage.NewRepositories(storage.Config{Type: "memory"})
+	require.NoError(t, err)
+	sched := scheduler.NewRoundRobin()
+	pubsub := mqttmocks.NewMockPubSub(t)
+	pubsub.On("Publish", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	pubsub.On("Subscribe", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	pubsub.On("Unsubscribe", mock.Anything, mock.Anything).Return(nil).Maybe()
+	pubsub.On("Disconnect", mock.Anything).Return(nil).Maybe()
+	logger := slog.Default()
+	svc, _ := manager.NewService(repos, sched, pubsub, "test-domain", "test-channel", logger)
+
+	return svc, repos
+}
+
+func TestListPropletsFilterByStatus(t *testing.T) {
+	t.Parallel()
+	svc, repos := newServiceWithRepos(t)
+	ctx := context.Background()
+
+	activeProplet := proplet.Proplet{
+		ID:           uuid.NewString(),
+		Name:         "active-proplet",
+		AliveHistory: []time.Time{time.Now()},
+	}
+	inactiveProplet := proplet.Proplet{
+		ID:           uuid.NewString(),
+		Name:         "inactive-proplet",
+		AliveHistory: []time.Time{time.Now().Add(-1 * time.Hour)},
+	}
+	require.NoError(t, repos.Proplets.Create(ctx, activeProplet))
+	require.NoError(t, repos.Proplets.Create(ctx, inactiveProplet))
+
+	all, err := svc.ListProplets(ctx, 0, 100, "")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), all.Total)
+
+	active, err := svc.ListProplets(ctx, 0, 100, manager.PropletStatusActive)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), active.Total)
+	assert.True(t, active.Proplets[0].Alive)
+
+	inactive, err := svc.ListProplets(ctx, 0, 100, manager.PropletStatusInactive)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), inactive.Total)
+	assert.False(t, inactive.Proplets[0].Alive)
+}
+
+func TestListPropletsInvalidStatus(t *testing.T) {
+	t.Parallel()
+	svc, _ := newServiceWithRepos(t)
+
+	_, err := svc.ListProplets(context.Background(), 0, 100, "unknown")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid value")
+}
+
+func TestListPropletsFilterPagination(t *testing.T) {
+	t.Parallel()
+	svc, repos := newServiceWithRepos(t)
+	ctx := context.Background()
+
+	for range 5 {
+		p := proplet.Proplet{
+			ID:           uuid.NewString(),
+			Name:         uuid.NewString(),
+			AliveHistory: []time.Time{time.Now()},
+		}
+		require.NoError(t, repos.Proplets.Create(ctx, p))
+	}
+
+	page, err := svc.ListProplets(ctx, 0, 3, manager.PropletStatusActive)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), page.Total)
+	assert.Len(t, page.Proplets, 3)
+
+	page2, err := svc.ListProplets(ctx, 3, 3, manager.PropletStatusActive)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), page2.Total)
+	assert.Len(t, page2.Proplets, 2)
+}
+
+func TestListJobsInterruptedMapsToFailed(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+	ctx := context.Background()
+
+	_, _, err := svc.CreateJob(ctx, "interrupted-job", []task.Task{
+		{Name: "t1", State: task.Interrupted},
+	}, "parallel")
+	require.NoError(t, err)
+
+	page, err := svc.ListJobs(ctx, 0, 100, manager.JobStatusFailed)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), page.Total, "interrupted job must appear under 'failed' filter")
+}
+
+func TestListJobsScheduledMapsToRunning(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+	ctx := context.Background()
+
+	_, _, err := svc.CreateJob(ctx, "scheduled-job", []task.Task{
+		{Name: "t1", State: task.Scheduled},
+	}, "parallel")
+	require.NoError(t, err)
+
+	page, err := svc.ListJobs(ctx, 0, 100, manager.JobStatusRunning)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), page.Total, "scheduled job must appear under 'running' filter")
+}

--- a/manager/service_proplet_test.go
+++ b/manager/service_proplet_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/absmach/propeller/manager"
+	pkgerrors "github.com/absmach/propeller/pkg/errors"
 	mqttmocks "github.com/absmach/propeller/pkg/mqtt/mocks"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/scheduler"
@@ -40,7 +41,8 @@ func TestListPropletsFilterByStatus(t *testing.T) {
 		desc          string
 		status        string
 		expectedTotal uint64
-		expectedAlive *bool
+		expectedAlive bool
+		checkAlive    bool
 		err           bool
 	}{
 		{
@@ -50,15 +52,17 @@ func TestListPropletsFilterByStatus(t *testing.T) {
 		},
 		{
 			desc:          "list active proplets",
-			status:        manager.PropletStatusActive,
+			status:        proplet.ActiveStatus.String(),
 			expectedTotal: 1,
-			expectedAlive: boolPtr(true),
+			expectedAlive: true,
+			checkAlive:    true,
 		},
 		{
 			desc:          "list inactive proplets",
-			status:        manager.PropletStatusInactive,
+			status:        proplet.InactiveStatus.String(),
 			expectedTotal: 1,
-			expectedAlive: boolPtr(false),
+			expectedAlive: false,
+			checkAlive:    true,
 		},
 		{
 			desc:   "invalid status returns error",
@@ -91,14 +95,15 @@ func TestListPropletsFilterByStatus(t *testing.T) {
 			page, err := svc.ListProplets(ctx, 0, 100, tc.status)
 			if tc.err {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "invalid value provided")
+				assert.ErrorIs(t, err, pkgerrors.ErrInvalidValue)
+				assert.ErrorIs(t, err, proplet.ErrInvalidStatus)
 
 				return
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedTotal, page.Total)
-			if tc.expectedAlive != nil && len(page.Proplets) > 0 {
-				assert.Equal(t, *tc.expectedAlive, page.Proplets[0].Alive)
+			if tc.checkAlive && len(page.Proplets) > 0 {
+				assert.Equal(t, tc.expectedAlive, page.Proplets[0].Alive)
 			}
 		})
 	}
@@ -145,12 +150,10 @@ func TestListPropletsFilterPagination(t *testing.T) {
 				require.NoError(t, repos.Proplets.Create(ctx, p))
 			}
 
-			page, err := svc.ListProplets(ctx, tc.offset, tc.limit, manager.PropletStatusActive)
+			page, err := svc.ListProplets(ctx, tc.offset, tc.limit, proplet.ActiveStatus.String())
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedTotal, page.Total)
 			assert.Len(t, page.Proplets, tc.expectedLen)
 		})
 	}
 }
-
-func boolPtr(b bool) *bool { return &b }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -45,8 +45,6 @@ func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 		errors.Is(err, pkgerrors.ErrEmptyKey),
 		errors.Is(err, pkgerrors.ErrInvalidValue):
 		w.WriteHeader(http.StatusBadRequest)
-	case errors.Is(err, pkgerrors.ErrInvalidValue):
-		w.WriteHeader(http.StatusBadRequest)
 	case errors.Is(err, pkgerrors.ErrNotFound):
 		w.WriteHeader(http.StatusNotFound)
 	case errors.Is(err, pkgerrors.ErrConflict):

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 
 	"github.com/absmach/magistrala"
-	pkgerrors "github.com/absmach/propeller/pkg/errors"
 	apiutil "github.com/absmach/magistrala/api/http/util"
+	pkgerrors "github.com/absmach/propeller/pkg/errors"
 )
 
 const (

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/absmach/magistrala"
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
+	apiutil "github.com/absmach/magistrala/api/http/util"
 )
 
 const (
@@ -40,7 +41,9 @@ func EncodeResponse(_ context.Context, w http.ResponseWriter, response any) erro
 func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", ContentType)
 	switch {
-	case errors.Is(err, pkgerrors.ErrEmptyKey):
+	case errors.Is(err, apiutil.ErrValidation),
+		errors.Is(err, pkgerrors.ErrEmptyKey),
+		errors.Is(err, pkgerrors.ErrInvalidValue):
 		w.WriteHeader(http.StatusBadRequest)
 	case errors.Is(err, pkgerrors.ErrInvalidValue):
 		w.WriteHeader(http.StatusBadRequest)

--- a/pkg/proplet/proplet.go
+++ b/pkg/proplet/proplet.go
@@ -1,8 +1,48 @@
 package proplet
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
-const AliveTimeout = 10 * time.Second
+var ErrInvalidStatus = errors.New("invalid proplet status")
+
+type Status uint8
+
+const (
+	ActiveStatus Status = iota
+	InactiveStatus
+)
+
+const (
+	AliveTimeout = 10 * time.Second
+
+	Active   = "active"
+	Inactive = "inactive"
+	Unknown  = "unknown"
+)
+
+func (s Status) String() string {
+	switch s {
+	case ActiveStatus:
+		return Active
+	case InactiveStatus:
+		return Inactive
+	default:
+		return Unknown
+	}
+}
+
+func ToStatus(status string) (Status, error) {
+	switch status {
+	case Active:
+		return ActiveStatus, nil
+	case Inactive:
+		return InactiveStatus, nil
+	default:
+		return Status(0), ErrInvalidStatus
+	}
+}
 
 type PropletMetadata struct {
 	Description      string   `json:"description,omitempty"`

--- a/pkg/proplet/proplet.go
+++ b/pkg/proplet/proplet.go
@@ -19,7 +19,9 @@ const (
 
 	Active   = "active"
 	Inactive = "inactive"
-	Unknown  = "unknown"
+	// unknown is unexported: it is only used as the default String() return value
+	// and is not a valid ?status= filter value (ToStatus rejects it with ErrInvalidStatus).
+	unknown = "unknown"
 )
 
 func (s Status) String() string {
@@ -29,7 +31,7 @@ func (s Status) String() string {
 	case InactiveStatus:
 		return Inactive
 	default:
-		return Unknown
+		return unknown
 	}
 }
 

--- a/pkg/proplet/proplet.go
+++ b/pkg/proplet/proplet.go
@@ -2,7 +2,7 @@ package proplet
 
 import "time"
 
-const aliveTimeout = 10 * time.Second
+const AliveTimeout = 10 * time.Second
 
 type PropletMetadata struct {
 	Description      string   `json:"description,omitempty"`
@@ -30,7 +30,7 @@ type Proplet struct {
 func (p *Proplet) SetAlive() {
 	if len(p.AliveHistory) > 0 {
 		lastAlive := p.AliveHistory[len(p.AliveHistory)-1]
-		if time.Since(lastAlive) <= aliveTimeout {
+		if time.Since(lastAlive) <= AliveTimeout {
 			p.Alive = true
 
 			return

--- a/pkg/proplet/status_test.go
+++ b/pkg/proplet/status_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestStatusString(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		desc   string
 		status proplet.Status
@@ -37,6 +39,8 @@ func TestStatusString(t *testing.T) {
 }
 
 func TestToStatus(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		desc   string
 		value  string

--- a/pkg/proplet/status_test.go
+++ b/pkg/proplet/status_test.go
@@ -1,0 +1,71 @@
+package proplet_test
+
+import (
+	"testing"
+
+	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusString(t *testing.T) {
+	cases := []struct {
+		desc   string
+		status proplet.Status
+		value  string
+	}{
+		{
+			desc:   "active status",
+			status: proplet.ActiveStatus,
+			value:  proplet.Active,
+		},
+		{
+			desc:   "inactive status",
+			status: proplet.InactiveStatus,
+			value:  proplet.Inactive,
+		},
+		{
+			desc:   "unknown status",
+			status: proplet.Status(100),
+			value:  proplet.Unknown,
+		},
+	}
+
+	for _, tc := range cases {
+		got := tc.status.String()
+		assert.Equal(t, tc.value, got, "Status.String() = %v, expected %v", got, tc.value)
+	}
+}
+
+func TestToStatus(t *testing.T) {
+	cases := []struct {
+		desc   string
+		value  string
+		status proplet.Status
+		err    error
+	}{
+		{
+			desc:   "active status",
+			value:  proplet.Active,
+			status: proplet.ActiveStatus,
+			err:    nil,
+		},
+		{
+			desc:   "inactive status",
+			value:  proplet.Inactive,
+			status: proplet.InactiveStatus,
+			err:    nil,
+		},
+		{
+			desc:   "invalid status",
+			value:  "unknown",
+			status: proplet.Status(0),
+			err:    proplet.ErrInvalidStatus,
+		},
+	}
+
+	for _, tc := range cases {
+		got, err := proplet.ToStatus(tc.value)
+		assert.Equal(t, tc.err, err, "ToStatus() error = %v, expected %v", err, tc.err)
+		assert.Equal(t, tc.status, got, "ToStatus() = %v, expected %v", got, tc.status)
+	}
+}

--- a/pkg/proplet/status_test.go
+++ b/pkg/proplet/status_test.go
@@ -28,7 +28,7 @@ func TestStatusString(t *testing.T) {
 		{
 			desc:   "unknown status",
 			status: proplet.Status(100),
-			value:  proplet.Unknown,
+			value:  "unknown",
 		},
 	}
 

--- a/pkg/sdk/proplet.go
+++ b/pkg/sdk/proplet.go
@@ -14,11 +14,11 @@ import (
 const propletsEndpoint = "/proplets"
 
 type Proplet struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	TaskCount uint64    `json:"task_count"`
-	Alive     bool      `json:"alive"`
-	CreatedAt time.Time `json:"created_at"`
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	TaskCount   uint64     `json:"task_count"`
+	Alive       bool       `json:"alive"`
+	LastAliveAt *time.Time `json:"last_alive_at,omitempty"`
 }
 
 type PropletPage struct {

--- a/pkg/sdk/proplet.go
+++ b/pkg/sdk/proplet.go
@@ -4,16 +4,34 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/absmach/propeller/pkg/proplet"
 )
 
 const propletsEndpoint = "/proplets"
 
-func (sdk *propSDK) GetPropletAliveHistory(id string, offset, limit uint64) (proplet.PropletAliveHistoryPage, error) {
-	url := fmt.Sprintf("%s%s/%s/alive-history?offset=%d&limit=%d", sdk.managerURL, propletsEndpoint, id, offset, limit)
+type Proplet struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	TaskCount uint64    `json:"task_count"`
+	Alive     bool      `json:"alive"`
+	CreatedAt time.Time `json:"created_at"`
+}
 
-	body, err := sdk.processRequest(http.MethodGet, url, nil, http.StatusOK)
+type PropletPage struct {
+	Offset   uint64    `json:"offset"`
+	Limit    uint64    `json:"limit"`
+	Total    uint64    `json:"total"`
+	Proplets []Proplet `json:"proplets"`
+}
+
+func (sdk *propSDK) GetPropletAliveHistory(id string, offset, limit uint64) (proplet.PropletAliveHistoryPage, error) {
+	reqURL := fmt.Sprintf("%s%s/%s/alive-history?offset=%d&limit=%d", sdk.managerURL, propletsEndpoint, id, offset, limit)
+
+	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
 	if err != nil {
 		return proplet.PropletAliveHistoryPage{}, err
 	}
@@ -26,10 +44,40 @@ func (sdk *propSDK) GetPropletAliveHistory(id string, offset, limit uint64) (pro
 	return page, nil
 }
 
-func (sdk *propSDK) DeleteProplet(id string) error {
-	url := sdk.managerURL + propletsEndpoint + "/" + id
+func (sdk *propSDK) ListProplets(offset, limit uint64, status string) (PropletPage, error) {
+	params := make([]string, 0)
+	if offset > 0 {
+		params = append(params, fmt.Sprintf("offset=%d", offset))
+	}
+	if limit > 0 {
+		params = append(params, fmt.Sprintf("limit=%d", limit))
+	}
+	if status != "" {
+		params = append(params, "status="+url.QueryEscape(status))
+	}
+	query := ""
+	if len(params) > 0 {
+		query = "?" + strings.Join(params, "&")
+	}
+	reqURL := sdk.managerURL + propletsEndpoint + query
 
-	if _, err := sdk.processRequest(http.MethodDelete, url, nil, http.StatusNoContent); err != nil {
+	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
+	if err != nil {
+		return PropletPage{}, err
+	}
+
+	var pp PropletPage
+	if err := json.Unmarshal(body, &pp); err != nil {
+		return PropletPage{}, err
+	}
+
+	return pp, nil
+}
+
+func (sdk *propSDK) DeleteProplet(id string) error {
+	reqURL := sdk.managerURL + propletsEndpoint + "/" + id
+
+	if _, err := sdk.processRequest(http.MethodDelete, reqURL, nil, http.StatusNoContent); err != nil {
 		return err
 	}
 

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -117,6 +117,14 @@ type SDK interface {
 	//  fmt.Println(page)
 	GetPropletAliveHistory(id string, offset, limit uint64) (proplet.PropletAliveHistoryPage, error)
 
+	// ListProplets lists proplets with optional status filter.
+	// Status can be "active", "inactive", or "" (all).
+	//
+	// example:
+	//  page, _ := sdk.ListProplets(0, 10, "")
+	//  page, _ := sdk.ListProplets(0, 10, "active")
+	ListProplets(offset uint64, limit uint64, status string) (PropletPage, error)
+
 	// DeleteProplet deletes a proplet by id.
 	//
 	// example:

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -90,11 +90,13 @@ type SDK interface {
 	//  job, _ := sdk.GetJob("b1d10738-c5d7-4ff1-8f4d-b9328ce6f040")
 	GetJob(jobID string) (JobResponse, error)
 
-	// ListJobs lists jobs.
+	// ListJobs lists jobs with optional status filter.
+	// Status can be "pending", "running", "completed", "failed", or "" (all).
 	//
 	// example:
-	//  jobPage, _ := sdk.ListJobs(0, 10)
-	ListJobs(offset uint64, limit uint64) (JobPage, error)
+	//  jobPage, _ := sdk.ListJobs(0, 10, "")
+	//  jobPage, _ := sdk.ListJobs(0, 10, "running")
+	ListJobs(offset uint64, limit uint64, status string) (JobPage, error)
 
 	// StartJob starts a job.
 	//

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -224,7 +224,7 @@ func (sdk *propSDK) ListJobs(offset, limit uint64, status string) (JobPage, erro
 		queries = append(queries, fmt.Sprintf("limit=%d", limit))
 	}
 	if status != "" {
-		queries = append(queries, fmt.Sprintf("status=%s", status))
+		queries = append(queries, "status="+status)
 	}
 	query := ""
 	if len(queries) > 0 {

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -40,9 +41,9 @@ func (sdk *propSDK) CreateTask(task Task) (Task, error) {
 		return Task{}, err
 	}
 
-	url := sdk.managerURL + tasksEndpoint
+	reqURL := sdk.managerURL + tasksEndpoint
 
-	body, err := sdk.processRequest(http.MethodPost, url, data, http.StatusCreated)
+	body, err := sdk.processRequest(http.MethodPost, reqURL, data, http.StatusCreated)
 	if err != nil {
 		return Task{}, err
 	}
@@ -56,9 +57,9 @@ func (sdk *propSDK) CreateTask(task Task) (Task, error) {
 }
 
 func (sdk *propSDK) GetTask(id string) (Task, error) {
-	url := sdk.managerURL + tasksEndpoint + "/" + id
+	reqURL := sdk.managerURL + tasksEndpoint + "/" + id
 
-	body, err := sdk.processRequest(http.MethodGet, url, nil, http.StatusOK)
+	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
 	if err != nil {
 		return Task{}, err
 	}
@@ -83,9 +84,9 @@ func (sdk *propSDK) ListTasks(offset, limit uint64) (TaskPage, error) {
 	if len(queries) > 0 {
 		query = "?" + strings.Join(queries, "&")
 	}
-	url := sdk.managerURL + tasksEndpoint + query
+	reqURL := sdk.managerURL + tasksEndpoint + query
 
-	body, err := sdk.processRequest(http.MethodGet, url, nil, http.StatusOK)
+	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
 	if err != nil {
 		return TaskPage{}, err
 	}
@@ -103,9 +104,9 @@ func (sdk *propSDK) UpdateTask(task Task) (Task, error) {
 	if err != nil {
 		return Task{}, err
 	}
-	url := sdk.managerURL + tasksEndpoint + "/" + task.ID
+	reqURL := sdk.managerURL + tasksEndpoint + "/" + task.ID
 
-	body, err := sdk.processRequest(http.MethodPut, url, data, http.StatusOK)
+	body, err := sdk.processRequest(http.MethodPut, reqURL, data, http.StatusOK)
 	if err != nil {
 		return Task{}, err
 	}
@@ -119,9 +120,9 @@ func (sdk *propSDK) UpdateTask(task Task) (Task, error) {
 }
 
 func (sdk *propSDK) DeleteTask(id string) error {
-	url := sdk.managerURL + tasksEndpoint + "/" + id
+	reqURL := sdk.managerURL + tasksEndpoint + "/" + id
 
-	if _, err := sdk.processRequest(http.MethodDelete, url, nil, http.StatusNoContent); err != nil {
+	if _, err := sdk.processRequest(http.MethodDelete, reqURL, nil, http.StatusNoContent); err != nil {
 		return err
 	}
 
@@ -129,9 +130,9 @@ func (sdk *propSDK) DeleteTask(id string) error {
 }
 
 func (sdk *propSDK) StartTask(id string) error {
-	url := fmt.Sprintf("%s/tasks/%s/start", sdk.managerURL, id)
+	reqURL := fmt.Sprintf("%s/tasks/%s/start", sdk.managerURL, id)
 
-	if _, err := sdk.processRequest(http.MethodPost, url, nil, http.StatusOK); err != nil {
+	if _, err := sdk.processRequest(http.MethodPost, reqURL, nil, http.StatusOK); err != nil {
 		return err
 	}
 
@@ -139,9 +140,9 @@ func (sdk *propSDK) StartTask(id string) error {
 }
 
 func (sdk *propSDK) StopTask(id string) error {
-	url := fmt.Sprintf("%s/tasks/%s/stop", sdk.managerURL, id)
+	reqURL := fmt.Sprintf("%s/tasks/%s/stop", sdk.managerURL, id)
 
-	if _, err := sdk.processRequest(http.MethodPost, url, nil, http.StatusOK); err != nil {
+	if _, err := sdk.processRequest(http.MethodPost, reqURL, nil, http.StatusOK); err != nil {
 		return err
 	}
 
@@ -184,9 +185,9 @@ func (sdk *propSDK) CreateJob(req JobRequest) (JobResponse, error) {
 		return JobResponse{}, err
 	}
 
-	url := sdk.managerURL + jobsEndpoint
+	reqURL := sdk.managerURL + jobsEndpoint
 
-	body, err := sdk.processRequest(http.MethodPost, url, data, http.StatusCreated)
+	body, err := sdk.processRequest(http.MethodPost, reqURL, data, http.StatusCreated)
 	if err != nil {
 		return JobResponse{}, err
 	}
@@ -200,9 +201,9 @@ func (sdk *propSDK) CreateJob(req JobRequest) (JobResponse, error) {
 }
 
 func (sdk *propSDK) GetJob(jobID string) (JobResponse, error) {
-	url := sdk.managerURL + jobsEndpoint + "/" + jobID
+	reqURL := sdk.managerURL + jobsEndpoint + "/" + jobID
 
-	body, err := sdk.processRequest(http.MethodGet, url, nil, http.StatusOK)
+	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
 	if err != nil {
 		return JobResponse{}, err
 	}
@@ -216,23 +217,23 @@ func (sdk *propSDK) GetJob(jobID string) (JobResponse, error) {
 }
 
 func (sdk *propSDK) ListJobs(offset, limit uint64, status string) (JobPage, error) {
-	queries := make([]string, 0)
+	params := make([]string, 0)
 	if offset > 0 {
-		queries = append(queries, fmt.Sprintf("offset=%d", offset))
+		params = append(params, fmt.Sprintf("offset=%d", offset))
 	}
 	if limit > 0 {
-		queries = append(queries, fmt.Sprintf("limit=%d", limit))
+		params = append(params, fmt.Sprintf("limit=%d", limit))
 	}
 	if status != "" {
-		queries = append(queries, "status="+status)
+		params = append(params, "status="+url.QueryEscape(status))
 	}
 	query := ""
-	if len(queries) > 0 {
-		query = "?" + strings.Join(queries, "&")
+	if len(params) > 0 {
+		query = "?" + strings.Join(params, "&")
 	}
-	url := sdk.managerURL + jobsEndpoint + query
+	reqURL := sdk.managerURL + jobsEndpoint + query
 
-	body, err := sdk.processRequest(http.MethodGet, url, nil, http.StatusOK)
+	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
 	if err != nil {
 		return JobPage{}, err
 	}
@@ -246,9 +247,9 @@ func (sdk *propSDK) ListJobs(offset, limit uint64, status string) (JobPage, erro
 }
 
 func (sdk *propSDK) StartJob(jobID string) error {
-	url := fmt.Sprintf("%s/jobs/%s/start", sdk.managerURL, jobID)
+	reqURL := fmt.Sprintf("%s/jobs/%s/start", sdk.managerURL, jobID)
 
-	if _, err := sdk.processRequest(http.MethodPost, url, nil, http.StatusOK); err != nil {
+	if _, err := sdk.processRequest(http.MethodPost, reqURL, nil, http.StatusOK); err != nil {
 		return err
 	}
 
@@ -256,9 +257,9 @@ func (sdk *propSDK) StartJob(jobID string) error {
 }
 
 func (sdk *propSDK) StopJob(jobID string) error {
-	url := fmt.Sprintf("%s/jobs/%s/stop", sdk.managerURL, jobID)
+	reqURL := fmt.Sprintf("%s/jobs/%s/stop", sdk.managerURL, jobID)
 
-	if _, err := sdk.processRequest(http.MethodPost, url, nil, http.StatusOK); err != nil {
+	if _, err := sdk.processRequest(http.MethodPost, reqURL, nil, http.StatusOK); err != nil {
 		return err
 	}
 

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -215,13 +215,16 @@ func (sdk *propSDK) GetJob(jobID string) (JobResponse, error) {
 	return jr, nil
 }
 
-func (sdk *propSDK) ListJobs(offset, limit uint64) (JobPage, error) {
+func (sdk *propSDK) ListJobs(offset, limit uint64, status string) (JobPage, error) {
 	queries := make([]string, 0)
 	if offset > 0 {
 		queries = append(queries, fmt.Sprintf("offset=%d", offset))
 	}
 	if limit > 0 {
 		queries = append(queries, fmt.Sprintf("limit=%d", limit))
+	}
+	if status != "" {
+		queries = append(queries, fmt.Sprintf("status=%s", status))
 	}
 	query := ""
 	if len(queries) > 0 {

--- a/pkg/storage/badger/init.go
+++ b/pkg/storage/badger/init.go
@@ -62,6 +62,7 @@ type PropletRepository interface {
 	Get(ctx context.Context, id string) (proplet.Proplet, error)
 	Update(ctx context.Context, p proplet.Proplet) error
 	List(ctx context.Context, offset, limit uint64) ([]proplet.Proplet, uint64, error)
+	ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error)
 	Delete(ctx context.Context, id string) error
 	GetAliveHistory(ctx context.Context, id string, offset, limit uint64) ([]time.Time, uint64, error)
 }

--- a/pkg/storage/badger/proplets.go
+++ b/pkg/storage/badger/proplets.go
@@ -83,6 +83,16 @@ const maxBadgerScan uint64 = 100000
 
 func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
 	prefix := []byte("proplet:")
+	total, err := r.db.countWithPrefix(prefix)
+	if err != nil {
+		return nil, 0, err
+	}
+	if total > maxBadgerScan {
+		return nil, 0, fmt.Errorf("%w: filtered proplet listing exceeds badger scan cap of %d records (found %d)", ErrDBQuery, maxBadgerScan, total)
+	}
+
+	// Badger cannot push liveness filtering into key iteration, so we scan the
+	// full proplet keyspace up to maxBadgerScan and paginate the filtered slice.
 	values, err := r.db.listWithPrefix(prefix, 0, maxBadgerScan)
 	if err != nil {
 		return nil, 0, err

--- a/pkg/storage/badger/proplets.go
+++ b/pkg/storage/badger/proplets.go
@@ -79,14 +79,11 @@ func (r *propletRepo) List(ctx context.Context, offset, limit uint64) ([]proplet
 	return proplets, total, nil
 }
 
+const maxBadgerScan uint64 = 100000
+
 func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
 	prefix := []byte("proplet:")
-	totalRaw, err := r.db.countWithPrefix(prefix)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	values, err := r.db.listWithPrefix(prefix, 0, totalRaw)
+	values, err := r.db.listWithPrefix(prefix, 0, maxBadgerScan)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/storage/badger/proplets.go
+++ b/pkg/storage/badger/proplets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/absmach/propeller/pkg/proplet"
@@ -87,13 +88,18 @@ func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, ali
 	if err != nil {
 		return nil, 0, err
 	}
+	scanLimit := total
 	if total > maxBadgerScan {
-		return nil, 0, fmt.Errorf("%w: filtered proplet listing exceeds badger scan cap of %d records (found %d)", ErrDBQuery, maxBadgerScan, total)
+		// Badger has no index for liveness filtering; a full keyspace scan is
+		// required. Beyond maxBadgerScan records the scan is truncated and results
+		// will be incomplete. TODO: consider an indexed approach for large deployments.
+		slog.Warn("Badger ListByAlive scan truncated", "total", total, "cap", maxBadgerScan)
+		scanLimit = maxBadgerScan
 	}
 
 	// Badger cannot push liveness filtering into key iteration, so we scan the
-	// full proplet keyspace up to maxBadgerScan and paginate the filtered slice.
-	values, err := r.db.listWithPrefix(prefix, 0, maxBadgerScan)
+	// full proplet keyspace up to scanLimit and paginate the filtered slice.
+	values, err := r.db.listWithPrefix(prefix, 0, scanLimit)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/storage/badger/proplets.go
+++ b/pkg/storage/badger/proplets.go
@@ -79,6 +79,42 @@ func (r *propletRepo) List(ctx context.Context, offset, limit uint64) ([]proplet
 	return proplets, total, nil
 }
 
+func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
+	prefix := []byte("proplet:")
+	totalRaw, err := r.db.countWithPrefix(prefix)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	values, err := r.db.listWithPrefix(prefix, 0, totalRaw)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var filtered []proplet.Proplet
+	for _, val := range values {
+		var p proplet.Proplet
+		if err := json.Unmarshal(val, &p); err != nil {
+			return nil, 0, fmt.Errorf("unmarshal error: %w", err)
+		}
+		isAlive := len(p.AliveHistory) > 0 && !p.AliveHistory[len(p.AliveHistory)-1].Before(since)
+		if isAlive == alive {
+			filtered = append(filtered, p)
+		}
+	}
+
+	filteredTotal := uint64(len(filtered))
+	if offset >= filteredTotal {
+		return []proplet.Proplet{}, filteredTotal, nil
+	}
+	end := offset + limit
+	if end > filteredTotal {
+		end = filteredTotal
+	}
+
+	return filtered[offset:end], filteredTotal, nil
+}
+
 func (r *propletRepo) Delete(ctx context.Context, id string) error {
 	key := []byte("proplet:" + id)
 

--- a/pkg/storage/badger/proplets.go
+++ b/pkg/storage/badger/proplets.go
@@ -104,10 +104,7 @@ func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, ali
 	if offset >= filteredTotal {
 		return []proplet.Proplet{}, filteredTotal, nil
 	}
-	end := offset + limit
-	if end > filteredTotal {
-		end = filteredTotal
-	}
+	end := min(offset+limit, filteredTotal)
 
 	return filtered[offset:end], filteredTotal, nil
 }

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -190,6 +190,10 @@ func (a *postgresPropletAdapter) List(ctx context.Context, offset, limit uint64)
 	return a.repo.List(ctx, offset, limit)
 }
 
+func (a *postgresPropletAdapter) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
+	return a.repo.ListByAlive(ctx, offset, limit, alive, since)
+}
+
 func (a *postgresPropletAdapter) Delete(ctx context.Context, id string) error {
 	return a.repo.Delete(ctx, id)
 }
@@ -342,6 +346,10 @@ func (a *sqlitePropletAdapter) List(ctx context.Context, offset, limit uint64) (
 	return a.repo.List(ctx, offset, limit)
 }
 
+func (a *sqlitePropletAdapter) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
+	return a.repo.ListByAlive(ctx, offset, limit, alive, since)
+}
+
 func (a *sqlitePropletAdapter) Delete(ctx context.Context, id string) error {
 	return a.repo.Delete(ctx, id)
 }
@@ -492,6 +500,10 @@ func (a *badgerPropletAdapter) Update(ctx context.Context, p proplet.Proplet) er
 
 func (a *badgerPropletAdapter) List(ctx context.Context, offset, limit uint64) ([]proplet.Proplet, uint64, error) {
 	return a.repo.List(ctx, offset, limit)
+}
+
+func (a *badgerPropletAdapter) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
+	return a.repo.ListByAlive(ctx, offset, limit, alive, since)
 }
 
 func (a *badgerPropletAdapter) Delete(ctx context.Context, id string) error {

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -153,6 +153,33 @@ func (r *memoryPropletRepo) List(ctx context.Context, offset, limit uint64) ([]p
 	return proplets, total, nil
 }
 
+func (r *memoryPropletRepo) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
+	data, _, err := r.storage.List(ctx, 0, maxMemoryFetch)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var filtered []proplet.Proplet
+	for _, d := range data {
+		p, ok := d.(proplet.Proplet)
+		if !ok {
+			continue
+		}
+		isAlive := len(p.AliveHistory) > 0 && !p.AliveHistory[len(p.AliveHistory)-1].Before(since)
+		if isAlive == alive {
+			filtered = append(filtered, p)
+		}
+	}
+
+	filteredTotal := uint64(len(filtered))
+	if offset >= filteredTotal {
+		return []proplet.Proplet{}, filteredTotal, nil
+	}
+	end := min(offset+limit, filteredTotal)
+
+	return filtered[offset:end], filteredTotal, nil
+}
+
 func (r *memoryPropletRepo) Delete(ctx context.Context, id string) error {
 	return r.storage.Delete(ctx, id)
 }

--- a/pkg/storage/memory_adapter.go
+++ b/pkg/storage/memory_adapter.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
@@ -64,7 +65,7 @@ func (r *memoryTaskRepo) List(ctx context.Context, offset, limit uint64) ([]task
 }
 
 func (r *memoryTaskRepo) ListByWorkflowID(ctx context.Context, workflowID string) ([]task.Task, error) {
-	data, _, err := r.storage.List(ctx, 0, maxMemoryFetch)
+	data, _, err := r.storage.List(ctx, 0, math.MaxUint64)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +85,7 @@ func (r *memoryTaskRepo) ListByWorkflowID(ctx context.Context, workflowID string
 }
 
 func (r *memoryTaskRepo) ListByJobID(ctx context.Context, jobID string) ([]task.Task, error) {
-	data, _, err := r.storage.List(ctx, 0, maxMemoryFetch)
+	data, _, err := r.storage.List(ctx, 0, math.MaxUint64)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +155,7 @@ func (r *memoryPropletRepo) List(ctx context.Context, offset, limit uint64) ([]p
 }
 
 func (r *memoryPropletRepo) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
-	data, _, err := r.storage.List(ctx, 0, maxMemoryFetch)
+	data, _, err := r.storage.List(ctx, 0, math.MaxUint64)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -278,8 +279,6 @@ func (r *memoryJobRepo) List(ctx context.Context, offset, limit uint64) ([]job.J
 func (r *memoryJobRepo) Delete(ctx context.Context, id string) error {
 	return r.storage.Delete(ctx, id)
 }
-
-const maxMemoryFetch = 100000
 
 type memoryMetricsRepo struct {
 	storage Storage

--- a/pkg/storage/mocks/proplet_repository.go
+++ b/pkg/storage/mocks/proplet_repository.go
@@ -299,6 +299,92 @@ func (_c *MockPropletRepository_List_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
+// ListByAlive provides a mock function for the type MockPropletRepository
+func (_mock *MockPropletRepository) ListByAlive(ctx context.Context, offset uint64, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
+	ret := _mock.Called(ctx, offset, limit, alive, since)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListByAlive")
+	}
+
+	var r0 []proplet.Proplet
+	var r1 uint64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64, bool, time.Time) ([]proplet.Proplet, uint64, error)); ok {
+		return returnFunc(ctx, offset, limit, alive, since)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint64, uint64, bool, time.Time) []proplet.Proplet); ok {
+		r0 = returnFunc(ctx, offset, limit, alive, since)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]proplet.Proplet)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint64, uint64, bool, time.Time) uint64); ok {
+		r1 = returnFunc(ctx, offset, limit, alive, since)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, uint64, uint64, bool, time.Time) error); ok {
+		r2 = returnFunc(ctx, offset, limit, alive, since)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockPropletRepository_ListByAlive_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListByAlive'
+type MockPropletRepository_ListByAlive_Call struct {
+	*mock.Call
+}
+
+// ListByAlive is a helper method to define mock.On call
+//   - ctx context.Context
+//   - offset uint64
+//   - limit uint64
+//   - alive bool
+//   - since time.Time
+func (_e *MockPropletRepository_Expecter) ListByAlive(ctx interface{}, offset interface{}, limit interface{}, alive interface{}, since interface{}) *MockPropletRepository_ListByAlive_Call {
+	return &MockPropletRepository_ListByAlive_Call{Call: _e.mock.On("ListByAlive", ctx, offset, limit, alive, since)}
+}
+
+func (_c *MockPropletRepository_ListByAlive_Call) Run(run func(ctx context.Context, offset uint64, limit uint64, alive bool, since time.Time)) *MockPropletRepository_ListByAlive_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint64
+		if args[1] != nil {
+			arg1 = args[1].(uint64)
+		}
+		var arg2 uint64
+		if args[2] != nil {
+			arg2 = args[2].(uint64)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
+		}
+		var arg4 time.Time
+		if args[4] != nil {
+			arg4 = args[4].(time.Time)
+		}
+		run(arg0, arg1, arg2, arg3, arg4)
+	})
+	return _c
+}
+
+func (_c *MockPropletRepository_ListByAlive_Call) Return(proplets []proplet.Proplet, v uint64, err error) *MockPropletRepository_ListByAlive_Call {
+	_c.Call.Return(proplets, v, err)
+	return _c
+}
+
+func (_c *MockPropletRepository_ListByAlive_Call) RunAndReturn(run func(ctx context.Context, offset uint64, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error)) *MockPropletRepository_ListByAlive_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Update provides a mock function for the type MockPropletRepository
 func (_mock *MockPropletRepository) Update(ctx context.Context, p proplet.Proplet) error {
 	ret := _mock.Called(ctx, p)

--- a/pkg/storage/mocks/proplet_repository.go
+++ b/pkg/storage/mocks/proplet_repository.go
@@ -299,7 +299,6 @@ func (_c *MockPropletRepository_List_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
-// ListByAlive provides a mock function for the type MockPropletRepository
 func (_mock *MockPropletRepository) ListByAlive(ctx context.Context, offset uint64, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
 	ret := _mock.Called(ctx, offset, limit, alive, since)
 
@@ -333,17 +332,10 @@ func (_mock *MockPropletRepository) ListByAlive(ctx context.Context, offset uint
 	return r0, r1, r2
 }
 
-// MockPropletRepository_ListByAlive_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListByAlive'
 type MockPropletRepository_ListByAlive_Call struct {
 	*mock.Call
 }
 
-// ListByAlive is a helper method to define mock.On call
-//   - ctx context.Context
-//   - offset uint64
-//   - limit uint64
-//   - alive bool
-//   - since time.Time
 func (_e *MockPropletRepository_Expecter) ListByAlive(ctx interface{}, offset interface{}, limit interface{}, alive interface{}, since interface{}) *MockPropletRepository_ListByAlive_Call {
 	return &MockPropletRepository_ListByAlive_Call{Call: _e.mock.On("ListByAlive", ctx, offset, limit, alive, since)}
 }

--- a/pkg/storage/postgres/init.go
+++ b/pkg/storage/postgres/init.go
@@ -64,6 +64,7 @@ type PropletRepository interface {
 	Get(ctx context.Context, id string) (proplet.Proplet, error)
 	Update(ctx context.Context, p proplet.Proplet) error
 	List(ctx context.Context, offset, limit uint64) ([]proplet.Proplet, uint64, error)
+	ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error)
 	Delete(ctx context.Context, id string) error
 	GetAliveHistory(ctx context.Context, id string, offset, limit uint64) ([]time.Time, uint64, error)
 }

--- a/pkg/storage/postgres/proplets.go
+++ b/pkg/storage/postgres/proplets.go
@@ -128,13 +128,19 @@ func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, ali
 		whereClause = `WHERE alive_history IS NULL OR jsonb_array_length(alive_history) = 0 OR (alive_history ->> (jsonb_array_length(alive_history) - 1))::timestamptz < $1`
 	}
 
+	tx, err := r.db.BeginTxx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+	defer tx.Rollback()
+
 	var total uint64
-	if err := r.db.GetContext(ctx, &total, fmt.Sprintf("SELECT COUNT(*) FROM proplets %s", whereClause), since); err != nil {
+	if err := tx.GetContext(ctx, &total, fmt.Sprintf("SELECT COUNT(*) FROM proplets %s", whereClause), since); err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 
 	query := fmt.Sprintf(`SELECT id, name, task_count, alive, alive_history, metadata FROM proplets %s LIMIT $2 OFFSET $3`, whereClause)
-	rows, err := r.db.QueryContext(ctx, query, since, limit, offset)
+	rows, err := tx.QueryContext(ctx, query, since, limit, offset)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}

--- a/pkg/storage/postgres/proplets.go
+++ b/pkg/storage/postgres/proplets.go
@@ -132,10 +132,10 @@ func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, ali
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	var total uint64
-	if err := tx.GetContext(ctx, &total, fmt.Sprintf("SELECT COUNT(*) FROM proplets %s", whereClause), since); err != nil {
+	if err := tx.GetContext(ctx, &total, "SELECT COUNT(*) FROM proplets "+whereClause, since); err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 

--- a/pkg/storage/postgres/proplets.go
+++ b/pkg/storage/postgres/proplets.go
@@ -120,6 +120,45 @@ func (r *propletRepo) List(ctx context.Context, offset, limit uint64) ([]proplet
 	return proplets, total, nil
 }
 
+func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
+	var whereClause string
+	if alive {
+		whereClause = `WHERE alive_history IS NOT NULL AND jsonb_array_length(alive_history) > 0 AND (alive_history ->> (jsonb_array_length(alive_history) - 1))::timestamptz >= $1`
+	} else {
+		whereClause = `WHERE alive_history IS NULL OR jsonb_array_length(alive_history) = 0 OR (alive_history ->> (jsonb_array_length(alive_history) - 1))::timestamptz < $1`
+	}
+
+	var total uint64
+	if err := r.db.GetContext(ctx, &total, fmt.Sprintf("SELECT COUNT(*) FROM proplets %s", whereClause), since); err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+
+	query := fmt.Sprintf(`SELECT id, name, task_count, alive, alive_history, metadata FROM proplets %s LIMIT $2 OFFSET $3`, whereClause)
+	rows, err := r.db.QueryContext(ctx, query, since, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+	defer rows.Close()
+
+	proplets := make([]proplet.Proplet, 0)
+	for rows.Next() {
+		var dbp dbProplet
+		if err := rows.Scan(&dbp.ID, &dbp.Name, &dbp.TaskCount, &dbp.Alive, &dbp.AliveHistory, &dbp.Metadata); err != nil {
+			return nil, 0, fmt.Errorf("%w: %w", ErrDBScan, err)
+		}
+		p, err := r.toProplet(dbp)
+		if err != nil {
+			return nil, 0, fmt.Errorf("%w: %w", ErrDBScan, err)
+		}
+		proplets = append(proplets, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+
+	return proplets, total, nil
+}
+
 func (r *propletRepo) Delete(ctx context.Context, id string) error {
 	query := `DELETE FROM proplets WHERE id = $1`
 

--- a/pkg/storage/repository.go
+++ b/pkg/storage/repository.go
@@ -24,6 +24,7 @@ type PropletRepository interface {
 	Get(ctx context.Context, id string) (proplet.Proplet, error)
 	Update(ctx context.Context, p proplet.Proplet) error
 	List(ctx context.Context, offset, limit uint64) ([]proplet.Proplet, uint64, error)
+	ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error)
 	Delete(ctx context.Context, id string) error
 	GetAliveHistory(ctx context.Context, id string, offset, limit uint64) ([]time.Time, uint64, error)
 }

--- a/pkg/storage/sqlite/init.go
+++ b/pkg/storage/sqlite/init.go
@@ -64,6 +64,7 @@ type PropletRepository interface {
 	Get(ctx context.Context, id string) (proplet.Proplet, error)
 	Update(ctx context.Context, p proplet.Proplet) error
 	List(ctx context.Context, offset, limit uint64) ([]proplet.Proplet, uint64, error)
+	ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error)
 	Delete(ctx context.Context, id string) error
 	GetAliveHistory(ctx context.Context, id string, offset, limit uint64) ([]time.Time, uint64, error)
 }

--- a/pkg/storage/sqlite/proplets.go
+++ b/pkg/storage/sqlite/proplets.go
@@ -122,36 +122,43 @@ func (r *propletRepo) List(ctx context.Context, offset, limit uint64) ([]proplet
 }
 
 func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
-	const pageSize uint64 = 1000
-	var all []proplet.Proplet
-	var scanOffset uint64
-	for {
-		batch, total, err := r.List(ctx, scanOffset, pageSize)
-		if err != nil {
-			return nil, 0, err
-		}
-		all = append(all, batch...)
-		scanOffset += uint64(len(batch))
-		if scanOffset >= total || len(batch) == 0 {
-			break
-		}
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `SELECT id, name, task_count, alive, alive_history, metadata FROM proplets`)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+	defer rows.Close()
 
 	var filtered []proplet.Proplet
-	for _, p := range all {
+	for rows.Next() {
+		var dbp dbProplet
+		if err := rows.Scan(&dbp.ID, &dbp.Name, &dbp.TaskCount, &dbp.Alive, &dbp.AliveHistory, &dbp.Metadata); err != nil {
+			return nil, 0, fmt.Errorf("%w: %w", ErrDBScan, err)
+		}
+		p, err := r.toProplet(dbp)
+		if err != nil {
+			return nil, 0, fmt.Errorf("%w: %w", ErrDBScan, err)
+		}
 		isAlive := len(p.AliveHistory) > 0 && !p.AliveHistory[len(p.AliveHistory)-1].Before(since)
 		if isAlive == alive {
 			filtered = append(filtered, p)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 
 	filteredTotal := uint64(len(filtered))
 	if offset >= filteredTotal {
 		return []proplet.Proplet{}, filteredTotal, nil
 	}
-	end := min(offset+limit, filteredTotal)
 
-	return filtered[offset:end], filteredTotal, nil
+	return filtered[offset:min(offset+limit, filteredTotal)], filteredTotal, nil
 }
 
 func (r *propletRepo) Delete(ctx context.Context, id string) error {

--- a/pkg/storage/sqlite/proplets.go
+++ b/pkg/storage/sqlite/proplets.go
@@ -132,9 +132,11 @@ func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, ali
 
 	// Use '$[' || (json_array_length-1) || ']' instead of '$[#-1]' to support
 	// SQLite < 3.38.0 (the last-element shorthand was added in 3.38, Feb 2022).
-	whereClause := `WHERE alive_history IS NOT NULL AND json_array_length(alive_history) > 0 AND unixepoch(json_extract(alive_history, '$[' || (json_array_length(alive_history) - 1) || ']')) >= unixepoch(?)`
+	// Use strftime('%s',...) instead of unixepoch() for the same reason: unixepoch()
+	// was also added in 3.38.0, while strftime has been available since SQLite 2.8.
+	whereClause := `WHERE alive_history IS NOT NULL AND json_array_length(alive_history) > 0 AND CAST(strftime('%s', json_extract(alive_history, '$[' || (json_array_length(alive_history) - 1) || ']')) AS INTEGER) >= CAST(strftime('%s', ?) AS INTEGER)`
 	if !alive {
-		whereClause = `WHERE alive_history IS NULL OR json_array_length(alive_history) = 0 OR unixepoch(json_extract(alive_history, '$[' || (json_array_length(alive_history) - 1) || ']')) < unixepoch(?)`
+		whereClause = `WHERE alive_history IS NULL OR json_array_length(alive_history) = 0 OR CAST(strftime('%s', json_extract(alive_history, '$[' || (json_array_length(alive_history) - 1) || ']')) AS INTEGER) < CAST(strftime('%s', ?) AS INTEGER)`
 	}
 
 	var total uint64

--- a/pkg/storage/sqlite/proplets.go
+++ b/pkg/storage/sqlite/proplets.go
@@ -130,9 +130,11 @@ func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, ali
 
 	sinceArg := since.Format(time.RFC3339Nano)
 
-	whereClause := `WHERE alive_history IS NOT NULL AND json_array_length(alive_history) > 0 AND unixepoch(json_extract(alive_history, '$[#-1]')) >= unixepoch(?)`
+	// Use '$[' || (json_array_length-1) || ']' instead of '$[#-1]' to support
+	// SQLite < 3.38.0 (the last-element shorthand was added in 3.38, Feb 2022).
+	whereClause := `WHERE alive_history IS NOT NULL AND json_array_length(alive_history) > 0 AND unixepoch(json_extract(alive_history, '$[' || (json_array_length(alive_history) - 1) || ']')) >= unixepoch(?)`
 	if !alive {
-		whereClause = `WHERE alive_history IS NULL OR json_array_length(alive_history) = 0 OR unixepoch(json_extract(alive_history, '$[#-1]')) < unixepoch(?)`
+		whereClause = `WHERE alive_history IS NULL OR json_array_length(alive_history) = 0 OR unixepoch(json_extract(alive_history, '$[' || (json_array_length(alive_history) - 1) || ']')) < unixepoch(?)`
 	}
 
 	var total uint64

--- a/pkg/storage/sqlite/proplets.go
+++ b/pkg/storage/sqlite/proplets.go
@@ -121,6 +121,39 @@ func (r *propletRepo) List(ctx context.Context, offset, limit uint64) ([]proplet
 	return proplets, total, nil
 }
 
+func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, alive bool, since time.Time) ([]proplet.Proplet, uint64, error) {
+	const pageSize uint64 = 1000
+	var all []proplet.Proplet
+	var scanOffset uint64
+	for {
+		batch, total, err := r.List(ctx, scanOffset, pageSize)
+		if err != nil {
+			return nil, 0, err
+		}
+		all = append(all, batch...)
+		scanOffset += uint64(len(batch))
+		if scanOffset >= total || len(batch) == 0 {
+			break
+		}
+	}
+
+	var filtered []proplet.Proplet
+	for _, p := range all {
+		isAlive := len(p.AliveHistory) > 0 && !p.AliveHistory[len(p.AliveHistory)-1].Before(since)
+		if isAlive == alive {
+			filtered = append(filtered, p)
+		}
+	}
+
+	filteredTotal := uint64(len(filtered))
+	if offset >= filteredTotal {
+		return []proplet.Proplet{}, filteredTotal, nil
+	}
+	end := min(offset+limit, filteredTotal)
+
+	return filtered[offset:end], filteredTotal, nil
+}
+
 func (r *propletRepo) Delete(ctx context.Context, id string) error {
 	query := `DELETE FROM proplets WHERE id = ?`
 

--- a/pkg/storage/sqlite/proplets.go
+++ b/pkg/storage/sqlite/proplets.go
@@ -128,13 +128,26 @@ func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, ali
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	rows, err := tx.QueryContext(ctx, `SELECT id, name, task_count, alive, alive_history, metadata FROM proplets`)
+	sinceArg := since.Format(time.RFC3339Nano)
+
+	whereClause := `WHERE alive_history IS NOT NULL AND json_array_length(alive_history) > 0 AND unixepoch(json_extract(alive_history, '$[#-1]')) >= unixepoch(?)`
+	if !alive {
+		whereClause = `WHERE alive_history IS NULL OR json_array_length(alive_history) = 0 OR unixepoch(json_extract(alive_history, '$[#-1]')) < unixepoch(?)`
+	}
+
+	var total uint64
+	if err := tx.GetContext(ctx, &total, "SELECT COUNT(*) FROM proplets "+whereClause, sinceArg); err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
+	}
+
+	query := `SELECT id, name, task_count, alive, alive_history, metadata FROM proplets ` + whereClause + ` LIMIT ? OFFSET ?`
+	rows, err := tx.QueryContext(ctx, query, sinceArg, limit, offset)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 	defer rows.Close()
 
-	var filtered []proplet.Proplet
+	proplets := make([]proplet.Proplet, 0)
 	for rows.Next() {
 		var dbp dbProplet
 		if err := rows.Scan(&dbp.ID, &dbp.Name, &dbp.TaskCount, &dbp.Alive, &dbp.AliveHistory, &dbp.Metadata); err != nil {
@@ -144,21 +157,13 @@ func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, ali
 		if err != nil {
 			return nil, 0, fmt.Errorf("%w: %w", ErrDBScan, err)
 		}
-		isAlive := len(p.AliveHistory) > 0 && !p.AliveHistory[len(p.AliveHistory)-1].Before(since)
-		if isAlive == alive {
-			filtered = append(filtered, p)
-		}
+		proplets = append(proplets, p)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
 
-	filteredTotal := uint64(len(filtered))
-	if offset >= filteredTotal {
-		return []proplet.Proplet{}, filteredTotal, nil
-	}
-
-	return filtered[offset:min(offset+limit, filteredTotal)], filteredTotal, nil
+	return proplets, total, nil
 }
 
 func (r *propletRepo) Delete(ctx context.Context, id string) error {

--- a/pkg/storage/sqlite/proplets.go
+++ b/pkg/storage/sqlite/proplets.go
@@ -126,7 +126,7 @@ func (r *propletRepo) ListByAlive(ctx context.Context, offset, limit uint64, ali
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w: %w", ErrDBQuery, err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	rows, err := tx.QueryContext(ctx, `SELECT id, name, task_count, alive, alive_history, metadata FROM proplets`)
 	if err != nil {

--- a/pkg/storage/sqlite/proplets_test.go
+++ b/pkg/storage/sqlite/proplets_test.go
@@ -1,0 +1,142 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/storage/sqlite"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPropletListByAlive(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	since := now.Add(-proplet.AliveTimeout)
+
+	cases := []struct {
+		desc          string
+		proplets      []proplet.Proplet
+		offset        uint64
+		limit         uint64
+		alive         bool
+		expectedTotal uint64
+		expectedLen   int
+	}{
+		{
+			desc: "list active proplets",
+			proplets: []proplet.Proplet{
+				{
+					ID:           uuid.NewString(),
+					Name:         "active-a",
+					AliveHistory: []time.Time{now.Add(-2 * time.Second)},
+				},
+				{
+					ID:           uuid.NewString(),
+					Name:         "active-b",
+					AliveHistory: []time.Time{now.Add(-1 * time.Second)},
+				},
+				{
+					ID:           uuid.NewString(),
+					Name:         "inactive-a",
+					AliveHistory: []time.Time{now.Add(-proplet.AliveTimeout - time.Second)},
+				},
+				{
+					ID:   uuid.NewString(),
+					Name: "inactive-b",
+				},
+			},
+			offset:        0,
+			limit:         10,
+			alive:         true,
+			expectedTotal: 2,
+			expectedLen:   2,
+		},
+		{
+			desc: "list inactive proplets",
+			proplets: []proplet.Proplet{
+				{
+					ID:           uuid.NewString(),
+					Name:         "active-a",
+					AliveHistory: []time.Time{now.Add(-2 * time.Second)},
+				},
+				{
+					ID:           uuid.NewString(),
+					Name:         "active-b",
+					AliveHistory: []time.Time{now.Add(-1 * time.Second)},
+				},
+				{
+					ID:           uuid.NewString(),
+					Name:         "inactive-a",
+					AliveHistory: []time.Time{now.Add(-proplet.AliveTimeout - time.Second)},
+				},
+				{
+					ID:   uuid.NewString(),
+					Name: "inactive-b",
+				},
+			},
+			offset:        0,
+			limit:         10,
+			alive:         false,
+			expectedTotal: 2,
+			expectedLen:   2,
+		},
+		{
+			desc: "paginate active proplets",
+			proplets: []proplet.Proplet{
+				{
+					ID:           uuid.NewString(),
+					Name:         uuid.NewString(),
+					AliveHistory: []time.Time{now},
+				},
+				{
+					ID:           uuid.NewString(),
+					Name:         uuid.NewString(),
+					AliveHistory: []time.Time{now},
+				},
+				{
+					ID:           uuid.NewString(),
+					Name:         uuid.NewString(),
+					AliveHistory: []time.Time{now},
+				},
+				{
+					ID:           uuid.NewString(),
+					Name:         uuid.NewString(),
+					AliveHistory: []time.Time{now},
+				},
+				{
+					ID:           uuid.NewString(),
+					Name:         uuid.NewString(),
+					AliveHistory: []time.Time{now},
+				},
+			},
+			offset:        1,
+			limit:         2,
+			alive:         true,
+			expectedTotal: 5,
+			expectedLen:   2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			repo := sqlite.NewPropletRepository(newTestDB(t))
+			ctx := context.Background()
+
+			for _, p := range tc.proplets {
+				require.NoError(t, repo.Create(ctx, p))
+			}
+
+			page, total, err := repo.ListByAlive(ctx, tc.offset, tc.limit, tc.alive, since)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedTotal, total)
+			assert.Len(t, page, tc.expectedLen)
+		})
+	}
+}

--- a/pkg/task/job_status_test.go
+++ b/pkg/task/job_status_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestJobStatusString(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		desc   string
 		status task.JobStatus
@@ -47,6 +49,8 @@ func TestJobStatusString(t *testing.T) {
 }
 
 func TestToJobStatus(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		desc   string
 		value  string

--- a/pkg/task/job_status_test.go
+++ b/pkg/task/job_status_test.go
@@ -1,0 +1,93 @@
+package task_test
+
+import (
+	"testing"
+
+	"github.com/absmach/propeller/pkg/task"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobStatusString(t *testing.T) {
+	cases := []struct {
+		desc   string
+		status task.JobStatus
+		value  string
+	}{
+		{
+			desc:   "pending status",
+			status: task.PendingStatus,
+			value:  task.JobStatusPending,
+		},
+		{
+			desc:   "running status",
+			status: task.RunningStatus,
+			value:  task.JobStatusRunning,
+		},
+		{
+			desc:   "completed status",
+			status: task.CompletedStatus,
+			value:  task.JobStatusCompleted,
+		},
+		{
+			desc:   "failed status",
+			status: task.FailedStatus,
+			value:  task.JobStatusFailed,
+		},
+		{
+			desc:   "unknown status",
+			status: task.JobStatus(100),
+			value:  task.JobStatusUnknown,
+		},
+	}
+
+	for _, tc := range cases {
+		got := tc.status.String()
+		assert.Equal(t, tc.value, got, "JobStatus.String() = %v, expected %v", got, tc.value)
+	}
+}
+
+func TestToJobStatus(t *testing.T) {
+	cases := []struct {
+		desc   string
+		value  string
+		status task.JobStatus
+		err    error
+	}{
+		{
+			desc:   "pending status",
+			value:  task.JobStatusPending,
+			status: task.PendingStatus,
+			err:    nil,
+		},
+		{
+			desc:   "running status",
+			value:  task.JobStatusRunning,
+			status: task.RunningStatus,
+			err:    nil,
+		},
+		{
+			desc:   "completed status",
+			value:  task.JobStatusCompleted,
+			status: task.CompletedStatus,
+			err:    nil,
+		},
+		{
+			desc:   "failed status",
+			value:  task.JobStatusFailed,
+			status: task.FailedStatus,
+			err:    nil,
+		},
+		{
+			desc:   "invalid status",
+			value:  "unknown",
+			status: task.JobStatus(0),
+			err:    task.ErrInvalidJobStatus,
+		},
+	}
+
+	for _, tc := range cases {
+		got, err := task.ToJobStatus(tc.value)
+		assert.Equal(t, tc.err, err, "ToJobStatus() error = %v, expected %v", err, tc.err)
+		assert.Equal(t, tc.status, got, "ToJobStatus() = %v, expected %v", got, tc.status)
+	}
+}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -88,6 +89,70 @@ const (
 	RunIfSuccess = "success"
 	RunIfFailure = "failure"
 )
+
+var ErrInvalidJobStatus = errors.New("invalid job status")
+
+type JobStatus uint8
+
+const (
+	PendingStatus JobStatus = iota
+	RunningStatus
+	CompletedStatus
+	FailedStatus
+)
+
+const (
+	JobStatusPending   = "pending"
+	JobStatusRunning   = "running"
+	JobStatusCompleted = "completed"
+	JobStatusFailed    = "failed"
+	JobStatusUnknown   = "unknown"
+)
+
+func (s JobStatus) String() string {
+	switch s {
+	case PendingStatus:
+		return JobStatusPending
+	case RunningStatus:
+		return JobStatusRunning
+	case CompletedStatus:
+		return JobStatusCompleted
+	case FailedStatus:
+		return JobStatusFailed
+	default:
+		return JobStatusUnknown
+	}
+}
+
+func ToJobStatus(status string) (JobStatus, error) {
+	switch status {
+	case JobStatusPending:
+		return PendingStatus, nil
+	case JobStatusRunning:
+		return RunningStatus, nil
+	case JobStatusCompleted:
+		return CompletedStatus, nil
+	case JobStatusFailed:
+		return FailedStatus, nil
+	default:
+		return JobStatus(0), ErrInvalidJobStatus
+	}
+}
+
+func (s JobStatus) State() State {
+	switch s {
+	case PendingStatus:
+		return Pending
+	case RunningStatus:
+		return Running
+	case CompletedStatus:
+		return Completed
+	case FailedStatus:
+		return Failed
+	default:
+		return Pending
+	}
+}
 
 type Task struct {
 	ID                string                     `json:"id"`


### PR DESCRIPTION
## What type of PR is this?

Feature - status-based filtering for proplets and jobs.

## What does this do?

- `GET /proplets?status=active|inactive` filters by liveness
- `GET /jobs?status=pending|running|completed|failed` filters by state
- `GET /tasks` returns 400 if `?status=` is passed
- SDK: `ListProplets` and `ListJobs` accept optional status param
- Invalid status values return 400, not 500

## Which issue(s) does this PR fix/relate to?

- Resolves #57. Supersedes #171 from @smithjilks.

## Have you included tests for your changes?

Yes - service-level and filter-pagination tests added.

## Did you document any new/modified features?

No - API is self-describing via query param validation errors.