### PR TITLE
NOISSUE - use golang:1.26 builder to support riscv64 platform

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,7 +62,7 @@ jobs:
           # distroless/cc-debian12 is used for amd64/arm64; riscv64 falls back
           # to debian:sid-slim which carries glibc + libgcc for CGO binaries.
           platforms: linux/amd64,linux/arm64,linux/riscv64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             SVC=${{ matrix.svc }}
             VERSION=${{ steps.meta.outputs.version }}
@@ -117,7 +117,7 @@ jobs:
           # cross-compiles on the host (amd64) rather than running under QEMU.
           # wasmtime releases provide amd64 and arm64 Linux binaries.
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             COMMIT=${{ steps.meta.outputs.commit }}
@@ -159,7 +159,7 @@ jobs:
           file: docker/Dockerfile.proplet-wasinn
           # OpenVINO backend is x86-only
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.IMAGE_PREFIX }}/proplet-wasi-nn:latest
             ${{ env.IMAGE_PREFIX }}/proplet-wasi-nn:${{ github.sha }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,8 +55,8 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          # Docker images only make sense on Linux; riscv64 support in the
-          # alpine builder image and multi-arch manifests is available.
+          # distroless/cc-debian12 is used for amd64/arm64; riscv64 falls back
+          # to debian:sid-slim which carries glibc + libgcc for CGO binaries.
           platforms: linux/amd64,linux/arm64,linux/riscv64
           push: true
           build-args: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+  pull_request:
+    branches:
+      - main
+
   workflow_dispatch:
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ endef
 
 .DEFAULT_GOAL := all
 
-manager: CGO_ENABLED := 1
+manager: CGO_ENABLED := $(if $(filter riscv64,$(GOARCH)),0,1)
 
 $(SERVICES):
 	$(call compile_service,$(@))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.26 AS builder
 ARG SVC
 # TARGETARCH / TARGETVARIANT are set automatically by docker buildx.
 # GOARCH / GOARM can still be passed explicitly via --build-arg to keep

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,19 @@ RUN apt-get update \
     && make $SVC GOARCH=${GOARCH} ${_goarm:+GOARM=${_goarm}} \
     && mv build/$SVC /exe
 
-FROM gcr.io/distroless/cc-debian12
+# distroless/cc-debian12 has no riscv64 manifest; fall back to debian:sid-slim
+# for that platform, which provides glibc and libgcc required by CGO binaries.
+FROM gcr.io/distroless/cc-debian12 AS final-amd64
+FROM gcr.io/distroless/cc-debian12 AS final-arm64
+FROM gcr.io/distroless/cc-debian12 AS final-arm
+FROM gcr.io/distroless/cc-debian12 AS final-ppc64le
+FROM gcr.io/distroless/cc-debian12 AS final-s390x
+FROM debian:sid-slim AS final-riscv64
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgcc-s1 \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM final-${TARGETARCH}
 LABEL org.opencontainers.image.source=https://github.com/absmach/propeller
 LABEL org.opencontainers.image.licenses=Apache-2.0
 


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

Bug fix: multi-platform Docker build failing for `riscv64`.

## What does this do?

- Switches builder from `golang:1.26-bookworm` to `golang:1.26` (bookworm has no `riscv64` manifest).
- Adds `debian:sid-slim` as the final stage for `riscv64` (`distroless/cc-debian12` has no `riscv64` manifest).
- Sets `CGO_ENABLED=0` for manager on `riscv64` — `wasmtime-go/v44` does not bundle a prebuilt `libwasmtime.a` for `riscv64`.
- Skips registry push on PR runs to avoid `denied: installation not allowed to Write organization package`.

## Which issue(s) does this PR fix/relate to?

No related issue.

## Have you included tests for your changes?

No tests needed; these are build and CI configuration changes only.

## Did you document any new/modified features?

No documentation needed.

### Notes

`golang:1.26` defaults to bookworm for amd64/arm64, so runtime behaviour is unchanged there.

### ⚠️ Caveat: wasm plugin system is disabled on riscv64

The manager's wasm plugin feature relies on `wasmtime-go/v44`, which embeds prebuilt `libwasmtime.a` C libraries. Although wasmtime v44.0.0 itself ships a `riscv64gc-linux-c-api` release asset, **`wasmtime-go/v44` does not bundle it** — the Go binding's `build/` directory only includes:

| Platform | Bundled in wasmtime-go |
|---|---|
| linux/amd64 | ✅ |
| linux/arm64 | ✅ |
| macos/amd64 | ✅ |
| macos/arm64 | ✅ |
| windows/amd64 | ✅ |
| **linux/riscv64** | ❌ (library exists upstream, not bundled) |

**References:**
- wasmtime v44.0.0 release assets (riscv64gc-linux-c-api present): https://github.com/bytecodealliance/wasmtime/releases/tag/v44.0.0
- wasmtime-go/v44 build directory (no riscv64): https://github.com/bytecodealliance/wasmtime-go/tree/main/build
- wasmtime platform support: https://docs.wasmtime.dev/stability-platform-support.html

On riscv64, the manager builds with `CGO_ENABLED=0` and any call to `LoadWasm` returns:
`wasm plugin support requires CGO; rebuild with CGO_ENABLED=1`

All other manager functionality (task scheduling, proplet management, MQTT, HTTP API) is unaffected.