### PR TITLE
NOISSUE - disable riscv64 docker build for cli

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,8 @@ jobs:
           # riscv64 disabled for manager and proxy until wasmtime-go adds
           # riscv64 support: https://github.com/bytecodealliance/wasmtime-go/pull/285
           - { svc: manager, platforms: "linux/amd64,linux/arm64" }
-          - { svc: cli,     platforms: "linux/amd64,linux/arm64,linux/riscv64" }
+          # cli: riscv64 also disabled — gcr.io/distroless/static-debian12 has no riscv64 image
+          - { svc: cli,     platforms: "linux/amd64,linux/arm64" }
           - { svc: proxy,   platforms: "linux/amd64,linux/arm64" }
 
     permissions:


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

This is a bug fix because it fixes the failing riscv64 Docker build for `cli`.

## What does this do?

Removes `linux/riscv64` from the Docker platform list for `cli` in `cd.yml`. The previous PR (#229) disabled riscv64 for `manager` and `proxy` but kept it for `cli` — however `gcr.io/distroless/static-debian12` (the runtime base image) has no riscv64 variant, so the `cli` Docker build fails with `no match for platform in manifest: not found`.

## Which issue(s) does this PR fix/relate to?

- Follow-up to #229

## Have you included tests for your changes?

No — this is a CI configuration change only.

## Did you document any new/modified features?

No.