### PR TITLE
NOISSUE - Add Rustfmt and clippy as required toolchain components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Adds `components = ["rustfmt", "clippy"]` to `rust-toolchain.toml`
- Without this, fresh CI runners install the 1.96.0 toolchain but skip `rustfmt`, causing `cargo fmt --all -- --check` to fail with `'cargo-fmt' is not installed for the toolchain '1.96.0-x86_64-unknown-linux-gnu'`
- This was the root cause of the CI failure after PR #244 was merged
