### PR TITLE
NOISSUE - disable riscv64 builds for manager and proxy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,11 @@ jobs:
         include:
           - { goos: linux, goarch: amd64, service: manager }
           - { goos: linux, goarch: arm64, service: manager }
-          - { goos: linux, goarch: riscv64, service: manager }
           - { goos: linux, goarch: amd64, service: cli }
           - { goos: linux, goarch: arm64, service: cli }
           - { goos: linux, goarch: riscv64, service: cli }
           - { goos: linux, goarch: amd64, service: proxy }
           - { goos: linux, goarch: arm64, service: proxy }
-          - { goos: linux, goarch: riscv64, service: proxy }
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        svc: [manager, cli, proxy]
+        include:
+          # riscv64 disabled for manager and proxy until wasmtime-go adds
+          # riscv64 support: https://github.com/bytecodealliance/wasmtime-go/pull/285
+          - { svc: manager, platforms: "linux/amd64,linux/arm64" }
+          - { svc: cli,     platforms: "linux/amd64,linux/arm64,linux/riscv64" }
+          - { svc: proxy,   platforms: "linux/amd64,linux/arm64" }
 
     permissions:
       contents: read
@@ -55,9 +60,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          # Docker images only make sense on Linux; riscv64 support in the
-          # alpine builder image and multi-arch manifests is available.
-          platforms: linux/amd64,linux/arm64,linux/riscv64
+          platforms: ${{ matrix.platforms }}
           push: true
           build-args: |
             SVC=${{ matrix.svc }}


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

This is a bug fix because it temporarily disables riscv64 builds for manager and proxy until wasmtime-go adds riscv64 support: bytecodealliance/wasmtime-go#285

## What does this do?

Removes \`linux/riscv64\` from the build matrix and Docker platforms for \`manager\` and \`proxy\`. The \`cli\` service is unaffected since it has no wasmtime-go dependency. Both \`build.yml\` (binary matrix) and \`cd.yml\` (Docker multi-arch platforms) are updated.

## Which issue(s) does this PR fix/relate to?

- Blocked by bytecodealliance/wasmtime-go#285

## Have you included tests for your changes?

No — this is a CI configuration change only.

## Did you document any new/modified features?

No. This is a temporary workaround; revert once wasmtime-go cuts a release with riscv64 support.