### PR TITLE
PROP-88 -  Use Semantic Definition Format (SDF) for Data and Interactions of Things

### DIFF
--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -71,6 +71,25 @@ func getPropletAliveHistoryEndpoint(svc manager.Service) endpoint.Endpoint {
 	}
 }
 
+func getPropletSDFEndpoint(svc manager.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request any) (any, error) {
+		req, ok := request.(entityReq)
+		if !ok {
+			return propletSDFResponse{}, errors.Join(apiutil.ErrValidation, pkgerrors.ErrInvalidData)
+		}
+		if err := req.validate(); err != nil {
+			return propletSDFResponse{}, errors.Join(apiutil.ErrValidation, err)
+		}
+
+		doc, err := svc.GetPropletSDF(ctx, req.id)
+		if err != nil {
+			return propletSDFResponse{}, err
+		}
+
+		return propletSDFResponse{Document: doc}, nil
+	}
+}
+
 func deletePropletEndpoint(svc manager.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request any) (any, error) {
 		req, ok := request.(entityReq)

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -9,6 +9,7 @@ import (
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/task"
+	"github.com/google/uuid"
 )
 
 var errStatusFilterUnsupported = errors.New("status filter is not supported")
@@ -96,6 +97,10 @@ type entityReq struct {
 func (e *entityReq) validate() error {
 	if e.id == "" {
 		return apiutil.ErrMissingID
+	}
+
+	if _, err := uuid.Parse(e.id); err != nil {
+		return apiutil.ErrInvalidQueryParams
 	}
 
 	return nil

--- a/manager/api/responses.go
+++ b/manager/api/responses.go
@@ -6,11 +6,13 @@ import (
 	"github.com/absmach/magistrala"
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/absmach/propeller/pkg/task"
 )
 
 var (
 	_ magistrala.Response = (*propletResponse)(nil)
+	_ magistrala.Response = (*propletSDFResponse)(nil)
 	_ magistrala.Response = (*listpropletResponse)(nil)
 	_ magistrala.Response = (*propletAliveHistoryResponse)(nil)
 	_ magistrala.Response = (*taskResponse)(nil)
@@ -54,6 +56,22 @@ func (w propletResponse) Headers() map[string]string {
 
 func (w propletResponse) Empty() bool {
 	return w.deleted
+}
+
+type propletSDFResponse struct {
+	sdf.Document
+}
+
+func (r propletSDFResponse) Code() int {
+	return http.StatusOK
+}
+
+func (r propletSDFResponse) Headers() map[string]string {
+	return map[string]string{}
+}
+
+func (r propletSDFResponse) Empty() bool {
+	return false
 }
 
 type listpropletResponse struct {

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -51,6 +51,12 @@ func MakeHandler(svc manager.Service, logger *slog.Logger, instanceID string) ht
 				api.EncodeResponse,
 				opts...,
 			), "delete-proplet").ServeHTTP)
+			r.Get("/sdf", otelhttp.NewHandler(kithttp.NewServer(
+				getPropletSDFEndpoint(svc),
+				decodeEntityReq("propletID"),
+				api.EncodeResponse,
+				opts...,
+			), "get-proplet-sdf").ServeHTTP)
 			r.Get("/metrics", otelhttp.NewHandler(kithttp.NewServer(
 				getPropletMetricsEndpoint(svc),
 				decodeMetricsReq("propletID"),

--- a/manager/api/transport_test.go
+++ b/manager/api/transport_test.go
@@ -1,0 +1,97 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	managerapi "github.com/absmach/propeller/manager/api"
+	"github.com/absmach/propeller/manager/mocks"
+	pkgerrors "github.com/absmach/propeller/pkg/errors"
+	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newServer(t *testing.T) (*httptest.Server, *mocks.MockService) {
+	t.Helper()
+	svc := new(mocks.MockService)
+	handler := managerapi.MakeHandler(svc, slog.Default(), "test")
+
+	return httptest.NewServer(handler), svc
+}
+
+func TestGetPropletSDF(t *testing.T) {
+	t.Parallel()
+
+	validID := uuid.NewString()
+	validDoc := sdf.Document{
+		Info: sdf.Info{Title: "test", Version: "1.0"},
+	}
+
+	cases := []struct {
+		desc       string
+		propletID  string
+		svcDoc     sdf.Document
+		svcErr     error
+		wantStatus int
+		wantTitle  string
+	}{
+		{
+			desc:       "get SDF for existing proplet",
+			propletID:  validID,
+			svcDoc:     validDoc,
+			svcErr:     nil,
+			wantStatus: http.StatusOK,
+			wantTitle:  "test",
+		},
+		{
+			desc:       "get SDF for unknown proplet returns 404",
+			propletID:  uuid.NewString(),
+			svcDoc:     sdf.Document{},
+			svcErr:     pkgerrors.ErrNotFound,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			desc:       "get SDF with invalid proplet ID returns 500",
+			propletID:  "not-a-valid-uuid",
+			svcDoc:     sdf.Document{},
+			svcErr:     pkgerrors.ErrNotFound,
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			ts, svc := newServer(t)
+			defer ts.Close()
+
+			if tc.propletID != "" {
+				svc.On("GetPropletSDF", mock.Anything, tc.propletID).Return(tc.svcDoc, tc.svcErr)
+			}
+
+			reqURL := fmt.Sprintf("%s/proplets/%s/sdf", ts.URL, tc.propletID)
+			res, err := http.Get(reqURL)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			assert.Equal(t, tc.wantStatus, res.StatusCode)
+
+			if tc.wantStatus == http.StatusOK {
+				body, err := io.ReadAll(res.Body)
+				require.NoError(t, err)
+
+				var doc sdf.Document
+				require.NoError(t, json.Unmarshal(body, &doc))
+				assert.Equal(t, tc.wantTitle, doc.Info.Title)
+			}
+		})
+	}
+}

--- a/manager/api/transport_test.go
+++ b/manager/api/transport_test.go
@@ -59,11 +59,18 @@ func TestGetPropletSDF(t *testing.T) {
 			wantStatus: http.StatusNotFound,
 		},
 		{
-			desc:       "get SDF with invalid proplet ID returns 500",
+			desc:       "get SDF for non-existent proplet ID returns 404",
 			propletID:  "not-a-valid-uuid",
 			svcDoc:     sdf.Document{},
 			svcErr:     pkgerrors.ErrNotFound,
 			wantStatus: http.StatusNotFound,
+		},
+		{
+			desc:       "get SDF with empty proplet ID returns 400",
+			propletID:  "",
+			svcDoc:     sdf.Document{},
+			svcErr:     nil,
+			wantStatus: http.StatusBadRequest,
 		},
 	}
 

--- a/manager/api/transport_test.go
+++ b/manager/api/transport_test.go
@@ -12,6 +12,7 @@ import (
 	managerapi "github.com/absmach/propeller/manager/api"
 	"github.com/absmach/propeller/manager/mocks"
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
+	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -59,11 +60,9 @@ func TestGetPropletSDF(t *testing.T) {
 			wantStatus: http.StatusNotFound,
 		},
 		{
-			desc:       "get SDF for non-existent proplet ID returns 404",
+			desc:       "get SDF with invalid proplet ID returns 400",
 			propletID:  "not-a-valid-uuid",
-			svcDoc:     sdf.Document{},
-			svcErr:     pkgerrors.ErrNotFound,
-			wantStatus: http.StatusNotFound,
+			wantStatus: http.StatusBadRequest,
 		},
 		{
 			desc:       "get SDF with empty proplet ID returns 400",
@@ -81,7 +80,9 @@ func TestGetPropletSDF(t *testing.T) {
 			defer ts.Close()
 
 			if tc.propletID != "" {
-				svc.On("GetPropletSDF", mock.Anything, tc.propletID).Return(tc.svcDoc, tc.svcErr)
+				if _, err := uuid.Parse(tc.propletID); err == nil {
+					svc.On("GetPropletSDF", mock.Anything, tc.propletID).Return(tc.svcDoc, tc.svcErr)
+				}
 			}
 
 			reqURL := fmt.Sprintf("%s/proplets/%s/sdf", ts.URL, tc.propletID)
@@ -98,6 +99,68 @@ func TestGetPropletSDF(t *testing.T) {
 				var doc sdf.Document
 				require.NoError(t, json.Unmarshal(body, &doc))
 				assert.Equal(t, tc.wantTitle, doc.Info.Title)
+			}
+		})
+	}
+}
+
+func TestListProplets(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc       string
+		query      string
+		svcPage    proplet.PropletPage
+		svcErr     error
+		wantStatus int
+		wantTotal  uint64
+	}{
+		{
+			desc:       "list proplets with defaults",
+			query:      "",
+			svcPage:    proplet.PropletPage{Total: 2, Proplets: []proplet.Proplet{{ID: uuid.NewString(), Name: "p1"}, {ID: uuid.NewString(), Name: "p2"}}},
+			wantStatus: http.StatusOK,
+			wantTotal:  2,
+		},
+		{
+			desc:       "list proplets returns empty page",
+			query:      "",
+			svcPage:    proplet.PropletPage{},
+			wantStatus: http.StatusOK,
+			wantTotal:  0,
+		},
+		{
+			desc:       "list proplets with invalid offset returns 400",
+			query:      "?offset=abc",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			ts, svc := newServer(t)
+			defer ts.Close()
+
+			if tc.wantStatus != http.StatusBadRequest {
+				svc.On("ListProplets", mock.Anything, uint64(0), mock.AnythingOfType("uint64")).Return(tc.svcPage, tc.svcErr)
+			}
+
+			res, err := http.Get(ts.URL + "/proplets/" + tc.query)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			assert.Equal(t, tc.wantStatus, res.StatusCode)
+
+			if tc.wantStatus == http.StatusOK {
+				body, err := io.ReadAll(res.Body)
+				require.NoError(t, err)
+
+				var page struct {
+					Total uint64 `json:"total"`
+				}
+				require.NoError(t, json.Unmarshal(body, &page))
+				assert.Equal(t, tc.wantTotal, page.Total)
 			}
 		})
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/absmach/propeller/pkg/task"
 )
 
 type Service interface {
 	GetProplet(ctx context.Context, propletID string) (proplet.Proplet, error)
+	GetPropletSDF(ctx context.Context, propletID string) (sdf.Document, error)
 	ListProplets(ctx context.Context, offset, limit uint64, status string) (proplet.PropletPage, error)
 	SelectProplet(ctx context.Context, task task.Task) (proplet.Proplet, error)
 	DeleteProplet(ctx context.Context, propletID string) error

--- a/manager/middleware/logging.go
+++ b/manager/middleware/logging.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/absmach/propeller/pkg/task"
 )
 
@@ -40,6 +41,26 @@ func (lm *loggingMiddleware) GetProplet(ctx context.Context, id string) (resp pr
 	}(time.Now())
 
 	return lm.svc.GetProplet(ctx, id)
+}
+
+func (lm *loggingMiddleware) GetPropletSDF(ctx context.Context, id string) (resp sdf.Document, err error) {
+	defer func(begin time.Time) {
+		args := []any{
+			slog.String("duration", time.Since(begin).String()),
+			slog.Group("proplet",
+				slog.String("id", id),
+			),
+		}
+		if err != nil {
+			args = append(args, slog.Any("error", err))
+			lm.logger.Warn("Get proplet SDF failed", args...)
+
+			return
+		}
+		lm.logger.Info("Get proplet SDF completed successfully", args...)
+	}(time.Now())
+
+	return lm.svc.GetPropletSDF(ctx, id)
 }
 
 func (lm *loggingMiddleware) ListProplets(ctx context.Context, offset, limit uint64, status string) (resp proplet.PropletPage, err error) {

--- a/manager/middleware/metrics.go
+++ b/manager/middleware/metrics.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/absmach/propeller/pkg/task"
 	"github.com/go-kit/kit/metrics"
 )
@@ -33,6 +34,15 @@ func (mm *metricsMiddleware) GetProplet(ctx context.Context, id string) (proplet
 	}(time.Now())
 
 	return mm.svc.GetProplet(ctx, id)
+}
+
+func (mm *metricsMiddleware) GetPropletSDF(ctx context.Context, id string) (sdf.Document, error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "get-proplet-sdf").Add(1)
+		mm.latency.With("method", "get-proplet-sdf").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.GetPropletSDF(ctx, id)
 }
 
 func (mm *metricsMiddleware) ListProplets(ctx context.Context, offset, limit uint64, status string) (proplet.PropletPage, error) {

--- a/manager/middleware/tracing.go
+++ b/manager/middleware/tracing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/absmach/propeller/pkg/task"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -28,6 +29,15 @@ func (tm *tracing) GetProplet(ctx context.Context, id string) (resp proplet.Prop
 	defer span.End()
 
 	return tm.svc.GetProplet(ctx, id)
+}
+
+func (tm *tracing) GetPropletSDF(ctx context.Context, id string) (resp sdf.Document, err error) {
+	ctx, span := tm.tracer.Start(ctx, "get-proplet-sdf", trace.WithAttributes(
+		attribute.String("id", id),
+	))
+	defer span.End()
+
+	return tm.svc.GetPropletSDF(ctx, id)
 }
 
 func (tm *tracing) ListProplets(ctx context.Context, offset, limit uint64, status string) (resp proplet.PropletPage, err error) {

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/absmach/propeller/pkg/task"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -701,6 +702,64 @@ func (_c *MockService_GetProplet_Call) Return(proplet1 proplet.Proplet, err erro
 }
 
 func (_c *MockService_GetProplet_Call) RunAndReturn(run func(ctx context.Context, propletID string) (proplet.Proplet, error)) *MockService_GetProplet_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+func (_mock *MockService) GetPropletSDF(ctx context.Context, propletID string) (sdf.Document, error) {
+	ret := _mock.Called(ctx, propletID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPropletSDF")
+	}
+
+	var r0 sdf.Document
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (sdf.Document, error)); ok {
+		return returnFunc(ctx, propletID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) sdf.Document); ok {
+		r0 = returnFunc(ctx, propletID)
+	} else {
+		r0 = ret.Get(0).(sdf.Document)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, propletID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+type MockService_GetPropletSDF_Call struct {
+	*mock.Call
+}
+
+func (_e *MockService_Expecter) GetPropletSDF(ctx interface{}, propletID interface{}) *MockService_GetPropletSDF_Call {
+	return &MockService_GetPropletSDF_Call{Call: _e.mock.On("GetPropletSDF", ctx, propletID)}
+}
+
+func (_c *MockService_GetPropletSDF_Call) Run(run func(ctx context.Context, propletID string)) *MockService_GetPropletSDF_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockService_GetPropletSDF_Call) Return(doc sdf.Document, err error) *MockService_GetPropletSDF_Call {
+	_c.Call.Return(doc, err)
+	return _c
+}
+
+func (_c *MockService_GetPropletSDF_Call) RunAndReturn(run func(ctx context.Context, propletID string) (sdf.Document, error)) *MockService_GetPropletSDF_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -706,6 +706,7 @@ func (_c *MockService_GetProplet_Call) RunAndReturn(run func(ctx context.Context
 	return _c
 }
 
+// GetPropletSDF provides a mock function for the type MockService
 func (_mock *MockService) GetPropletSDF(ctx context.Context, propletID string) (sdf.Document, error) {
 	ret := _mock.Called(ctx, propletID)
 

--- a/manager/service.go
+++ b/manager/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/absmach/propeller/pkg/mqtt"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/scheduler"
+	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/absmach/propeller/pkg/storage"
 	"github.com/absmach/propeller/pkg/task"
 	"github.com/google/uuid"
@@ -114,6 +115,15 @@ func (svc *service) GetProplet(ctx context.Context, propletID string) (proplet.P
 	w.SetAlive()
 
 	return w, nil
+}
+
+func (svc *service) GetPropletSDF(ctx context.Context, propletID string) (sdf.Document, error) {
+	p, err := svc.GetProplet(ctx, propletID)
+	if err != nil {
+		return sdf.Document{}, err
+	}
+
+	return sdf.PropletDocument(p), nil
 }
 
 func (svc *service) ListProplets(ctx context.Context, offset, limit uint64, status string) (proplet.PropletPage, error) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/absmach/magistrala"
 	apiutil "github.com/absmach/magistrala/api/http/util"
+
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
 )
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/absmach/magistrala"
 	apiutil "github.com/absmach/magistrala/api/http/util"
-
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
 )
 

