### PR TITLE
NOISSUE - Optimize task handling and fix dependency validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,8 @@ define docker_push
 		done
 endef
 
+.DEFAULT_GOAL := all
+
 $(SERVICES):
 	$(call compile_service,$(@))
 

--- a/cli/provision.go
+++ b/cli/provision.go
@@ -25,7 +25,7 @@ var (
 	fileName = "config.toml"
 )
 
-const filePermission = 0o644
+const filePermission = 0o600
 
 func SetSuperMQSDK(sdk smqSDK.SDK) {
 	smqsdk = sdk

--- a/manager/cron.go
+++ b/manager/cron.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/absmach/propeller/pkg/cron"
@@ -28,6 +29,7 @@ type cronScheduler struct {
 	logger        *slog.Logger
 	checkInterval time.Duration
 	stopChan      chan struct{}
+	stopOnce      sync.Once
 }
 
 func NewCronScheduler(tasksDB storage.TaskRepository, service Service, logger *slog.Logger) CronScheduler {
@@ -69,7 +71,7 @@ func (cs *cronScheduler) Start(ctx context.Context) error {
 }
 
 func (cs *cronScheduler) Stop() {
-	close(cs.stopChan)
+	cs.stopOnce.Do(func() { close(cs.stopChan) })
 }
 
 func (cs *cronScheduler) ScheduleTask(ctx context.Context, taskID string) error {

--- a/manager/service.go
+++ b/manager/service.go
@@ -343,29 +343,6 @@ func (svc *service) GetJob(ctx context.Context, jobID string) ([]task.Task, erro
 }
 
 func (svc *service) ListJobs(ctx context.Context, offset, limit uint64) (JobPage, error) {
-	jobs := make([]JobSummary, 0)
-	seen := make(map[string]struct{})
-
-	if svc.jobRepo != nil {
-		storedJobs, err := svc.listAllStoredJobs(ctx)
-		if err != nil {
-			return JobPage{}, err
-		}
-
-		jobs = make([]JobSummary, 0, len(storedJobs))
-		for _, sj := range storedJobs {
-			tasks, err := svc.taskRepo.ListByJobID(ctx, sj.ID)
-			if err != nil {
-				return JobPage{}, err
-			}
-
-			summary := computeJobSummary(sj.ID, tasks)
-			summary.Name = sj.Name
-			jobs = append(jobs, summary)
-			seen[sj.ID] = struct{}{}
-		}
-	}
-
 	allTasks, err := svc.listAllTasks(ctx)
 	if err != nil {
 		return JobPage{}, err
@@ -375,6 +352,23 @@ func (svc *service) ListJobs(ctx context.Context, offset, limit uint64) (JobPage
 	for i := range allTasks {
 		if allTasks[i].JobID != "" {
 			jobMap[allTasks[i].JobID] = append(jobMap[allTasks[i].JobID], allTasks[i])
+		}
+	}
+
+	jobs := make([]JobSummary, 0, len(jobMap))
+	seen := make(map[string]struct{})
+	if svc.jobRepo != nil {
+		storedJobs, err := svc.listAllStoredJobs(ctx)
+		if err != nil {
+			return JobPage{}, err
+		}
+
+		for _, sj := range storedJobs {
+			tasks := jobMap[sj.ID]
+			summary := computeJobSummary(sj.ID, tasks)
+			summary.Name = sj.Name
+			jobs = append(jobs, summary)
+			seen[sj.ID] = struct{}{}
 		}
 	}
 

--- a/manager/workflow.go
+++ b/manager/workflow.go
@@ -47,6 +47,8 @@ func (wc *WorkflowCoordinator) EvaluateConditionalExecution(ctx context.Context,
 		return true
 
 	case task.RunIfFailure:
+		// Intentionally asymmetric with RunIfSuccess: triggers if ANY dependency
+		// failed (error-handler pattern), rather than requiring all to fail.
 		for _, depID := range t.DependsOn {
 			state, exists := parentStates[depID]
 			if exists && state == task.Failed {

--- a/pkg/dag/validator.go
+++ b/pkg/dag/validator.go
@@ -87,6 +87,10 @@ func ValidateDependenciesExist(tasks []task.Task) error {
 }
 
 func TopologicalSort(tasks []task.Task) ([]task.Task, error) {
+	if err := ValidateDependenciesExist(tasks); err != nil {
+		return nil, err
+	}
+
 	if err := ValidateDAG(tasks); err != nil {
 		return nil, err
 	}

--- a/pkg/dag/validator.go
+++ b/pkg/dag/validator.go
@@ -97,17 +97,14 @@ func TopologicalSort(tasks []task.Task) ([]task.Task, error) {
 
 	taskMap := make(map[string]task.Task)
 	inDegree := make(map[string]int)
+	dependents := make(map[string][]string)
 
 	for i := range tasks {
 		t := &tasks[i]
 		taskMap[t.ID] = *t
-		inDegree[t.ID] = 0
-	}
-
-	for i := range tasks {
-		t := &tasks[i]
-		for range t.DependsOn {
-			inDegree[t.ID]++
+		inDegree[t.ID] = len(t.DependsOn)
+		for _, depID := range t.DependsOn {
+			dependents[depID] = append(dependents[depID], t.ID)
 		}
 	}
 
@@ -132,13 +129,10 @@ func TopologicalSort(tasks []task.Task) ([]task.Task, error) {
 		visited[currentID] = true
 		result = append(result, taskMap[currentID])
 
-		for i := range tasks {
-			t := &tasks[i]
-			if slices.Contains(t.DependsOn, currentID) {
-				inDegree[t.ID]--
-				if inDegree[t.ID] == 0 {
-					queue = append(queue, t.ID)
-				}
+		for _, depID := range dependents[currentID] {
+			inDegree[depID]--
+			if inDegree[depID] == 0 {
+				queue = append(queue, depID)
 			}
 		}
 	}

--- a/pkg/dag/validator_test.go
+++ b/pkg/dag/validator_test.go
@@ -236,6 +236,21 @@ func TestGetReadyTasks_FailedDependencyUnblocks(t *testing.T) {
 	}
 }
 
+func TestTopologicalSort_MissingDependency(t *testing.T) {
+	t.Parallel()
+	tasks := []task.Task{
+		{ID: "task1", DependsOn: []string{"nonexistent"}},
+	}
+
+	_, err := dag.TopologicalSort(tasks)
+	if err == nil {
+		t.Fatal("Expected error for missing dependency, got nil")
+	}
+	if !errors.Is(err, dag.ErrMissingDependency) {
+		t.Fatalf("Expected ErrMissingDependency, got: %v", err)
+	}
+}
+
 func TestTopologicalSort_SelfCycle(t *testing.T) {
 	t.Parallel()
 	tasks := []task.Task{

--- a/pkg/scheduler/roundrobin.go
+++ b/pkg/scheduler/roundrobin.go
@@ -40,7 +40,6 @@ func (r *roundRobin) SelectProplet(t task.Task, proplets []proplet.Proplet) (pro
 	if !p.Alive {
 		return r.SelectProplet(t, proplets)
 	}
-	p.TaskCount += 1
 
 	return p, nil
 }

--- a/pkg/scheduler/roundrobin.go
+++ b/pkg/scheduler/roundrobin.go
@@ -30,16 +30,12 @@ func (r *roundRobin) SelectProplet(t task.Task, proplets []proplet.Proplet) (pro
 		return proplet.Proplet{}, ErrDeadProplers
 	}
 
-	if len(proplets) == 1 {
-		return proplets[0], nil
+	for i := 0; i < len(proplets); i++ {
+		r.LastProplet = (r.LastProplet + 1) % len(proplets)
+		if proplets[r.LastProplet].Alive {
+			return proplets[r.LastProplet], nil
+		}
 	}
 
-	r.LastProplet = (r.LastProplet + 1) % len(proplets)
-
-	p := proplets[r.LastProplet]
-	if !p.Alive {
-		return r.SelectProplet(t, proplets)
-	}
-
-	return p, nil
+	return proplet.Proplet{}, ErrDeadProplers
 }

--- a/pkg/scheduler/roundrobin.go
+++ b/pkg/scheduler/roundrobin.go
@@ -30,7 +30,7 @@ func (r *roundRobin) SelectProplet(t task.Task, proplets []proplet.Proplet) (pro
 		return proplet.Proplet{}, ErrDeadProplers
 	}
 
-	for i := 0; i < len(proplets); i++ {
+	for range len(proplets) {
 		r.LastProplet = (r.LastProplet + 1) % len(proplets)
 		if proplets[r.LastProplet].Alive {
 			return proplets[r.LastProplet], nil

--- a/pkg/scheduler/roundrobin.go
+++ b/pkg/scheduler/roundrobin.go
@@ -30,7 +30,7 @@ func (r *roundRobin) SelectProplet(t task.Task, proplets []proplet.Proplet) (pro
 		return proplet.Proplet{}, ErrDeadProplers
 	}
 
-	for range len(proplets) {
+	for range proplets {
 		r.LastProplet = (r.LastProplet + 1) % len(proplets)
 		if proplets[r.LastProplet].Alive {
 			return proplets[r.LastProplet], nil


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?
This is a bug fix and optimisation because it addresses several correctness and security issues found during a code review.

<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
  - Fix double-close panic in CronScheduler.Stop(): Guards close(stopChan) with sync.Once so calling Stop() more than once no longer panics.
  - Fix unbounded recursion in round-robin scheduler: Replaces the recursive SelectProplet call (which could stack-overflow with many dead proplets) with an iterative loop.
  - Optimise TopologicalSort from O(n²) to O(n+e): Builds a reverse adjacency map (dependents) up front so the BFS inner step is O(1) per edge instead of scanning all tasks on every iteration.
  - Fix TopologicalSort missing dependency validation: ValidateDependenciesExist is now called before ValidateDAG, ensuring tasks with references to non-existent dependencies are caught early.
  - Fix world-readable config file permissions: Changes filePermission from 0o644 to 0o600 so provisioned config files (which contain MQTT credentials) are not readable by other users on the system.
  - Clarify RunIfFailure semantics: Adds a comment explaining the intentional asymmetry — success requires all dependencies to complete, failure triggers if any dependency fails.
  - Batch job listing: Refactors ListJobs to fetch all tasks once and build a job map, rather than issuing a separate ListByJobID query per stored job.
  - Makefile default goal: Sets .DEFAULT_GOAL := all so a bare make builds everything.

## Which issue(s) does this PR fix/relate to?
N/A

## Have you included tests for your changes?
No user-facing features were added. The RunIfFailure behaviour is documented inline with a code comment.

## Did you document any new/modified features?
The round-robin fix also removes the p.TaskCount += 1 increment that was present in the old path but operated on a copy of the struct (the increment was already a no-op).

### Notes
N/A
