### PR TITLE
NOISSUE - Add CPU/memory Prometheus metrics and OTLP task lifecycle spans

### DIFF
--- a/docker/addons/grafana/grafana/dashboards/propeller.json
+++ b/docker/addons/grafana/grafana/dashboards/propeller.json
@@ -3,12 +3,20 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "datasource", "uid": "grafana" },
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
-        "target": { "limit": 100, "matchAny": false, "tags": [], "type": "dashboard" },
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
@@ -34,43 +42,76 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "title": "Task Execution",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 5 },
-              { "color": "red", "value": 20 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "id": 2,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "title": "Tasks Running",
       "type": "stat",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "proplet_tasks_running",
           "legendFormat": "running",
           "refId": "A"
@@ -78,30 +119,57 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
       "id": 3,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "title": "Tasks Started (total)",
       "type": "stat",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "proplet_tasks_started_total",
           "legendFormat": "started",
           "refId": "A"
@@ -109,30 +177,57 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
       "id": 4,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "title": "Tasks Completed (total)",
       "type": "stat",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "proplet_tasks_completed_total",
           "legendFormat": "completed",
           "refId": "A"
@@ -140,36 +235,61 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
       "id": 5,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "title": "Tasks Failed (total)",
       "type": "stat",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "proplet_tasks_failed_total",
           "legendFormat": "failed",
           "refId": "A"
@@ -177,10 +297,15 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -190,43 +315,79 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "unit": "ops"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 5 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
       "id": 6,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull", "max"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "title": "Task Rate",
       "type": "timeseries",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "rate(proplet_tasks_started_total[1m])",
           "legendFormat": "started/s",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "rate(proplet_tasks_completed_total[1m])",
           "legendFormat": "completed/s",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "rate(proplet_tasks_failed_total[1m])",
           "legendFormat": "failed/s",
           "refId": "C"
@@ -235,16 +396,26 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
       "id": 10,
       "title": "Proplet System",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -252,11 +423,18 @@
             "fillOpacity": 10,
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "max": 1,
           "min": 0,
@@ -264,17 +442,35 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
       "id": 11,
       "options": {
-        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "title": "CPU Usage",
       "type": "timeseries",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "proplet_cpu_usage_ratio",
           "legendFormat": "cpu",
           "refId": "A"
@@ -282,10 +478,15 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -293,27 +494,52 @@
             "fillOpacity": 10,
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
       "id": 12,
       "options": {
-        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "title": "Memory RSS",
       "type": "timeseries",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "proplet_memory_rss_bytes",
           "legendFormat": "rss",
           "refId": "A"
@@ -321,37 +547,219 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "CPU Time (cumulative)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
+          "expr": "proplet_cpu_user_seconds_total",
+          "legendFormat": "User seconds",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
+          "expr": "proplet_cpu_system_seconds_total",
+          "legendFormat": "System seconds",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "Container Memory",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
+          "expr": "proplet_memory_container_usage_bytes",
+          "legendFormat": "Container usage",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
+          "expr": "proplet_memory_container_limit_bytes",
+          "legendFormat": "Container limit",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 3 },
-              { "color": "red", "value": 10 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 22 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 38
+      },
       "id": 13,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "title": "MQTT Reconnects (total)",
       "type": "stat",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "proplet_mqtt_reconnects_total",
           "legendFormat": "reconnects",
           "refId": "A"
@@ -359,30 +767,57 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 22 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 38
+      },
       "id": 14,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "title": "Wasm Fetched (total bytes)",
       "type": "stat",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "proplet_wasm_fetch_bytes_total",
           "legendFormat": "bytes",
           "refId": "A"
@@ -391,16 +826,26 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
       "id": 20,
       "title": "Manager API",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -408,27 +853,52 @@
             "fillOpacity": 10,
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "unit": "ops"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 27 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
       "id": 21,
       "options": {
-        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "title": "Request Rate by Method",
       "type": "timeseries",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "rate(manager_api_request_count[1m])",
           "legendFormat": "{{method}}",
           "refId": "A"
@@ -436,10 +906,15 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "propeller-prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -447,39 +922,70 @@
             "fillOpacity": 10,
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
-          "unit": "µs"
+          "unit": "\u00b5s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 27 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
       "id": 22,
       "options": {
-        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "title": "Request Latency by Method",
       "type": "timeseries",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "manager_api_request_latency_microseconds{quantile=\"0.5\"}",
           "legendFormat": "{{method}} p50",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "manager_api_request_latency_microseconds{quantile=\"0.9\"}",
           "legendFormat": "{{method}} p90",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "propeller-prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "propeller-prometheus"
+          },
           "expr": "manager_api_request_latency_microseconds{quantile=\"0.99\"}",
           "legendFormat": "{{method}} p99",
           "refId": "C"
@@ -489,9 +995,16 @@
   ],
   "refresh": "30s",
   "schemaVersion": 38,
-  "tags": ["propeller"],
-  "templating": { "list": [] },
-  "time": { "from": "now-1h", "to": "now" },
+  "tags": [
+    "propeller"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "Propeller",

--- a/docker/addons/grafana/grafana/dashboards/propeller.json
+++ b/docker/addons/grafana/grafana/dashboards/propeller.json
@@ -608,7 +608,7 @@
             "type": "prometheus",
             "uid": "propeller-prometheus"
           },
-          "expr": "proplet_cpu_user_seconds_total",
+          "expr": "proplet_cpu_user_seconds",
           "legendFormat": "User seconds",
           "refId": "A"
         },