--- a/pkg/sdf/proplet.go
+++ b/pkg/sdf/proplet.go
@@ -59,8 +59,7 @@ func PropletDocument(p proplet.Proplet) Document {
 					"stop_task": {
 						Description: "Stop a running task on this proplet",
 						SdfInputData: &DataAfford{
-							Description: "Identifier of the task to stop",
-							Type:        "string",
+							SdfRef: "#/sdfThing/Proplet/sdfData/TaskStop",
 						},
 					},
 				},
@@ -112,6 +111,14 @@ func PropletDocument(p proplet.Proplet) Document {
 							"kbs_resource_path": {Type: "string"},
 						},
 					},
+					"TaskStop": {
+						Description: "Payload used to stop a running task on the proplet",
+						Type:        "object",
+						Required:    []string{"id"},
+						Properties: map[string]DataAfford{
+							"id": {Type: "string", Description: "Identifier of the task to stop"},
+						},
+					},
 					"HeartbeatPayload": {
 						Description: "Payload of a proplet heartbeat event",
 						Type:        "object",
@@ -129,12 +136,21 @@ func PropletDocument(p proplet.Proplet) Document {
 							"task_id":    {Type: "string"},
 							"proplet_id": {Type: "string"},
 							"state":      {Type: "string", Enum: []any{"Completed", "Failed", "Skipped", "Interrupted"}},
-							"results":    {Description: "Arbitrary task output; schema varies by task"},
-							"error":      {Type: "string"},
+							"results": {
+								Type:        "object",
+								Description: "Key-value output produced by the task; keys and value types depend on the wasm module",
+							},
+							"error": {Type: "string"},
 						},
 					},
 				},
 			},
 		},
 	}
