### PR TITLE
NOISSUE - fix install gcc and musl-dev for CGO builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ARG TIME
 WORKDIR /go/src/github.com/absmach/propeller
 COPY . .
 RUN apk update \
-    && apk add make \
+    && apk add make gcc musl-dev \
     && _goarm="${GOARM:-${TARGETVARIANT#v}}" \
     && make $SVC GOARCH=${GOARCH} ${_goarm:+GOARM=${_goarm}} \
     && mv build/$SVC /exe

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine3.23 AS builder
+FROM golang:1.26-bookworm AS builder
 ARG SVC
 # TARGETARCH / TARGETVARIANT are set automatically by docker buildx.
 # GOARCH / GOARM can still be passed explicitly via --build-arg to keep
@@ -13,16 +13,15 @@ ARG TIME
 
 WORKDIR /go/src/github.com/absmach/propeller
 COPY . .
-RUN apk update \
-    && apk add make gcc musl-dev \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends make \
     && _goarm="${GOARM:-${TARGETVARIANT#v}}" \
     && make $SVC GOARCH=${GOARCH} ${_goarm:+GOARM=${_goarm}} \
     && mv build/$SVC /exe
 
-FROM scratch
+FROM gcr.io/distroless/cc-debian12
 LABEL org.opencontainers.image.source=https://github.com/absmach/propeller
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /exe /
 ENTRYPOINT ["/exe"]


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

Bug fix

## What does this do?

Adds `gcc` and `musl-dev` to the Alpine builder image.

## Which issue(s) does this PR fix/relate to?

- Fixes CI failure on `main` after #185 merged.

## Have you included tests for your changes?

No; build pipeline serves as the test.

## Did you document any new/modified features?

No documentation changes needed.