@@ -617,7 +617,7 @@
             "type": "prometheus",
             "uid": "propeller-prometheus"
           },
-          "expr": "proplet_cpu_system_seconds_total",
+          "expr": "proplet_cpu_system_seconds",
           "legendFormat": "System seconds",
           "refId": "B"
         }

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -377,9 +377,23 @@ impl PropletService {
         };
 
         self.metrics.cpu_usage.set(cpu_metrics.percent / 100.0);
+        self.metrics.cpu_user_seconds.set(cpu_metrics.user_seconds);
+        self.metrics
+            .cpu_system_seconds
+            .set(cpu_metrics.system_seconds);
         self.metrics
             .memory_rss_bytes
             .set(memory_metrics.rss_bytes as f64);
+        if let Some(usage) = memory_metrics.container_usage_bytes {
+            self.metrics
+                .memory_container_usage_bytes
+                .set(usage as f64);
+        }
+        if let Some(limit) = memory_metrics.container_limit_bytes {
+            self.metrics
+                .memory_container_limit_bytes
+                .set(limit as f64);
+        }
 
         #[derive(serde::Serialize)]
         struct PropletMetricsMessage {

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -385,14 +385,10 @@ impl PropletService {
             .memory_rss_bytes
             .set(memory_metrics.rss_bytes as f64);
         if let Some(usage) = memory_metrics.container_usage_bytes {
-            self.metrics
-                .memory_container_usage_bytes
-                .set(usage as f64);
+            self.metrics.memory_container_usage_bytes.set(usage as f64);
         }
         if let Some(limit) = memory_metrics.container_limit_bytes {
-            self.metrics
-                .memory_container_limit_bytes
-                .set(limit as f64);
+            self.metrics.memory_container_limit_bytes.set(limit as f64);
         }
 
         #[derive(serde::Serialize)]
@@ -682,7 +678,8 @@ impl PropletService {
 
         let export_metrics = monitoring_profile.enabled && monitoring_profile.export_to_mqtt;
 
-        let execute_span = tracing::info_span!("task.execute", task_id = %task_id, task_name = %task_name);
+        let execute_span =
+            tracing::info_span!("task.execute", task_id = %task_id, task_name = %task_name);
         tokio::spawn(async move {
             let ctx = RuntimeContext {
                 proplet_id: proplet_id.clone(),
@@ -891,7 +888,7 @@ impl PropletService {
             let result = async {
                 runtime.start_app(ctx, config).await
             }
-            .instrument(tracing::info_span!("wasm.execute", task_id = %task_id))
+            .instrument(tracing::info_span!("wasm.execute"))
             .await;
 
             if let Some(handle) = monitor_handle {
@@ -1050,11 +1047,12 @@ impl PropletService {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, msg), name = "task.stop")]
+    #[tracing::instrument(skip(self, msg), name = "task.stop", fields(task_id))]
     async fn handle_stop_command(&self, msg: MqttMessage) -> Result<()> {
         let req: StopRequest = msg.decode()?;
         req.validate()?;
 
+        tracing::Span::current().record("task_id", req.id.as_str());
         info!("Received stop command for task: {}", req.id);
 
         self.runtime.stop_app(req.id.clone()).await?;

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -940,7 +940,9 @@ impl PropletService {
                     None => {
                         error!("MANAGER_COORDINATOR_URL not set. Must be provided via environment variable in .env file for FML tasks.");
                         running_tasks.lock().await.remove(&task_id);
-                        metrics.tasks_failed.inc();
+                        if error.is_none() {
+                            metrics.tasks_failed.inc();
+                        }
                         metrics.tasks_running.dec();
                         return;
                     }

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -15,7 +15,7 @@ use std::time::SystemTime;
 use sysinfo::System;
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::Instant;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, warn, Instrument};
 
 const WASM_FETCH_MAX_BYTES: usize = 100 * 1024 * 1024; // 100MB
 
@@ -445,6 +445,7 @@ impl PropletService {
         }
     }
 
+    #[tracing::instrument(skip(self, msg), name = "task.start", fields(task_id, task_name))]
     async fn handle_start_command(&self, msg: MqttMessage) -> Result<()> {
         let req: StartRequest = msg.decode().map_err(|e| {
             error!(
@@ -455,6 +456,9 @@ impl PropletService {
             e
         })?;
         req.validate()?;
+
+        tracing::Span::current().record("task_id", req.id.as_str());
+        tracing::Span::current().record("task_name", req.name.as_str());
 
         if !req.broadcast {
             if let Some(ref target_id) = req.proplet_id {
@@ -664,6 +668,7 @@ impl PropletService {
 
         let export_metrics = monitoring_profile.enabled && monitoring_profile.export_to_mqtt;
 
+        let execute_span = tracing::info_span!("task.execute", task_id = %task_id, task_name = %task_name);
         tokio::spawn(async move {
             let ctx = RuntimeContext {
                 proplet_id: proplet_id.clone(),
@@ -869,7 +874,11 @@ impl PropletService {
                 PluginRegistry::notify_task_start(Arc::clone(registry), plugin_task);
             }
 
-            let result = runtime.start_app(ctx, config).await;
+            let result = async {
+                runtime.start_app(ctx, config).await
+            }
+            .instrument(tracing::info_span!("wasm.execute", task_id = %task_id))
+            .await;
 
             if let Some(handle) = monitor_handle {
                 let _ = handle.await;
@@ -1022,11 +1031,12 @@ impl PropletService {
             if running_tasks.lock().await.remove(&task_id).is_some() {
                 metrics.tasks_running.dec();
             }
-        });
+        }.instrument(execute_span));
 
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, msg), name = "task.stop")]
     async fn handle_stop_command(&self, msg: MqttMessage) -> Result<()> {
         let req: StopRequest = msg.decode()?;
         req.validate()?;

--- a/proplet/src/telemetry.rs
+++ b/proplet/src/telemetry.rs
@@ -21,7 +21,11 @@ pub struct PropletMetrics {
     pub mqtt_reconnects: IntCounter,
     pub wasm_fetch_bytes: IntCounter,
     pub cpu_usage: Gauge,
+    pub cpu_user_seconds: Gauge,
+    pub cpu_system_seconds: Gauge,
     pub memory_rss_bytes: Gauge,
+    pub memory_container_usage_bytes: Gauge,
+    pub memory_container_limit_bytes: Gauge,
 }
 
 impl PropletMetrics {
@@ -70,11 +74,35 @@ impl PropletMetrics {
         ))?;
         registry.register(Box::new(cpu_usage.clone()))?;
 
+        let cpu_user_seconds = Gauge::with_opts(Opts::new(
+            "proplet_cpu_user_seconds_total",
+            "Total CPU time spent in user mode (seconds)",
+        ))?;
+        registry.register(Box::new(cpu_user_seconds.clone()))?;
+
+        let cpu_system_seconds = Gauge::with_opts(Opts::new(
+            "proplet_cpu_system_seconds_total",
+            "Total CPU time spent in system (kernel) mode (seconds)",
+        ))?;
+        registry.register(Box::new(cpu_system_seconds.clone()))?;
+
         let memory_rss_bytes = Gauge::with_opts(Opts::new(
             "proplet_memory_rss_bytes",
             "Process RSS memory in bytes",
         ))?;
         registry.register(Box::new(memory_rss_bytes.clone()))?;
+
+        let memory_container_usage_bytes = Gauge::with_opts(Opts::new(
+            "proplet_memory_container_usage_bytes",
+            "Container memory usage in bytes (from cgroup)",
+        ))?;
+        registry.register(Box::new(memory_container_usage_bytes.clone()))?;
+
+        let memory_container_limit_bytes = Gauge::with_opts(Opts::new(
+            "proplet_memory_container_limit_bytes",
+            "Container memory limit in bytes (from cgroup; 0 = unlimited)",
+        ))?;
+        registry.register(Box::new(memory_container_limit_bytes.clone()))?;
 
         Ok(Self {
             registry,
@@ -85,7 +113,11 @@ impl PropletMetrics {
             mqtt_reconnects,
             wasm_fetch_bytes,
             cpu_usage,
+            cpu_user_seconds,
+            cpu_system_seconds,
             memory_rss_bytes,
+            memory_container_usage_bytes,
+            memory_container_limit_bytes,
         })
     }
 }
@@ -213,6 +245,23 @@ mod tests {
         assert!(names.contains(&"proplet_tasks_running"));
         assert!(names.contains(&"proplet_mqtt_reconnects_total"));
         assert!(names.contains(&"proplet_cpu_usage_ratio"));
+        assert!(names.contains(&"proplet_cpu_user_seconds_total"));
+        assert!(names.contains(&"proplet_cpu_system_seconds_total"));
         assert!(names.contains(&"proplet_memory_rss_bytes"));
+        assert!(names.contains(&"proplet_memory_container_usage_bytes"));
+        assert!(names.contains(&"proplet_memory_container_limit_bytes"));
+    }
+
+    #[test]
+    fn test_cpu_and_container_metrics_set() {
+        let m = PropletMetrics::new().unwrap();
+        m.cpu_user_seconds.set(12.5);
+        m.cpu_system_seconds.set(3.2);
+        m.memory_container_usage_bytes.set(104_857_600.0);
+        m.memory_container_limit_bytes.set(536_870_912.0);
+        assert_eq!(m.cpu_user_seconds.get(), 12.5);
+        assert_eq!(m.cpu_system_seconds.get(), 3.2);
+        assert_eq!(m.memory_container_usage_bytes.get(), 104_857_600.0);
+        assert_eq!(m.memory_container_limit_bytes.get(), 536_870_912.0);
     }
 }

--- a/proplet/src/telemetry.rs
+++ b/proplet/src/telemetry.rs
@@ -75,14 +75,14 @@ impl PropletMetrics {
         registry.register(Box::new(cpu_usage.clone()))?;
 
         let cpu_user_seconds = Gauge::with_opts(Opts::new(
-            "proplet_cpu_user_seconds_total",
-            "Total CPU time spent in user mode (seconds)",
+            "proplet_cpu_user_seconds",
+            "Cumulative CPU time spent in user mode (seconds)",
         ))?;
         registry.register(Box::new(cpu_user_seconds.clone()))?;
 
         let cpu_system_seconds = Gauge::with_opts(Opts::new(
-            "proplet_cpu_system_seconds_total",
-            "Total CPU time spent in system (kernel) mode (seconds)",
+            "proplet_cpu_system_seconds",
+            "Cumulative CPU time spent in system (kernel) mode (seconds)",
         ))?;
         registry.register(Box::new(cpu_system_seconds.clone()))?;
 
@@ -218,6 +218,12 @@ mod tests {
         assert_eq!(m.tasks_running.get(), 0);
         assert_eq!(m.mqtt_reconnects.get(), 0);
         assert_eq!(m.wasm_fetch_bytes.get(), 0);
+        assert_eq!(m.cpu_usage.get(), 0.0);
+        assert_eq!(m.cpu_user_seconds.get(), 0.0);
+        assert_eq!(m.cpu_system_seconds.get(), 0.0);
+        assert_eq!(m.memory_rss_bytes.get(), 0.0);
+        assert_eq!(m.memory_container_usage_bytes.get(), 0.0);
+        assert_eq!(m.memory_container_limit_bytes.get(), 0.0);
     }
 
     #[test]
@@ -245,8 +251,8 @@ mod tests {
         assert!(names.contains(&"proplet_tasks_running"));
         assert!(names.contains(&"proplet_mqtt_reconnects_total"));
         assert!(names.contains(&"proplet_cpu_usage_ratio"));
-        assert!(names.contains(&"proplet_cpu_user_seconds_total"));
-        assert!(names.contains(&"proplet_cpu_system_seconds_total"));
+        assert!(names.contains(&"proplet_cpu_user_seconds"));
+        assert!(names.contains(&"proplet_cpu_system_seconds"));
         assert!(names.contains(&"proplet_memory_rss_bytes"));
         assert!(names.contains(&"proplet_memory_container_usage_bytes"));
         assert!(names.contains(&"proplet_memory_container_limit_bytes"));

--- a/proplet/src/telemetry.rs
+++ b/proplet/src/telemetry.rs
@@ -248,8 +248,10 @@ mod tests {
         let names: Vec<&str> = gathered.iter().map(|mf| mf.get_name()).collect();
         assert!(names.contains(&"proplet_tasks_started_total"));
         assert!(names.contains(&"proplet_tasks_completed_total"));
+        assert!(names.contains(&"proplet_tasks_failed_total"));
         assert!(names.contains(&"proplet_tasks_running"));
         assert!(names.contains(&"proplet_mqtt_reconnects_total"));
+        assert!(names.contains(&"proplet_wasm_fetch_bytes_total"));
         assert!(names.contains(&"proplet_cpu_usage_ratio"));
         assert!(names.contains(&"proplet_cpu_user_seconds"));
         assert!(names.contains(&"proplet_cpu_system_seconds"));


### PR DESCRIPTION
### What does this do?

Surfaces proplet CPU and container memory data as Prometheus metrics and instruments the task execution lifecycle with OTLP trace spans.

Previously, CPU and container memory data from `MetricsCollector` was only published over MQTT to the manager. This PR makes that data scrapeable at `:9092/metrics` alongside the existing task counters by adding four new Gauges:

- `proplet_cpu_user_seconds` — cumulative CPU time in user mode (sourced from `/proc/self/stat`)
- `proplet_cpu_system_seconds` — cumulative CPU time in kernel mode
- `proplet_memory_container_usage_bytes` — container memory usage in bytes (from cgroup)
- `proplet_memory_container_limit_bytes` — container memory limit in bytes (0 = unlimited)

It also adds three OTLP trace spans so proplet execution appears in Jaeger alongside the manager:

- `task.start` — covers MQTT decode through task dispatch, tagged with `task_id` and `task_name`
- `task.execute` — wraps the full spawned task lifetime end-to-end
- `wasm.execute` — child span around `runtime.start_app` so wasmtime execution time is visible separately

The Grafana dashboard gains two new panels in the Proplet System row: **CPU Time (cumulative)** and **Container Memory**.

Also fixes a double-count bug in the FML coordinator error path where `tasks_failed` was incremented even when the wasm task had already succeeded.

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality

No breaking changes. The four new metrics are additive. The `task.stop` span gains a `task_id` field for Jaeger correlation with `task.start`.

### Have you included tests for your changes?

Yes — `cargo test` passes (128 tests). Three tests in `telemetry.rs` cover the new metrics:

- `test_metrics_new_all_zero` — asserts all 12 metrics initialise to zero
- `test_metrics_registry_gathers_all_metrics` — asserts all 12 metric names are present in the Prometheus registry
- `test_cpu_and_container_metrics_set` — exercises the new gauge setters with concrete values

### Did you document any new/modified functionality?

The Grafana dashboard JSON (`docker/addons/grafana/grafana/dashboards/propeller.json`) is updated with the two new panels.

### Notes

The CPU gauge names intentionally omit the `_total` suffix. Prometheus convention reserves `_total` for `Counter` types. These metrics are `Gauge` values set via `set()`, not monotonically incremented via `inc()`.