+}
+
+func minPtr() *float64 {
+	v := float64(0)
+
+	return &v
 }

--- a/pkg/sdf/proplet.go
+++ b/pkg/sdf/proplet.go
@@ -2,11 +2,13 @@ package sdf
 
 import "github.com/absmach/propeller/pkg/proplet"
 
+const schemaVersion = "1.0"
+
 func PropletDocument(p proplet.Proplet) Document {
 	return Document{
 		Info: Info{
 			Title:   "Propeller Proplet: " + p.Name + " (" + p.ID + ")",
-			Version: "1.0",
+			Version: schemaVersion,
 			License: "Apache-2.0",
 		},
 		SdfThing: map[string]ThingAfford{

--- a/pkg/sdf/proplet.go
+++ b/pkg/sdf/proplet.go
@@ -2,6 +2,8 @@ package sdf
 
 import "github.com/absmach/propeller/pkg/proplet"
 
+// schemaVersion is the version of this proplet SDF schema definition, not the SDF spec version.
+// Increment it when the shape of the generated document changes in a breaking way.
 const schemaVersion = "1.0"
 
 func PropletDocument(p proplet.Proplet) Document {

--- a/pkg/sdf/proplet.go
+++ b/pkg/sdf/proplet.go
@@ -1,0 +1,140 @@
+package sdf
+
+import "github.com/absmach/propeller/pkg/proplet"
+
+func PropletDocument(p proplet.Proplet) Document {
+	return Document{
+		Info: Info{
+			Title:   "Propeller Proplet: " + p.Name + " (" + p.ID + ")",
+			Version: "1.0",
+			License: "Apache-2.0",
+		},
+		SdfThing: map[string]ThingAfford{
+			"Proplet": {
+				Description: "A Propeller proplet — an edge node that executes WebAssembly tasks",
+				SdfProperty: map[string]PropertyAfford{
+					"id": {
+						DataAfford: DataAfford{
+							Description: "Unique proplet identifier",
+							Type:        "string",
+							ReadOnly:    true,
+						},
+					},
+					"name": {
+						DataAfford: DataAfford{
+							Description: "Human-readable proplet name",
+							Type:        "string",
+						},
+					},
+					"alive": {
+						DataAfford: DataAfford{
+							Description: "Whether the proplet sent a heartbeat within the liveness window",
+							Type:        "boolean",
+							ReadOnly:    true,
+						},
+						Observable: true,
+					},
+					"task_count": {
+						DataAfford: DataAfford{
+							Description: "Number of tasks currently running on this proplet",
+							Type:        "integer",
+							ReadOnly:    true,
+							Minimum:     minPtr(),
+						},
+						Observable: true,
+					},
+					"metadata": {
+						DataAfford: DataAfford{
+							SdfRef: "#/sdfThing/Proplet/sdfData/PropletMetadata",
+						},
+					},
+				},
+				SdfAction: map[string]ActionAfford{
+					"start_task": {
+						Description: "Dispatch a WebAssembly task to this proplet",
+						SdfInputData: &DataAfford{
+							SdfRef: "#/sdfThing/Proplet/sdfData/TaskDispatch",
+						},
+					},
+					"stop_task": {
+						Description: "Stop a running task on this proplet",
+						SdfInputData: &DataAfford{
+							Description: "Identifier of the task to stop",
+							Type:        "string",
+						},
+					},
+				},
+				SdfEvent: map[string]EventAfford{
+					"heartbeat": {
+						Description: "Periodic liveness signal from the proplet",
+						SdfOutputData: &DataAfford{
+							SdfRef: "#/sdfThing/Proplet/sdfData/HeartbeatPayload",
+						},
+					},
+					"task_result": {
+						Description: "Emitted when a task finishes (success or failure)",
+						SdfOutputData: &DataAfford{
+							SdfRef: "#/sdfThing/Proplet/sdfData/TaskResult",
+						},
+					},
+				},
+				SdfData: map[string]DataAfford{
+					"PropletMetadata": {
+						Description: "Static metadata reported by the proplet at registration",
+						Type:        "object",
+						Properties: map[string]DataAfford{
+							"description":        {Type: "string"},
+							"tags":               {Type: "array", Items: &DataAfford{Type: "string"}},
+							"location":           {Type: "string"},
+							"ip":                 {Type: "string"},
+							"environment":        {Type: "string"},
+							"os":                 {Type: "string"},
+							"hostname":           {Type: "string"},
+							"cpu_arch":           {Type: "string"},
+							"total_memory_bytes": {Type: "integer", Minimum: minPtr()},
+							"proplet_version":    {Type: "string"},
+							"wasm_runtime":       {Type: "string"},
+						},
+					},
+					"TaskDispatch": {
+						Description: "Payload used to dispatch a task to the proplet",
+						Type:        "object",
+						Required:    []string{"id", "name"},
+						Properties: map[string]DataAfford{
+							"id":                {Type: "string"},
+							"name":              {Type: "string"},
+							"image_url":         {Type: "string"},
+							"cli_args":          {Type: "array", Items: &DataAfford{Type: "string"}},
+							"inputs":            {Type: "array", Items: &DataAfford{Type: "string"}},
+							"env":               {Type: "object", AdditionalProperties: &DataAfford{Type: "string"}},
+							"daemon":            {Type: "boolean"},
+							"encrypted":         {Type: "boolean"},
+							"kbs_resource_path": {Type: "string"},
+						},
+					},
+					"HeartbeatPayload": {
+						Description: "Payload of a proplet heartbeat event",
+						Type:        "object",
+						Properties: map[string]DataAfford{
+							"proplet_id": {Type: "string"},
+							"name":       {Type: "string"},
+							"task_count": {Type: "integer", Minimum: minPtr()},
+							"alive":      {Type: "boolean"},
+						},
+					},
+					"TaskResult": {
+						Description: "Result payload emitted after a task completes",
+						Type:        "object",
+						Properties: map[string]DataAfford{
+							"task_id":    {Type: "string"},
+							"proplet_id": {Type: "string"},
+							"state":      {Type: "string", Enum: []any{"Completed", "Failed", "Skipped", "Interrupted"}},
+							"results":    {Description: "Arbitrary task output; schema varies by task"},
+							"error":      {Type: "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/sdf/proplet_test.go
+++ b/pkg/sdf/proplet_test.go
@@ -82,71 +82,37 @@ func TestPropletDocument(t *testing.T) {
 func TestPropletDocumentTaskResultStateEnum(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		desc       string
-		proplet    proplet.Proplet
-		wantStates []string
-	}{
-		{
-			desc:       "task result state enum contains all expected values",
-			proplet:    proplet.Proplet{ID: "abc-123", Name: "my-proplet"},
-			wantStates: []string{"Completed", "Failed", "Skipped", "Interrupted"},
-		},
+	doc := sdf.PropletDocument(proplet.Proplet{ID: "abc-123", Name: "my-proplet"})
+	thing := doc.SdfThing["Proplet"]
+
+	result, ok := thing.SdfData["TaskResult"]
+	assert.True(t, ok, "expected sdfData['TaskResult'] to exist")
+
+	stateAfford, ok := result.Properties["state"]
+	assert.True(t, ok, "expected TaskResult.properties.state to exist")
+
+	enumSet := make(map[string]bool)
+	for _, v := range stateAfford.Enum {
+		s, ok := v.(string)
+		assert.True(t, ok, "expected state enum value to be string, got %T", v)
+		enumSet[s] = true
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
-
-			doc := sdf.PropletDocument(tc.proplet)
-			thing := doc.SdfThing["Proplet"]
-
-			result, ok := thing.SdfData["TaskResult"]
-			assert.True(t, ok, "expected sdfData['TaskResult'] to exist")
-
-			stateAfford, ok := result.Properties["state"]
-			assert.True(t, ok, "expected TaskResult.properties.state to exist")
-
-			enumSet := make(map[string]bool)
-			for _, v := range stateAfford.Enum {
-				s, ok := v.(string)
-				assert.True(t, ok, "expected state enum value to be string, got %T", v)
-				enumSet[s] = true
-			}
-
-			for _, s := range tc.wantStates {
-				assert.True(t, enumSet[s], "missing state enum value %q", s)
-			}
-		})
+	for _, s := range []string{"Completed", "Failed", "Skipped", "Interrupted"} {
+		assert.True(t, enumSet[s], "missing state enum value %q", s)
 	}
 }
 
 func TestPropletDocumentMinimumPointerNotAliased(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		desc    string
-		proplet proplet.Proplet
-	}{
-		{
-			desc:    "minimum pointers are not aliased across fields",
-			proplet: proplet.Proplet{ID: "x", Name: "n"},
-		},
-	}
+	doc := sdf.PropletDocument(proplet.Proplet{ID: "x", Name: "n"})
+	thing := doc.SdfThing["Proplet"]
 
-	for _, tc := range cases {
-		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
+	taskCount := thing.SdfProperty["task_count"]
+	heartbeat := thing.SdfData["HeartbeatPayload"]
 
-			doc := sdf.PropletDocument(tc.proplet)
-			thing := doc.SdfThing["Proplet"]
-
-			taskCount := thing.SdfProperty["task_count"]
-			heartbeat := thing.SdfData["HeartbeatPayload"]
-
-			assert.NotNil(t, taskCount.Minimum)
-			assert.NotNil(t, heartbeat.Properties["task_count"].Minimum)
-			assert.NotSame(t, taskCount.Minimum, heartbeat.Properties["task_count"].Minimum, "Minimum pointers must not be aliased")
-		})
-	}
+	assert.NotNil(t, taskCount.Minimum)
+	assert.NotNil(t, heartbeat.Properties["task_count"].Minimum)
+	assert.NotSame(t, taskCount.Minimum, heartbeat.Properties["task_count"].Minimum, "Minimum pointers must not be aliased")
 }

--- a/pkg/sdf/proplet_test.go
+++ b/pkg/sdf/proplet_test.go
@@ -27,7 +27,7 @@ func TestPropletDocument(t *testing.T) {
 			wantProperties:  []string{"id", "name", "alive", "task_count", "metadata"},
 			wantActions:     []string{"start_task", "stop_task"},
 			wantEvents:      []string{"heartbeat", "task_result"},
-			wantSdfDataKeys: []string{"PropletMetadata", "TaskDispatch", "HeartbeatPayload", "TaskResult"},
+			wantSdfDataKeys: []string{"PropletMetadata", "TaskDispatch", "TaskStop", "HeartbeatPayload", "TaskResult"},
 		},
 		{
 			desc:            "proplet with empty name",
@@ -36,7 +36,7 @@ func TestPropletDocument(t *testing.T) {
 			wantProperties:  []string{"id", "name", "alive", "task_count", "metadata"},
 			wantActions:     []string{"start_task", "stop_task"},
 			wantEvents:      []string{"heartbeat", "task_result"},
-			wantSdfDataKeys: []string{"PropletMetadata", "TaskDispatch", "HeartbeatPayload", "TaskResult"},
+			wantSdfDataKeys: []string{"PropletMetadata", "TaskDispatch", "TaskStop", "HeartbeatPayload", "TaskResult"},
 		},
 	}
 

--- a/pkg/sdf/proplet_test.go
+++ b/pkg/sdf/proplet_test.go
@@ -1,7 +1,6 @@
 package sdf_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/absmach/propeller/pkg/proplet"
@@ -10,6 +9,8 @@ import (
 )
 
 func TestPropletDocument(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		desc            string
 		proplet         proplet.Proplet
@@ -20,34 +21,36 @@ func TestPropletDocument(t *testing.T) {
 		wantSdfDataKeys []string
 	}{
 		{
-			desc:           "full proplet with name and id",
-			proplet:        proplet.Proplet{ID: "abc-123", Name: "my-proplet"},
-			wantTitleHasID: true,
-			wantProperties: []string{"id", "name", "alive", "task_count", "metadata"},
-			wantActions:    []string{"start_task", "stop_task"},
-			wantEvents:     []string{"heartbeat", "task_result"},
+			desc:            "full proplet with name and id",
+			proplet:         proplet.Proplet{ID: "abc-123", Name: "my-proplet"},
+			wantTitleHasID:  true,
+			wantProperties:  []string{"id", "name", "alive", "task_count", "metadata"},
+			wantActions:     []string{"start_task", "stop_task"},
+			wantEvents:      []string{"heartbeat", "task_result"},
 			wantSdfDataKeys: []string{"PropletMetadata", "TaskDispatch", "HeartbeatPayload", "TaskResult"},
 		},
 		{
-			desc:           "proplet with empty name",
-			proplet:        proplet.Proplet{ID: "xyz-456", Name: ""},
-			wantTitleHasID: true,
-			wantProperties: []string{"id", "name", "alive", "task_count", "metadata"},
-			wantActions:    []string{"start_task", "stop_task"},
-			wantEvents:     []string{"heartbeat", "task_result"},
+			desc:            "proplet with empty name",
+			proplet:         proplet.Proplet{ID: "xyz-456", Name: ""},
+			wantTitleHasID:  true,
+			wantProperties:  []string{"id", "name", "alive", "task_count", "metadata"},
+			wantActions:     []string{"start_task", "stop_task"},
+			wantEvents:      []string{"heartbeat", "task_result"},
 			wantSdfDataKeys: []string{"PropletMetadata", "TaskDispatch", "HeartbeatPayload", "TaskResult"},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
 			doc := sdf.PropletDocument(tc.proplet)
 
 			assert.NotEmpty(t, doc.Info.Title)
 			assert.NotEmpty(t, doc.Info.Version)
 
 			if tc.wantTitleHasID {
-				assert.True(t, strings.Contains(doc.Info.Title, tc.proplet.ID), "expected title to contain proplet ID %q, got %q", tc.proplet.ID, doc.Info.Title)
+				assert.Contains(t, doc.Info.Title, tc.proplet.ID, "expected title to contain proplet ID %q, got %q", tc.proplet.ID, doc.Info.Title)
 			}
 
 			thing, ok := doc.SdfThing["Proplet"]
@@ -77,10 +80,12 @@ func TestPropletDocument(t *testing.T) {
 }
 
 func TestPropletDocumentTaskResultStateEnum(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
-		desc        string
-		proplet     proplet.Proplet
-		wantStates  []string
+		desc       string
+		proplet    proplet.Proplet
+		wantStates []string
 	}{
 		{
 			desc:       "task result state enum contains all expected values",
@@ -91,6 +96,8 @@ func TestPropletDocumentTaskResultStateEnum(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
 			doc := sdf.PropletDocument(tc.proplet)
 			thing := doc.SdfThing["Proplet"]
 
@@ -115,6 +122,8 @@ func TestPropletDocumentTaskResultStateEnum(t *testing.T) {
 }
 
 func TestPropletDocumentMinimumPointerNotAliased(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		desc    string
 		proplet proplet.Proplet
@@ -127,6 +136,8 @@ func TestPropletDocumentMinimumPointerNotAliased(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
 			doc := sdf.PropletDocument(tc.proplet)
 			thing := doc.SdfThing["Proplet"]
 

--- a/pkg/sdf/proplet_test.go
+++ b/pkg/sdf/proplet_test.go
@@ -1,0 +1,141 @@
+package sdf_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/sdf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPropletDocument(t *testing.T) {
+	cases := []struct {
+		desc            string
+		proplet         proplet.Proplet
+		wantTitleHasID  bool
+		wantProperties  []string
+		wantActions     []string
+		wantEvents      []string
+		wantSdfDataKeys []string
+	}{
+		{
+			desc:           "full proplet with name and id",
+			proplet:        proplet.Proplet{ID: "abc-123", Name: "my-proplet"},
+			wantTitleHasID: true,
+			wantProperties: []string{"id", "name", "alive", "task_count", "metadata"},
+			wantActions:    []string{"start_task", "stop_task"},
+			wantEvents:     []string{"heartbeat", "task_result"},
+			wantSdfDataKeys: []string{"PropletMetadata", "TaskDispatch", "HeartbeatPayload", "TaskResult"},
+		},
+		{
+			desc:           "proplet with empty name",
+			proplet:        proplet.Proplet{ID: "xyz-456", Name: ""},
+			wantTitleHasID: true,
+			wantProperties: []string{"id", "name", "alive", "task_count", "metadata"},
+			wantActions:    []string{"start_task", "stop_task"},
+			wantEvents:     []string{"heartbeat", "task_result"},
+			wantSdfDataKeys: []string{"PropletMetadata", "TaskDispatch", "HeartbeatPayload", "TaskResult"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			doc := sdf.PropletDocument(tc.proplet)
+
+			assert.NotEmpty(t, doc.Info.Title)
+			assert.NotEmpty(t, doc.Info.Version)
+
+			if tc.wantTitleHasID {
+				assert.True(t, strings.Contains(doc.Info.Title, tc.proplet.ID), "expected title to contain proplet ID %q, got %q", tc.proplet.ID, doc.Info.Title)
+			}
+
+			thing, ok := doc.SdfThing["Proplet"]
+			assert.True(t, ok, "expected SdfThing['Proplet'] to exist")
+
+			for _, key := range tc.wantProperties {
+				_, ok := thing.SdfProperty[key]
+				assert.True(t, ok, "expected sdfProperty[%q] to exist", key)
+			}
+
+			for _, key := range tc.wantActions {
+				_, ok := thing.SdfAction[key]
+				assert.True(t, ok, "expected sdfAction[%q] to exist", key)
+			}
+
+			for _, key := range tc.wantEvents {
+				_, ok := thing.SdfEvent[key]
+				assert.True(t, ok, "expected sdfEvent[%q] to exist", key)
+			}
+
+			for _, key := range tc.wantSdfDataKeys {
+				_, ok := thing.SdfData[key]
+				assert.True(t, ok, "expected sdfData[%q] to exist", key)
+			}
+		})
+	}
+}
+
+func TestPropletDocumentTaskResultStateEnum(t *testing.T) {
+	cases := []struct {
+		desc        string
+		proplet     proplet.Proplet
+		wantStates  []string
+	}{
+		{
+			desc:       "task result state enum contains all expected values",
+			proplet:    proplet.Proplet{ID: "abc-123", Name: "my-proplet"},
+			wantStates: []string{"Completed", "Failed", "Skipped", "Interrupted"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			doc := sdf.PropletDocument(tc.proplet)
+			thing := doc.SdfThing["Proplet"]
+
+			result, ok := thing.SdfData["TaskResult"]
+			assert.True(t, ok, "expected sdfData['TaskResult'] to exist")
+
+			stateAfford, ok := result.Properties["state"]
+			assert.True(t, ok, "expected TaskResult.properties.state to exist")
+
+			enumSet := make(map[string]bool)
+			for _, v := range stateAfford.Enum {
+				s, ok := v.(string)
+				assert.True(t, ok, "expected state enum value to be string, got %T", v)
+				enumSet[s] = true
+			}
+
+			for _, s := range tc.wantStates {
+				assert.True(t, enumSet[s], "missing state enum value %q", s)
+			}
+		})
+	}
+}
+
+func TestPropletDocumentMinimumPointerNotAliased(t *testing.T) {
+	cases := []struct {
+		desc    string
+		proplet proplet.Proplet
+	}{
+		{
+			desc:    "minimum pointers are not aliased across fields",
+			proplet: proplet.Proplet{ID: "x", Name: "n"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			doc := sdf.PropletDocument(tc.proplet)
+			thing := doc.SdfThing["Proplet"]
+
+			taskCount := thing.SdfProperty["task_count"]
+			heartbeat := thing.SdfData["HeartbeatPayload"]
+
+			assert.NotNil(t, taskCount.Minimum)
+			assert.NotNil(t, heartbeat.Properties["task_count"].Minimum)
+			assert.NotSame(t, taskCount.Minimum, heartbeat.Properties["task_count"].Minimum, "Minimum pointers must not be aliased")
+		})
+	}
+}

--- a/pkg/sdf/sdf.go
+++ b/pkg/sdf/sdf.go
@@ -35,6 +35,7 @@ type DataAfford struct {
 
 type PropertyAfford struct {
 	DataAfford
+
 	Observable bool `json:"observable,omitempty"`
 }
 
@@ -68,5 +69,6 @@ type ThingAfford struct {
 
 func minPtr() *float64 {
 	v := float64(0)
+
 	return &v
 }

--- a/pkg/sdf/sdf.go
+++ b/pkg/sdf/sdf.go
@@ -49,14 +49,6 @@ type EventAfford struct {
 	SdfOutputData *DataAfford `json:"sdfOutputData,omitempty"`
 }
 
-type ObjectAfford struct {
-	Description string                    `json:"description,omitempty"`
-	SdfProperty map[string]PropertyAfford `json:"sdfProperty,omitempty"`
-	SdfAction   map[string]ActionAfford   `json:"sdfAction,omitempty"`
-	SdfEvent    map[string]EventAfford    `json:"sdfEvent,omitempty"`
-	SdfData     map[string]DataAfford     `json:"sdfData,omitempty"`
-}
-
 type ThingAfford struct {
 	Description string                    `json:"description,omitempty"`
 	SdfProperty map[string]PropertyAfford `json:"sdfProperty,omitempty"`
@@ -64,3 +56,5 @@ type ThingAfford struct {
 	SdfEvent    map[string]EventAfford    `json:"sdfEvent,omitempty"`
 	SdfData     map[string]DataAfford     `json:"sdfData,omitempty"`
 }
+
+type ObjectAfford = ThingAfford

--- a/pkg/sdf/sdf.go
+++ b/pkg/sdf/sdf.go
@@ -56,5 +56,3 @@ type ThingAfford struct {
 	SdfEvent    map[string]EventAfford    `json:"sdfEvent,omitempty"`
 	SdfData     map[string]DataAfford     `json:"sdfData,omitempty"`
 }
-
-type ObjectAfford = ThingAfford

--- a/pkg/sdf/sdf.go
+++ b/pkg/sdf/sdf.go
@@ -7,7 +7,6 @@ type Document struct {
 	SdfProperty      map[string]PropertyAfford `json:"sdfProperty,omitempty"`
 	SdfAction        map[string]ActionAfford   `json:"sdfAction,omitempty"`
 	SdfEvent         map[string]EventAfford    `json:"sdfEvent,omitempty"`
-	SdfObject        map[string]ObjectAfford   `json:"sdfObject,omitempty"`
 	SdfThing         map[string]ThingAfford    `json:"sdfThing,omitempty"`
 	SdfData          map[string]DataAfford     `json:"sdfData,omitempty"`
 }
@@ -63,12 +62,5 @@ type ThingAfford struct {
 	SdfProperty map[string]PropertyAfford `json:"sdfProperty,omitempty"`
 	SdfAction   map[string]ActionAfford   `json:"sdfAction,omitempty"`
 	SdfEvent    map[string]EventAfford    `json:"sdfEvent,omitempty"`
-	SdfObject   map[string]ObjectAfford   `json:"sdfObject,omitempty"`
 	SdfData     map[string]DataAfford     `json:"sdfData,omitempty"`
-}
-
-func minPtr() *float64 {
-	v := float64(0)
-
-	return &v
 }

--- a/pkg/sdf/sdf.go
+++ b/pkg/sdf/sdf.go
@@ -1,0 +1,72 @@
+package sdf
+
+type Document struct {
+	Info             Info                      `json:"info"`
+	Namespace        map[string]string         `json:"namespace,omitempty"`
+	DefaultNamespace string                    `json:"defaultNamespace,omitempty"`
+	SdfProperty      map[string]PropertyAfford `json:"sdfProperty,omitempty"`
+	SdfAction        map[string]ActionAfford   `json:"sdfAction,omitempty"`
+	SdfEvent         map[string]EventAfford    `json:"sdfEvent,omitempty"`
+	SdfObject        map[string]ObjectAfford   `json:"sdfObject,omitempty"`
+	SdfThing         map[string]ThingAfford    `json:"sdfThing,omitempty"`
+	SdfData          map[string]DataAfford     `json:"sdfData,omitempty"`
+}
+
+type Info struct {
+	Title     string `json:"title"`
+	Version   string `json:"version"`
+	Copyright string `json:"copyright,omitempty"`
+	License   string `json:"license,omitempty"`
+}
+
+type DataAfford struct {
+	Description          string                `json:"description,omitempty"`
+	Type                 string                `json:"type,omitempty"`
+	SdfRef               string                `json:"sdfRef,omitempty"`
+	Properties           map[string]DataAfford `json:"properties,omitempty"`
+	AdditionalProperties *DataAfford           `json:"additionalProperties,omitempty"`
+	Items                *DataAfford           `json:"items,omitempty"`
+	ReadOnly             bool                  `json:"readOnly,omitempty"`
+	Minimum              *float64              `json:"minimum,omitempty"`
+	Maximum              *float64              `json:"maximum,omitempty"`
+	Enum                 []any                 `json:"enum,omitempty"`
+	Required             []string              `json:"required,omitempty"`
+}
+
+type PropertyAfford struct {
+	DataAfford
+	Observable bool `json:"observable,omitempty"`
+}
+
+type ActionAfford struct {
+	Description   string      `json:"description,omitempty"`
+	SdfInputData  *DataAfford `json:"sdfInputData,omitempty"`
+	SdfOutputData *DataAfford `json:"sdfOutputData,omitempty"`
+}
+
+type EventAfford struct {
+	Description   string      `json:"description,omitempty"`
+	SdfOutputData *DataAfford `json:"sdfOutputData,omitempty"`
+}
+
+type ObjectAfford struct {
+	Description string                    `json:"description,omitempty"`
+	SdfProperty map[string]PropertyAfford `json:"sdfProperty,omitempty"`
+	SdfAction   map[string]ActionAfford   `json:"sdfAction,omitempty"`
+	SdfEvent    map[string]EventAfford    `json:"sdfEvent,omitempty"`
+	SdfData     map[string]DataAfford     `json:"sdfData,omitempty"`
+}
+
+type ThingAfford struct {
+	Description string                    `json:"description,omitempty"`
+	SdfProperty map[string]PropertyAfford `json:"sdfProperty,omitempty"`
+	SdfAction   map[string]ActionAfford   `json:"sdfAction,omitempty"`
+	SdfEvent    map[string]EventAfford    `json:"sdfEvent,omitempty"`
+	SdfObject   map[string]ObjectAfford   `json:"sdfObject,omitempty"`
+	SdfData     map[string]DataAfford     `json:"sdfData,omitempty"`
+}
+
+func minPtr() *float64 {
+	v := float64(0)
+	return &v
+}

--- a/pkg/sdk/proplet.go
+++ b/pkg/sdk/proplet.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -30,9 +29,9 @@ type PropletPage struct {
 }
 
 func (sdk *propSDK) GetPropletAliveHistory(id string, offset, limit uint64) (proplet.PropletAliveHistoryPage, error) {
-	reqURL := fmt.Sprintf("%s%s/%s/alive-history?offset=%d&limit=%d", sdk.managerURL, propletsEndpoint, id, offset, limit)
+	url := fmt.Sprintf("%s%s/%s/alive-history?offset=%d&limit=%d", sdk.managerURL, propletsEndpoint, id, offset, limit)
 
-	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
+	body, err := sdk.processRequest(http.MethodGet, url, nil, http.StatusOK)
 	if err != nil {
 		return proplet.PropletAliveHistoryPage{}, err
 	}
@@ -46,9 +45,9 @@ func (sdk *propSDK) GetPropletAliveHistory(id string, offset, limit uint64) (pro
 }
 
 func (sdk *propSDK) GetPropletSDF(id string) (sdf.Document, error) {
-	reqURL := sdk.managerURL + propletsEndpoint + "/" + id + "/sdf"
+	url := sdk.managerURL + propletsEndpoint + "/" + id + "/sdf"
 
-	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
+	body, err := sdk.processRequest(http.MethodGet, url, nil, http.StatusOK)
 	if err != nil {
 		return sdf.Document{}, err
 	}
@@ -70,15 +69,15 @@ func (sdk *propSDK) ListProplets(offset, limit uint64, status string) (PropletPa
 		params = append(params, fmt.Sprintf("limit=%d", limit))
 	}
 	if status != "" {
-		params = append(params, "status="+url.QueryEscape(status))
+		params = append(params, "status="+status)
 	}
 	query := ""
 	if len(params) > 0 {
 		query = "?" + strings.Join(params, "&")
 	}
-	reqURL := sdk.managerURL + propletsEndpoint + query
+	url := sdk.managerURL + propletsEndpoint + query
 
-	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
+	body, err := sdk.processRequest(http.MethodGet, url, nil, http.StatusOK)
 	if err != nil {
 		return PropletPage{}, err
 	}
@@ -92,9 +91,9 @@ func (sdk *propSDK) ListProplets(offset, limit uint64, status string) (PropletPa
 }
 
 func (sdk *propSDK) DeleteProplet(id string) error {
-	reqURL := sdk.managerURL + propletsEndpoint + "/" + id
+	url := sdk.managerURL + propletsEndpoint + "/" + id
 
-	if _, err := sdk.processRequest(http.MethodDelete, reqURL, nil, http.StatusNoContent); err != nil {
+	if _, err := sdk.processRequest(http.MethodDelete, url, nil, http.StatusNoContent); err != nil {
 		return err
 	}
 

--- a/pkg/sdk/proplet.go
+++ b/pkg/sdk/proplet.go
@@ -13,6 +13,10 @@ import (
 
 const propletsEndpoint = "/proplets"
 
+// Proplet is the SDK-facing shape of a proplet. It intentionally differs from
+// proplet.Proplet: it exposes CreatedAt (surfaced by the list endpoint) and
+// omits AliveHistory and Metadata, which are internal fields not needed by SDK
+// callers. Keep in sync with the manager list response when fields change.
 type Proplet struct {
 	ID          string     `json:"id"`
 	Name        string     `json:"name"`
@@ -21,6 +25,8 @@ type Proplet struct {
 	LastAliveAt *time.Time `json:"last_alive_at,omitempty"`
 }
 
+// PropletPage mirrors the manager list response. Uses the SDK Proplet type
+// rather than proplet.PropletPage to match the fields declared above.
 type PropletPage struct {
 	Offset   uint64    `json:"offset"`
 	Limit    uint64    `json:"limit"`

--- a/pkg/sdk/proplet.go
+++ b/pkg/sdk/proplet.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/sdf"
 )
 
 const propletsEndpoint = "/proplets"
@@ -42,6 +43,22 @@ func (sdk *propSDK) GetPropletAliveHistory(id string, offset, limit uint64) (pro
 	}
 
 	return page, nil
+}
+
+func (sdk *propSDK) GetPropletSDF(id string) (sdf.Document, error) {
+	reqURL := sdk.managerURL + propletsEndpoint + "/" + id + "/sdf"
+
+	body, err := sdk.processRequest(http.MethodGet, reqURL, nil, http.StatusOK)
+	if err != nil {
+		return sdf.Document{}, err
+	}
+
+	var doc sdf.Document
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return sdf.Document{}, err
+	}
+
+	return doc, nil
 }
 
 func (sdk *propSDK) ListProplets(offset, limit uint64, status string) (PropletPage, error) {

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -132,14 +132,6 @@ type SDK interface {
 	//  fmt.Println(doc)
 	GetPropletSDF(id string) (sdf.Document, error)
 
-	// ListProplets lists proplets with optional status filter.
-	// Status can be "active", "inactive", or "" (all).
-	//
-	// example:
-	//  page, _ := sdk.ListProplets(0, 10, "")
-	//  page, _ := sdk.ListProplets(0, 10, "active")
-	ListProplets(offset uint64, limit uint64, status string) (PropletPage, error)
-
 	// DeleteProplet deletes a proplet by id.
 	//
 	// example:

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -118,6 +118,13 @@ type SDK interface {
 	//  fmt.Println(page)
 	GetPropletAliveHistory(id string, offset, limit uint64) (proplet.PropletAliveHistoryPage, error)
 
+	// ListProplets returns a paginated list of proplets, optionally filtered by status.
+	//
+	// example:
+	//  page, _ := sdk.ListProplets(0, 10, "")
+	//  fmt.Println(page)
+	ListProplets(offset, limit uint64, status string) (PropletPage, error)
+
 	// GetPropletSDF returns the SDF description of a proplet.
 	//
 	// example:

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/sdf"
 )
 
 const CTJSON string = "application/json"
@@ -116,6 +117,13 @@ type SDK interface {
 	//  page, _ := sdk.GetPropletAliveHistory("b1d10738-c5d7-4ff1-8f4d-b9328ce6f040", 0, 10)
 	//  fmt.Println(page)
 	GetPropletAliveHistory(id string, offset, limit uint64) (proplet.PropletAliveHistoryPage, error)
+
+	// GetPropletSDF returns the SDF description of a proplet.
+	//
+	// example:
+	//  doc, _ := sdk.GetPropletSDF("b1d10738-c5d7-4ff1-8f4d-b9328ce6f040")
+	//  fmt.Println(doc)
+	GetPropletSDF(id string) (sdf.Document, error)
 
 	// ListProplets lists proplets with optional status filter.
 	// Status can be "active", "inactive", or "" (all).


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

This is a feature because it adds SDF (Semantic Definition Format) support for describing proplet data and interactions.

<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?

Introduces a new `pkg/sdf` package that implements the [Semantic Definition Format (SDF)](https://datatracker.ietf.org/doc/draft-ietf-asdf-sdf/) for describing proplet data and interactions as standardized Thing descriptions.

- Adds `pkg/sdf` with `Document` and affordance types (`PropertyAfford`, `ActionAfford`, `EventAfford`, `ObjectAfford`, `ThingAfford`, `DataAfford`) following the SDF spec
- Adds `PropletDocument(p proplet.Proplet) sdf.Document` which builds a full SDF Thing description for a proplet, including properties (`id`, `name`, `alive`, `task_count`, `metadata`), actions (`start_task`, `stop_task`), events (`heartbeat`, `task_result`), and data schemas (`PropletMetadata`, `TaskDispatch`, `HeartbeatPayload`, `TaskResult`)
- Wires `GetPropletSDF` through the full manager stack: service interface, implementation, endpoint, HTTP transport (`GET /proplets/{id}/sdf`), logging/metrics/tracing middleware, and mock
- Exposes `GetPropletSDF(id string) (sdf.Document, error)` on the SDK interface

## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->
- Resolves #88

## Have you included tests for your changes?

Yes. `pkg/sdf/proplet_test.go` contains table-driven tests covering:
- Correct `Info` fields (title contains proplet ID, non-empty version)
- All expected `sdfProperty`, `sdfAction`, `sdfEvent`, and `sdfData` keys on the `Proplet` thing
- `TaskResult.state` enum completeness (`Completed`, `Failed`, `Skipped`, `Interrupted`)
- `Minimum` pointer aliasing safety across `DataAfford` fields

## Did you document any new/modified features?

The new `GET /proplets/{id}/sdf` endpoint and `GetPropletSDF` SDK method follow the existing patterns in the codebase. The SDK interface entry includes an inline usage example consistent with all other SDK methods.

### Notes

The SDF document is returned as a flat JSON object (fields of `sdf.Document` directly at the top level), consistent with how other response types embed their domain structs. The shape matches what the SDK `GetPropletSDF` unmarshals.