### PR TITLE
NOISSUE - Add redaction for API responses and logs, update toolchain targets

### DIFF
--- a/manager/api/redact.go
+++ b/manager/api/redact.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"encoding/base64"
+
+	"github.com/absmach/propeller/manager"
+	"github.com/absmach/propeller/pkg/task"
+)
+
+const redactedMarker = "<REDACTED>"
+
+func redactFile(file []byte) string {
+	if len(file) == 0 {
+		return ""
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(file)
+	if len(encoded) <= 20 {
+		return encoded
+	}
+
+	return encoded[:10] + redactedMarker + encoded[len(encoded)-10:]
+}
+
+type taskAlias task.Task
+
+type redactedTask struct {
+	taskAlias
+	File string `json:"file,omitempty"`
+}
+
+func newRedactedTask(t task.Task) redactedTask {
+	return redactedTask{taskAlias: taskAlias(t), File: redactFile(t.File)}
+}
+
+func redactTasks(tasks []task.Task) []redactedTask {
+	if tasks == nil {
+		return nil
+	}
+
+	out := make([]redactedTask, len(tasks))
+	for i, t := range tasks {
+		out[i] = newRedactedTask(t)
+	}
+
+	return out
+}
+
+type redactedJobSummary struct {
+	manager.JobSummary
+	Tasks []redactedTask `json:"tasks"`
+}
+
+func redactJobSummaries(jobs []manager.JobSummary) []redactedJobSummary {
+	if jobs == nil {
+		return nil
+	}
+
+	out := make([]redactedJobSummary, len(jobs))
+	for i, j := range jobs {
+		out[i] = redactedJobSummary{JobSummary: j, Tasks: redactTasks(j.Tasks)}
+	}
+
+	return out
+}

--- a/manager/api/redact.go
+++ b/manager/api/redact.go
@@ -26,6 +26,7 @@ type taskAlias task.Task
 
 type redactedTask struct {
 	taskAlias
+
 	File string `json:"file,omitempty"`
 }
 
@@ -39,8 +40,8 @@ func redactTasks(tasks []task.Task) []redactedTask {
 	}
 
 	out := make([]redactedTask, len(tasks))
-	for i, t := range tasks {
-		out[i] = newRedactedTask(t)
+	for i := range tasks {
+		out[i] = newRedactedTask(tasks[i])
 	}
 
 	return out
@@ -48,6 +49,7 @@ func redactTasks(tasks []task.Task) []redactedTask {
 
 type redactedJobSummary struct {
 	manager.JobSummary
+
 	Tasks []redactedTask `json:"tasks"`
 }
 
@@ -57,8 +59,8 @@ func redactJobSummaries(jobs []manager.JobSummary) []redactedJobSummary {
 	}
 
 	out := make([]redactedJobSummary, len(jobs))
-	for i, j := range jobs {
-		out[i] = redactedJobSummary{JobSummary: j, Tasks: redactTasks(j.Tasks)}
+	for i := range jobs {
+		out[i] = redactedJobSummary{JobSummary: jobs[i], Tasks: redactTasks(jobs[i].Tasks)}
 	}
 
 	return out

--- a/manager/api/responses.go
+++ b/manager/api/responses.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/absmach/magistrala"
@@ -138,6 +139,10 @@ func (t taskResponse) Empty() bool {
 	return t.deleted
 }
 
+func (t taskResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(newRedactedTask(t.Task))
+}
+
 type listTaskResponse struct {
 	task.TaskPage
 }
@@ -152,6 +157,20 @@ func (l listTaskResponse) Headers() map[string]string {
 
 func (l listTaskResponse) Empty() bool {
 	return false
+}
+
+func (l listTaskResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Offset uint64         `json:"offset"`
+		Limit  uint64         `json:"limit"`
+		Total  uint64         `json:"total"`
+		Tasks  []redactedTask `json:"tasks"`
+	}{
+		Offset: l.Offset,
+		Limit:  l.Limit,
+		Total:  l.Total,
+		Tasks:  redactTasks(l.Tasks),
+	})
 }
 
 type messageResponse map[string]any
@@ -216,6 +235,12 @@ func (w workflowResponse) Empty() bool {
 	return len(w.Tasks) == 0
 }
 
+func (w workflowResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Tasks []redactedTask `json:"tasks"`
+	}{Tasks: redactTasks(w.Tasks)})
+}
+
 type taskResultsResponse struct {
 	Results any `json:"results"`
 }
@@ -251,6 +276,13 @@ func (j jobResponse) Empty() bool {
 	return len(j.Tasks) == 0
 }
 
+func (j jobResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		JobID string         `json:"job_id"`
+		Tasks []redactedTask `json:"tasks"`
+	}{JobID: j.JobID, Tasks: redactTasks(j.Tasks)})
+}
+
 type listJobResponse struct {
 	manager.JobPage
 }
@@ -265,4 +297,18 @@ func (l listJobResponse) Headers() map[string]string {
 
 func (l listJobResponse) Empty() bool {
 	return len(l.Jobs) == 0
+}
+
+func (l listJobResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Offset uint64               `json:"offset"`
+		Limit  uint64               `json:"limit"`
+		Total  uint64               `json:"total"`
+		Jobs   []redactedJobSummary `json:"jobs"`
+	}{
+		Offset: l.Offset,
+		Limit:  l.Limit,
+		Total:  l.Total,
+		Jobs:   redactJobSummaries(l.Jobs),
+	})
 }

--- a/proplet/src/main.rs
+++ b/proplet/src/main.rs
@@ -5,6 +5,7 @@ mod metrics;
 mod monitoring;
 mod mqtt;
 mod plugin;
+mod redact;
 mod runtime;
 mod service;
 mod task_handler;

--- a/proplet/src/redact.rs
+++ b/proplet/src/redact.rs
@@ -1,0 +1,104 @@
+use serde_json::Value;
+
+const REDACTED_MARKER: &str = "<REDACTED>";
+
+const SENSITIVE_KEYS: [&str; 2] = ["file", "data"];
+
+pub fn redact_value(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    if chars.len() <= 20 {
+        return value.to_string();
+    }
+
+    let head: String = chars[..10].iter().collect();
+    let tail: String = chars[chars.len() - 10..].iter().collect();
+
+    format!("{head}{REDACTED_MARKER}{tail}")
+}
+
+pub fn redact_payload(payload: &str) -> String {
+    match serde_json::from_str::<Value>(payload) {
+        Ok(mut value) => {
+            redact_json(&mut value);
+            value.to_string()
+        }
+        Err(_) => payload.to_string(),
+    }
+}
+
+fn redact_json(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                match val {
+                    Value::String(s) if SENSITIVE_KEYS.contains(&key.as_str()) => {
+                        *s = redact_value(s);
+                    }
+                    other => redact_json(other),
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for val in arr.iter_mut() {
+                redact_json(val);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn short_values_are_unchanged() {
+        assert_eq!(redact_value(""), "");
+        assert_eq!(redact_value("short"), "short");
+        assert_eq!(redact_value("01234567890123456789"), "01234567890123456789");
+    }
+
+    #[test]
+    fn long_values_are_redacted() {
+        let value = "0123456789ABCDEFGHIJ0123456789"; // 30 chars
+        assert_eq!(redact_value(value), "0123456789<REDACTED>0123456789");
+    }
+
+    #[test]
+    fn redacts_file_field_in_payload() {
+        let file = "AGFzbQEAAAABBwFgAn9/AX8DAgEABwcBA2FkZAAA";
+        let payload = json!({ "id": "task-1", "file": file }).to_string();
+
+        let redacted = redact_payload(&payload);
+        let value: Value = serde_json::from_str(&redacted).unwrap();
+
+        assert_eq!(value["id"], "task-1");
+        assert_eq!(value["file"], redact_value(file));
+        assert_eq!(value["file"].as_str().unwrap().len(), 30);
+        assert!(value["file"].as_str().unwrap().contains(REDACTED_MARKER));
+        assert!(value["file"].as_str().unwrap().starts_with(&file[..10]));
+        assert!(value["file"]
+            .as_str()
+            .unwrap()
+            .ends_with(&file[file.len() - 10..]));
+    }
+
+    #[test]
+    fn redacts_data_field_in_payload() {
+        let data = "aGVsbG8gd29ybGQgdGhpcyBpcyBhIGNodW5r";
+        let payload = json!({ "app_name": "my-app", "data": data }).to_string();
+
+        let redacted = redact_payload(&payload);
+        let value: Value = serde_json::from_str(&redacted).unwrap();
+
+        assert_eq!(value["app_name"], "my-app");
+        assert_eq!(value["data"], redact_value(data));
+        assert!(value["data"].as_str().unwrap().contains(REDACTED_MARKER));
+    }
+
+    #[test]
+    fn non_json_payload_is_unchanged() {
+        assert_eq!(redact_payload("not json"), "not json");
+    }
+}

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -434,7 +434,10 @@ impl PropletService {
         debug!("Handling message from topic: {}", msg.topic);
 
         if let Ok(payload_str) = String::from_utf8(msg.payload.clone()) {
-            debug!("Raw message payload: {}", payload_str);
+            debug!(
+                "Raw message payload: {}",
+                crate::redact::redact_payload(&payload_str)
+            );
         }
 
         if msg.topic.contains("control/manager/start") {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,9 @@
 [toolchain]
 channel = "1.96.0"
 components = ["rustfmt", "clippy"]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "riscv64gc-unknown-linux-gnu",
+  "wasm32-wasip2",
+]


### PR DESCRIPTION
# What type of PR is this?

This is a security enhancement because it redacts sensitive Wasm binary data from API responses and debug logs.

## What does this do?

Redacts the `file` field (base64-encoded Wasm binary) in Manager API responses and proplet MQTT payload debug logs using `<REDACTED>` markers. Adds explicit cross-compilation targets to `rust-toolchain.toml`.

## Which issue(s) does this PR fix/relate to?
N/A

## Have you included tests for your changes?
Yes

## Did you document any new/modified features?
Yes, https://github.com/absmach/propeller-docs/pull/37

### Notes
N/A
