### PR TITLE
PROP-239 - Add latent tasks for on-demand FaaS execution

### DIFF
--- a/cli/tasks.go
+++ b/cli/tasks.go
@@ -339,12 +339,13 @@ func newTaskInvokeCmd() *cobra.Command {
 				return
 			}
 
-			if err := psdk.InvokeTask(args[0], args[1:]); err != nil {
+			results, err := psdk.InvokeTask(args[0], args[1:])
+			if err != nil {
 				logErrorCmd(*cmd, err)
 
 				return
 			}
-			logOKCmd(*cmd)
+			logJSONCmd(*cmd, results)
 		},
 	}
 }

--- a/cli/tasks.go
+++ b/cli/tasks.go
@@ -327,6 +327,28 @@ func newTaskStopCmd() *cobra.Command {
 	}
 }
 
+func newTaskInvokeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "invoke <id> [inputs...]",
+		Short: "Invoke a latent task",
+		Long:  `Invoke a latent task with optional inputs.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				logUsageCmd(*cmd, cmd.Use)
+
+				return
+			}
+
+			if err := psdk.InvokeTask(args[0], args[1:]); err != nil {
+				logErrorCmd(*cmd, err)
+
+				return
+			}
+			logOKCmd(*cmd)
+		},
+	}
+}
+
 func newTaskMetricsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "metrics <id>",
@@ -398,9 +420,9 @@ func newTaskUploadCmd() *cobra.Command {
 
 func NewTasksCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tasks [create|view|list|update|delete|start|stop|metrics|results|upload]",
+		Use:   "tasks [create|view|list|update|delete|start|stop|invoke|metrics|results|upload]",
 		Short: "Tasks manager",
-		Long:  `Create, view, list, update, delete, start, stop, and inspect tasks.`,
+		Long:  `Create, view, list, update, delete, start, stop, invoke, and inspect tasks.`,
 	}
 
 	cmd.AddCommand(newTaskCreateCmd())
@@ -410,6 +432,7 @@ func NewTasksCmd() *cobra.Command {
 	cmd.AddCommand(newTaskDeleteCmd())
 	cmd.AddCommand(newTaskStartCmd())
 	cmd.AddCommand(newTaskStopCmd())
+	cmd.AddCommand(newTaskInvokeCmd())
 	cmd.AddCommand(newTaskMetricsCmd())
 	cmd.AddCommand(newTaskResultsCmd())
 	cmd.AddCommand(newTaskUploadCmd())

--- a/cli/tasks.go
+++ b/cli/tasks.go
@@ -28,6 +28,7 @@ type taskFlags struct {
 	inputs          []string
 	env             []string
 	daemon          bool
+	latent          bool
 	encrypted       bool
 	kbsResourcePath string
 	propletID       string
@@ -47,6 +48,7 @@ func registerTaskFlags(cmd *cobra.Command, tf *taskFlags) {
 	cmd.Flags().StringSliceVar(&tf.inputs, "inputs", nil, "Input values passed to the Wasm module (comma-separated)")
 	cmd.Flags().StringSliceVar(&tf.env, "env", nil, "Environment variables KEY=VALUE (comma-separated or repeatable)")
 	cmd.Flags().BoolVar(&tf.daemon, "daemon", false, "Run continuously until stopped")
+	cmd.Flags().BoolVar(&tf.latent, "latent", false, "Precompile on start and keep resident for on-demand invocation")
 	cmd.Flags().BoolVar(&tf.encrypted, "encrypted", false, "Wasm binary is encrypted (requires KBS)")
 	cmd.Flags().StringVar(&tf.kbsResourcePath, "kbs-resource-path", "", "KBS resource path for encrypted binaries")
 	cmd.Flags().StringVar(&tf.propletID, "proplet-id", "", "Target proplet ID (mutually exclusive with --broadcast)")
@@ -81,6 +83,9 @@ func taskFromFlags(cmd *cobra.Command, tf *taskFlags, id, name string) sdk.Task 
 	}
 	if f.Changed("daemon") {
 		t.Daemon = tf.daemon
+	}
+	if f.Changed("latent") {
+		t.Latent = tf.latent
 	}
 	if f.Changed("encrypted") {
 		t.Encrypted = tf.encrypted
@@ -158,7 +163,10 @@ Examples:
   propeller-cli tasks create wasi-nn-inference --cli-args="-S,nn,--dir=/home/proplet/fixture::fixture"
 
   # Create a task from an OCI image reference
-  propeller-cli tasks create my-task --image-url docker.io/myorg/app:v1`,
+  propeller-cli tasks create my-task --image-url docker.io/myorg/app:v1
+
+  # Create a latent task that stays resident and is invoked on demand
+  propeller-cli tasks create greet --latent`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
 				logUsageCmd(*cmd, cmd.Use)

--- a/cli/tasks.go
+++ b/cli/tasks.go
@@ -336,10 +336,18 @@ func newTaskStopCmd() *cobra.Command {
 }
 
 func newTaskInvokeCmd() *cobra.Command {
-	return &cobra.Command{
+	var env []string
+	cmd := &cobra.Command{
 		Use:   "invoke <id> [inputs...]",
 		Short: "Invoke a latent task",
-		Long:  `Invoke a latent task with optional inputs.`,
+		Long: `Invoke a latent task with optional inputs.
+
+Examples:
+  # Invoke with positional inputs
+  propeller-cli tasks invoke <id> '"world"'
+
+  # Override environment variables for this invocation only
+  propeller-cli tasks invoke <id> '"world"' --env GREETING=hola`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) < 1 {
 				logUsageCmd(*cmd, cmd.Use)
@@ -347,7 +355,7 @@ func newTaskInvokeCmd() *cobra.Command {
 				return
 			}
 
-			results, err := psdk.InvokeTask(args[0], args[1:])
+			results, err := psdk.InvokeTask(args[0], args[1:], toMap(env))
 			if err != nil {
 				logErrorCmd(*cmd, err)
 
@@ -356,6 +364,9 @@ func newTaskInvokeCmd() *cobra.Command {
 			logJSONCmd(*cmd, results)
 		},
 	}
+	cmd.Flags().StringSliceVar(&env, "env", nil, "Environment variables KEY=VALUE applied to this invocation only (comma-separated or repeatable)")
+
+	return cmd
 }
 
 func newTaskMetricsCmd() *cobra.Command {

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -392,12 +392,14 @@ func invokeTaskEndpoint(svc manager.Service) endpoint.Endpoint {
 			return messageResponse{}, errors.Join(api.ErrValidation, err)
 		}
 
-		if err := svc.InvokeTask(ctx, req.id, req.inputs); err != nil {
+		results, err := svc.InvokeTask(ctx, req.id, req.inputs)
+		if err != nil {
 			return messageResponse{}, err
 		}
 
 		return messageResponse{
 			"invoked": true,
+			"results": results,
 		}, nil
 	}
 }

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -382,6 +382,26 @@ func stopTaskEndpoint(svc manager.Service) endpoint.Endpoint {
 	}
 }
 
+func invokeTaskEndpoint(svc manager.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request any) (any, error) {
+		req, ok := request.(invokeReq)
+		if !ok {
+			return messageResponse{}, errors.Join(api.ErrValidation, pkgerrors.ErrInvalidData)
+		}
+		if err := req.validate(); err != nil {
+			return messageResponse{}, errors.Join(api.ErrValidation, err)
+		}
+
+		if err := svc.InvokeTask(ctx, req.id, req.inputs); err != nil {
+			return messageResponse{}, err
+		}
+
+		return messageResponse{
+			"invoked": true,
+		}, nil
+	}
+}
+
 func getTaskMetricsEndpoint(svc manager.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request any) (any, error) {
 		req, ok := request.(metricsReq)

--- a/manager/api/endpoint.go
+++ b/manager/api/endpoint.go
@@ -392,7 +392,7 @@ func invokeTaskEndpoint(svc manager.Service) endpoint.Endpoint {
 			return messageResponse{}, errors.Join(api.ErrValidation, err)
 		}
 
-		results, err := svc.InvokeTask(ctx, req.id, req.inputs)
+		results, err := svc.InvokeTask(ctx, req.id, req.inputs, req.env)
 		if err != nil {
 			return messageResponse{}, err
 		}

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -119,6 +119,23 @@ func (e *entityReq) validate() error {
 	return nil
 }
 
+type invokeReq struct {
+	id     string
+	inputs []string
+}
+
+func (r *invokeReq) validate() error {
+	if r.id == "" {
+		return api.ErrMissingID
+	}
+
+	if _, err := uuid.Parse(r.id); err != nil {
+		return api.ErrInvalidQueryParams
+	}
+
+	return nil
+}
+
 type listEntityStatus uint8
 
 const (

--- a/manager/api/requests.go
+++ b/manager/api/requests.go
@@ -122,6 +122,7 @@ func (e *entityReq) validate() error {
 type invokeReq struct {
 	id     string
 	inputs []string
+	env    map[string]string
 }
 
 func (r *invokeReq) validate() error {

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/api"
 	"github.com/absmach/propeller/pkg/plugin"
+	"github.com/absmach/propeller/pkg/task"
 	"github.com/go-chi/chi/v5"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -129,6 +130,12 @@ func MakeHandler(svc manager.Service, logger *slog.Logger, instanceID string) ht
 				api.EncodeResponse,
 				opts...,
 			), "stop-task").ServeHTTP)
+			r.Post("/invoke", otelhttp.NewHandler(kithttp.NewServer(
+				invokeTaskEndpoint(svc),
+				decodeInvokeTaskReq,
+				api.EncodeResponse,
+				opts...,
+			), "invoke-task").ServeHTTP)
 			r.Get("/metrics", otelhttp.NewHandler(kithttp.NewServer(
 				getTaskMetricsEndpoint(svc),
 				decodeMetricsReq("taskID"),
@@ -300,6 +307,28 @@ func decodeUploadTaskFileReq(_ context.Context, r *http.Request) (any, error) {
 	}
 	req.File = data
 	req.ID = chi.URLParam(r, "taskID")
+
+	return req, nil
+}
+
+func decodeInvokeTaskReq(_ context.Context, r *http.Request) (any, error) {
+	req := invokeReq{id: chi.URLParam(r, "taskID")}
+
+	if r.Body == nil || r.ContentLength == 0 {
+		return req, nil
+	}
+
+	if !strings.Contains(r.Header.Get("Content-Type"), api.ContentType) {
+		return nil, errors.Join(api.ErrValidation, api.ErrUnsupportedContentType)
+	}
+
+	var body struct {
+		Inputs task.FlexStrings `json:"inputs"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return nil, errors.Join(err, api.ErrValidation)
+	}
+	req.inputs = []string(body.Inputs)
 
 	return req, nil
 }

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -323,12 +323,14 @@ func decodeInvokeTaskReq(_ context.Context, r *http.Request) (any, error) {
 	}
 
 	var body struct {
-		Inputs task.FlexStrings `json:"inputs"`
+		Inputs task.FlexStrings  `json:"inputs"`
+		Env    map[string]string `json:"env"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		return nil, errors.Join(err, api.ErrValidation)
 	}
 	req.inputs = []string(body.Inputs)
+	req.env = body.Env
 
 	return req, nil
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -34,7 +34,7 @@ type Service interface {
 	DeleteTask(ctx context.Context, taskID string) error
 	StartTask(ctx context.Context, taskID string) error
 	StopTask(ctx context.Context, taskID string) error
-	InvokeTask(ctx context.Context, taskID string, inputs []string) error
+	InvokeTask(ctx context.Context, taskID string, inputs []string) (string, error)
 
 	GetTaskResults(ctx context.Context, taskID string) (any, error)
 	GetParentResults(ctx context.Context, taskID string) (map[string]any, error)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -34,6 +34,7 @@ type Service interface {
 	DeleteTask(ctx context.Context, taskID string) error
 	StartTask(ctx context.Context, taskID string) error
 	StopTask(ctx context.Context, taskID string) error
+	InvokeTask(ctx context.Context, taskID string, inputs []string) error
 
 	GetTaskResults(ctx context.Context, taskID string) (any, error)
 	GetParentResults(ctx context.Context, taskID string) (map[string]any, error)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -34,7 +34,7 @@ type Service interface {
 	DeleteTask(ctx context.Context, taskID string) error
 	StartTask(ctx context.Context, taskID string) error
 	StopTask(ctx context.Context, taskID string) error
-	InvokeTask(ctx context.Context, taskID string, inputs []string) (string, error)
+	InvokeTask(ctx context.Context, taskID string, inputs []string, env map[string]string) (string, error)
 
 	GetTaskResults(ctx context.Context, taskID string) (any, error)
 	GetParentResults(ctx context.Context, taskID string) (map[string]any, error)

--- a/manager/middleware/logging.go
+++ b/manager/middleware/logging.go
@@ -290,6 +290,26 @@ func (lm *loggingMiddleware) StopTask(ctx context.Context, id string) (err error
 	return lm.svc.StopTask(ctx, id)
 }
 
+func (lm *loggingMiddleware) InvokeTask(ctx context.Context, id string, inputs []string) (err error) {
+	defer func(begin time.Time) {
+		args := []any{
+			slog.String("duration", time.Since(begin).String()),
+			slog.Group("task",
+				slog.String("id", id),
+			),
+		}
+		if err != nil {
+			args = append(args, slog.Any("error", err))
+			lm.logger.Warn("Invoking task failed", args...)
+
+			return
+		}
+		lm.logger.Info("Invoking task completed successfully", args...)
+	}(time.Now())
+
+	return lm.svc.InvokeTask(ctx, id, inputs)
+}
+
 func (lm *loggingMiddleware) GetTaskMetrics(ctx context.Context, taskID string, offset, limit uint64) (resp manager.TaskMetricsPage, err error) {
 	defer func(begin time.Time) {
 		args := []any{

--- a/manager/middleware/logging.go
+++ b/manager/middleware/logging.go
@@ -290,7 +290,7 @@ func (lm *loggingMiddleware) StopTask(ctx context.Context, id string) (err error
 	return lm.svc.StopTask(ctx, id)
 }
 
-func (lm *loggingMiddleware) InvokeTask(ctx context.Context, id string, inputs []string) (err error) {
+func (lm *loggingMiddleware) InvokeTask(ctx context.Context, id string, inputs []string) (result string, err error) {
 	defer func(begin time.Time) {
 		args := []any{
 			slog.String("duration", time.Since(begin).String()),

--- a/manager/middleware/logging.go
+++ b/manager/middleware/logging.go
@@ -290,7 +290,7 @@ func (lm *loggingMiddleware) StopTask(ctx context.Context, id string) (err error
 	return lm.svc.StopTask(ctx, id)
 }
 
-func (lm *loggingMiddleware) InvokeTask(ctx context.Context, id string, inputs []string) (result string, err error) {
+func (lm *loggingMiddleware) InvokeTask(ctx context.Context, id string, inputs []string, env map[string]string) (result string, err error) {
 	defer func(begin time.Time) {
 		args := []any{
 			slog.String("duration", time.Since(begin).String()),
@@ -307,7 +307,7 @@ func (lm *loggingMiddleware) InvokeTask(ctx context.Context, id string, inputs [
 		lm.logger.Info("Invoking task completed successfully", args...)
 	}(time.Now())
 
-	return lm.svc.InvokeTask(ctx, id, inputs)
+	return lm.svc.InvokeTask(ctx, id, inputs, env)
 }
 
 func (lm *loggingMiddleware) GetTaskMetrics(ctx context.Context, taskID string, offset, limit uint64) (resp manager.TaskMetricsPage, err error) {

--- a/manager/middleware/metrics.go
+++ b/manager/middleware/metrics.go
@@ -144,6 +144,15 @@ func (mm *metricsMiddleware) StopTask(ctx context.Context, id string) error {
 	return mm.svc.StopTask(ctx, id)
 }
 
+func (mm *metricsMiddleware) InvokeTask(ctx context.Context, id string, inputs []string) error {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "invoke-task").Add(1)
+		mm.latency.With("method", "invoke-task").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.InvokeTask(ctx, id, inputs)
+}
+
 func (mm *metricsMiddleware) GetTaskMetrics(ctx context.Context, taskID string, offset, limit uint64) (manager.TaskMetricsPage, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "get-task-metrics").Add(1)

--- a/manager/middleware/metrics.go
+++ b/manager/middleware/metrics.go
@@ -144,7 +144,7 @@ func (mm *metricsMiddleware) StopTask(ctx context.Context, id string) error {
 	return mm.svc.StopTask(ctx, id)
 }
 
-func (mm *metricsMiddleware) InvokeTask(ctx context.Context, id string, inputs []string) error {
+func (mm *metricsMiddleware) InvokeTask(ctx context.Context, id string, inputs []string) (string, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "invoke-task").Add(1)
 		mm.latency.With("method", "invoke-task").Observe(time.Since(begin).Seconds())

--- a/manager/middleware/metrics.go
+++ b/manager/middleware/metrics.go
@@ -144,13 +144,13 @@ func (mm *metricsMiddleware) StopTask(ctx context.Context, id string) error {
 	return mm.svc.StopTask(ctx, id)
 }
 
-func (mm *metricsMiddleware) InvokeTask(ctx context.Context, id string, inputs []string) (string, error) {
+func (mm *metricsMiddleware) InvokeTask(ctx context.Context, id string, inputs []string, env map[string]string) (string, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "invoke-task").Add(1)
 		mm.latency.With("method", "invoke-task").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.InvokeTask(ctx, id, inputs)
+	return mm.svc.InvokeTask(ctx, id, inputs, env)
 }
 
 func (mm *metricsMiddleware) GetTaskMetrics(ctx context.Context, taskID string, offset, limit uint64) (manager.TaskMetricsPage, error) {

--- a/manager/middleware/plugin.go
+++ b/manager/middleware/plugin.go
@@ -84,6 +84,19 @@ func (pm *pluginMiddleware) StartTask(ctx context.Context, taskID string) error 
 	return nil
 }
 
+func (pm *pluginMiddleware) InvokeTask(ctx context.Context, taskID string, inputs []string) error {
+	t, err := pm.GetTask(ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	if err := pm.authorize(ctx, plugin.ActionInvoke, plugin.NewTaskInfo(t)); err != nil {
+		return err
+	}
+
+	return pm.Service.InvokeTask(ctx, taskID, inputs)
+}
+
 func (pm *pluginMiddleware) StopTask(ctx context.Context, taskID string) error {
 	t, err := pm.GetTask(ctx, taskID)
 	if err != nil {

--- a/manager/middleware/plugin.go
+++ b/manager/middleware/plugin.go
@@ -84,14 +84,14 @@ func (pm *pluginMiddleware) StartTask(ctx context.Context, taskID string) error 
 	return nil
 }
 
-func (pm *pluginMiddleware) InvokeTask(ctx context.Context, taskID string, inputs []string) error {
+func (pm *pluginMiddleware) InvokeTask(ctx context.Context, taskID string, inputs []string) (string, error) {
 	t, err := pm.GetTask(ctx, taskID)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if err := pm.authorize(ctx, plugin.ActionInvoke, plugin.NewTaskInfo(t)); err != nil {
-		return err
+		return "", err
 	}
 
 	return pm.Service.InvokeTask(ctx, taskID, inputs)

--- a/manager/middleware/plugin.go
+++ b/manager/middleware/plugin.go
@@ -84,7 +84,7 @@ func (pm *pluginMiddleware) StartTask(ctx context.Context, taskID string) error 
 	return nil
 }
 
-func (pm *pluginMiddleware) InvokeTask(ctx context.Context, taskID string, inputs []string) (string, error) {
+func (pm *pluginMiddleware) InvokeTask(ctx context.Context, taskID string, inputs []string, env map[string]string) (string, error) {
 	t, err := pm.GetTask(ctx, taskID)
 	if err != nil {
 		return "", err
@@ -94,7 +94,7 @@ func (pm *pluginMiddleware) InvokeTask(ctx context.Context, taskID string, input
 		return "", err
 	}
 
-	return pm.Service.InvokeTask(ctx, taskID, inputs)
+	return pm.Service.InvokeTask(ctx, taskID, inputs, env)
 }
 
 func (pm *pluginMiddleware) StopTask(ctx context.Context, taskID string) error {

--- a/manager/middleware/tracing.go
+++ b/manager/middleware/tracing.go
@@ -149,7 +149,7 @@ func (tm *tracing) StopTask(ctx context.Context, id string) (err error) {
 	return tm.svc.StopTask(ctx, id)
 }
 
-func (tm *tracing) InvokeTask(ctx context.Context, id string, inputs []string) (err error) {
+func (tm *tracing) InvokeTask(ctx context.Context, id string, inputs []string) (string, error) {
 	ctx, span := tm.tracer.Start(ctx, "invoke-task", trace.WithAttributes(
 		attribute.String("id", id),
 	))

--- a/manager/middleware/tracing.go
+++ b/manager/middleware/tracing.go
@@ -149,6 +149,15 @@ func (tm *tracing) StopTask(ctx context.Context, id string) (err error) {
 	return tm.svc.StopTask(ctx, id)
 }
 
+func (tm *tracing) InvokeTask(ctx context.Context, id string, inputs []string) (err error) {
+	ctx, span := tm.tracer.Start(ctx, "invoke-task", trace.WithAttributes(
+		attribute.String("id", id),
+	))
+	defer span.End()
+
+	return tm.svc.InvokeTask(ctx, id, inputs)
+}
+
 func (tm *tracing) GetTaskMetrics(ctx context.Context, taskID string, offset, limit uint64) (resp manager.TaskMetricsPage, err error) {
 	ctx, span := tm.tracer.Start(ctx, "get-task-metrics", trace.WithAttributes(
 		attribute.String("task_id", taskID),

--- a/manager/middleware/tracing.go
+++ b/manager/middleware/tracing.go
@@ -149,13 +149,13 @@ func (tm *tracing) StopTask(ctx context.Context, id string) (err error) {
 	return tm.svc.StopTask(ctx, id)
 }
 
-func (tm *tracing) InvokeTask(ctx context.Context, id string, inputs []string) (string, error) {
+func (tm *tracing) InvokeTask(ctx context.Context, id string, inputs []string, env map[string]string) (string, error) {
 	ctx, span := tm.tracer.Start(ctx, "invoke-task", trace.WithAttributes(
 		attribute.String("id", id),
 	))
 	defer span.End()
 
-	return tm.svc.InvokeTask(ctx, id, inputs)
+	return tm.svc.InvokeTask(ctx, id, inputs, env)
 }
 
 func (tm *tracing) GetTaskMetrics(ctx context.Context, taskID string, offset, limit uint64) (resp manager.TaskMetricsPage, err error) {

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -1206,6 +1206,84 @@ func (_c *MockService_GetTaskResults_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
+// InvokeTask provides a mock function for the type MockService
+func (_mock *MockService) InvokeTask(ctx context.Context, taskID string, inputs []string, env map[string]string) (string, error) {
+	ret := _mock.Called(ctx, taskID, inputs, env)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InvokeTask")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, map[string]string) (string, error)); ok {
+		return returnFunc(ctx, taskID, inputs, env)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, map[string]string) string); ok {
+		r0 = returnFunc(ctx, taskID, inputs, env)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string, map[string]string) error); ok {
+		r1 = returnFunc(ctx, taskID, inputs, env)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockService_InvokeTask_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InvokeTask'
+type MockService_InvokeTask_Call struct {
+	*mock.Call
+}
+
+// InvokeTask is a helper method to define mock.On call
+//   - ctx context.Context
+//   - taskID string
+//   - inputs []string
+//   - env map[string]string
+func (_e *MockService_Expecter) InvokeTask(ctx interface{}, taskID interface{}, inputs interface{}, env interface{}) *MockService_InvokeTask_Call {
+	return &MockService_InvokeTask_Call{Call: _e.mock.On("InvokeTask", ctx, taskID, inputs, env)}
+}
+
+func (_c *MockService_InvokeTask_Call) Run(run func(ctx context.Context, taskID string, inputs []string, env map[string]string)) *MockService_InvokeTask_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		var arg3 map[string]string
+		if args[3] != nil {
+			arg3 = args[3].(map[string]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_InvokeTask_Call) Return(s string, err error) *MockService_InvokeTask_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *MockService_InvokeTask_Call) RunAndReturn(run func(ctx context.Context, taskID string, inputs []string, env map[string]string) (string, error)) *MockService_InvokeTask_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListJobs provides a mock function for the type MockService
 func (_mock *MockService) ListJobs(ctx context.Context, offset uint64, limit uint64, status string) (manager.JobPage, error) {
 	ret := _mock.Called(ctx, offset, limit, status)
@@ -1820,78 +1898,6 @@ func (_c *MockService_StartTask_Call) Return(err error) *MockService_StartTask_C
 }
 
 func (_c *MockService_StartTask_Call) RunAndReturn(run func(ctx context.Context, taskID string) error) *MockService_StartTask_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// InvokeTask provides a mock function for the type MockService
-func (_mock *MockService) InvokeTask(ctx context.Context, taskID string, inputs []string) (string, error) {
-	ret := _mock.Called(ctx, taskID, inputs)
-
-	if len(ret) == 0 {
-		panic("no return value specified for InvokeTask")
-	}
-
-	var r0 string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) (string, error)); ok {
-		return returnFunc(ctx, taskID, inputs)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) string); ok {
-		r0 = returnFunc(ctx, taskID, inputs)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string) error); ok {
-		r1 = returnFunc(ctx, taskID, inputs)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockService_InvokeTask_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InvokeTask'
-type MockService_InvokeTask_Call struct {
-	*mock.Call
-}
-
-// InvokeTask is a helper method to define mock.On call
-//   - ctx context.Context
-//   - taskID string
-//   - inputs []string
-func (_e *MockService_Expecter) InvokeTask(ctx interface{}, taskID interface{}, inputs interface{}) *MockService_InvokeTask_Call {
-	return &MockService_InvokeTask_Call{Call: _e.mock.On("InvokeTask", ctx, taskID, inputs)}
-}
-
-func (_c *MockService_InvokeTask_Call) Run(run func(ctx context.Context, taskID string, inputs []string)) *MockService_InvokeTask_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 []string
-		if args[2] != nil {
-			arg2 = args[2].([]string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockService_InvokeTask_Call) Return(s string, err error) *MockService_InvokeTask_Call {
-	_c.Call.Return(s, err)
-	return _c
-}
-
-func (_c *MockService_InvokeTask_Call) RunAndReturn(run func(ctx context.Context, taskID string, inputs []string) (string, error)) *MockService_InvokeTask_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -1824,6 +1824,69 @@ func (_c *MockService_StartTask_Call) RunAndReturn(run func(ctx context.Context,
 	return _c
 }
 
+// InvokeTask provides a mock function for the type MockService
+func (_mock *MockService) InvokeTask(ctx context.Context, taskID string, inputs []string) error {
+	ret := _mock.Called(ctx, taskID, inputs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InvokeTask")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) error); ok {
+		r0 = returnFunc(ctx, taskID, inputs)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockService_InvokeTask_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InvokeTask'
+type MockService_InvokeTask_Call struct {
+	*mock.Call
+}
+
+// InvokeTask is a helper method to define mock.On call
+//   - ctx context.Context
+//   - taskID string
+//   - inputs []string
+func (_e *MockService_Expecter) InvokeTask(ctx interface{}, taskID interface{}, inputs interface{}) *MockService_InvokeTask_Call {
+	return &MockService_InvokeTask_Call{Call: _e.mock.On("InvokeTask", ctx, taskID, inputs)}
+}
+
+func (_c *MockService_InvokeTask_Call) Run(run func(ctx context.Context, taskID string, inputs []string)) *MockService_InvokeTask_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_InvokeTask_Call) Return(err error) *MockService_InvokeTask_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockService_InvokeTask_Call) RunAndReturn(run func(ctx context.Context, taskID string, inputs []string) error) *MockService_InvokeTask_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // StopJob provides a mock function for the type MockService
 func (_mock *MockService) StopJob(ctx context.Context, jobID string) error {
 	ret := _mock.Called(ctx, jobID)

--- a/manager/mocks/service.go
+++ b/manager/mocks/service.go
@@ -1825,20 +1825,29 @@ func (_c *MockService_StartTask_Call) RunAndReturn(run func(ctx context.Context,
 }
 
 // InvokeTask provides a mock function for the type MockService
-func (_mock *MockService) InvokeTask(ctx context.Context, taskID string, inputs []string) error {
+func (_mock *MockService) InvokeTask(ctx context.Context, taskID string, inputs []string) (string, error) {
 	ret := _mock.Called(ctx, taskID, inputs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for InvokeTask")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) error); ok {
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) (string, error)); ok {
+		return returnFunc(ctx, taskID, inputs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) string); ok {
 		r0 = returnFunc(ctx, taskID, inputs)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(string)
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string) error); ok {
+		r1 = returnFunc(ctx, taskID, inputs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockService_InvokeTask_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InvokeTask'
@@ -1877,12 +1886,12 @@ func (_c *MockService_InvokeTask_Call) Run(run func(ctx context.Context, taskID 
 	return _c
 }
 
-func (_c *MockService_InvokeTask_Call) Return(err error) *MockService_InvokeTask_Call {
-	_c.Call.Return(err)
+func (_c *MockService_InvokeTask_Call) Return(s string, err error) *MockService_InvokeTask_Call {
+	_c.Call.Return(s, err)
 	return _c
 }
 
-func (_c *MockService_InvokeTask_Call) RunAndReturn(run func(ctx context.Context, taskID string, inputs []string) error) *MockService_InvokeTask_Call {
+func (_c *MockService_InvokeTask_Call) RunAndReturn(run func(ctx context.Context, taskID string, inputs []string) (string, error)) *MockService_InvokeTask_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/manager/service.go
+++ b/manager/service.go
@@ -1462,40 +1462,26 @@ func (svc *service) updateResultsHandler(ctx context.Context, msg map[string]any
 	return nil
 }
 
-func (svc *service) updateInvokeResultsHandler(ctx context.Context, msg map[string]any) error {
-	taskID, ok := msg["task_id"].(string)
-	if !ok {
-		return errors.New("invalid task_id")
-	}
-	if taskID == "" {
-		return errors.New("task id is empty")
+func (svc *service) updateInvokeResultsHandler(_ context.Context, msg map[string]any) error {
+	invocationID, ok := msg["invocation_id"].(string)
+	if !ok || invocationID == "" {
+		return nil
 	}
 
 	results, _ := msg["results"].(string)
 	errMsg, _ := msg["error"].(string)
 
-	if invocationID, ok := msg["invocation_id"].(string); ok && invocationID != "" {
-		svc.pendingInvokesMu.Lock()
-		ch, waiting := svc.pendingInvokes[invocationID]
-		svc.pendingInvokesMu.Unlock()
-		if waiting {
-			select {
-			case ch <- invokeResult{results: results, err: errMsg}:
-			default:
-			}
+	svc.pendingInvokesMu.Lock()
+	ch, waiting := svc.pendingInvokes[invocationID]
+	svc.pendingInvokesMu.Unlock()
+	if waiting {
+		select {
+		case ch <- invokeResult{results: results, err: errMsg}:
+		default:
 		}
 	}
 
-	t, err := svc.GetTask(ctx, taskID)
-	if err != nil {
-		return err
-	}
-
-	t.Results = msg["results"]
-	t.Error = errMsg
-	t.UpdatedAt = time.Now()
-
-	return svc.taskRepo.Update(ctx, t)
+	return nil
 }
 
 func (svc *service) startJobDependentTasks(ctx context.Context, jobTasks []task.Task, completedTaskID string) {

--- a/manager/service.go
+++ b/manager/service.go
@@ -1492,10 +1492,8 @@ func (svc *service) updateInvokeResultsHandler(ctx context.Context, msg map[stri
 	}
 
 	t.Results = msg["results"]
+	t.Error = errMsg
 	t.UpdatedAt = time.Now()
-	if errMsg != "" {
-		t.Error = errMsg
-	}
 
 	return svc.taskRepo.Update(ctx, t)
 }

--- a/manager/service.go
+++ b/manager/service.go
@@ -841,7 +841,7 @@ func (svc *service) StopTask(ctx context.Context, taskID string) error {
 	return nil
 }
 
-func (svc *service) InvokeTask(ctx context.Context, taskID string, inputs []string) (string, error) {
+func (svc *service) InvokeTask(ctx context.Context, taskID string, inputs []string, env map[string]string) (string, error) {
 	if svc.shuttingDown.Load() {
 		return "", errShuttingDown
 	}
@@ -871,7 +871,7 @@ func (svc *service) InvokeTask(ctx context.Context, taskID string, inputs []stri
 		svc.pendingInvokesMu.Unlock()
 	}()
 
-	if err := svc.publishInvoke(ctx, taskID, propletID, invocationID, inputs); err != nil {
+	if err := svc.publishInvoke(ctx, taskID, propletID, invocationID, inputs, env); err != nil {
 		return "", err
 	}
 
@@ -2008,13 +2008,16 @@ func (svc *service) invocationProplet(ctx context.Context, t task.Task) (string,
 	return svc.taskPropletRepo.Get(ctx, t.ID)
 }
 
-func (svc *service) publishInvoke(ctx context.Context, taskID, propletID, invocationID string, inputs []string) error {
+func (svc *service) publishInvoke(ctx context.Context, taskID, propletID, invocationID string, inputs []string, env map[string]string) error {
 	payload := map[string]any{
 		"id":            taskID,
 		"broadcast":     false,
 		"proplet_id":    propletID,
 		"invocation_id": invocationID,
 		"inputs":        inputs,
+	}
+	if len(env) > 0 {
+		payload["env"] = env
 	}
 	topic := svc.baseTopic + "/control/manager/invoke"
 

--- a/manager/service.go
+++ b/manager/service.go
@@ -875,6 +875,9 @@ func (svc *service) InvokeTask(ctx context.Context, taskID string, inputs []stri
 		return "", err
 	}
 
+	timer := time.NewTimer(invokeTimeout)
+	defer timer.Stop()
+
 	select {
 	case res := <-resultCh:
 		if res.err != "" {
@@ -882,7 +885,7 @@ func (svc *service) InvokeTask(ctx context.Context, taskID string, inputs []stri
 		}
 
 		return res.results, nil
-	case <-time.After(invokeTimeout):
+	case <-timer.C:
 		return "", fmt.Errorf("invocation of task %s timed out after %s", taskID, invokeTimeout)
 	case <-ctx.Done():
 		return "", ctx.Err()

--- a/manager/service.go
+++ b/manager/service.go
@@ -845,16 +845,12 @@ func (svc *service) InvokeTask(ctx context.Context, taskID string, inputs []stri
 		return fmt.Errorf("task %s is not a latent task and cannot be invoked", taskID)
 	}
 
-	if t.Broadcast {
-		return svc.publishInvoke(ctx, t, "", inputs)
-	}
-
-	propletID, err := svc.taskPropletRepo.Get(ctx, taskID)
+	propletID, err := svc.invocationProplet(ctx, t)
 	if err != nil {
 		return err
 	}
 
-	return svc.publishInvoke(ctx, t, propletID, inputs)
+	return svc.publishInvoke(ctx, taskID, propletID, inputs)
 }
 
 func (svc *service) StartJob(ctx context.Context, jobID string) error {
@@ -1961,10 +1957,23 @@ func (svc *service) publishStop(ctx context.Context, t task.Task, propletID stri
 	return svc.pubsub.Publish(ctx, topic, stopPayload)
 }
 
-func (svc *service) publishInvoke(ctx context.Context, t task.Task, propletID string, inputs []string) error {
+func (svc *service) invocationProplet(ctx context.Context, t task.Task) (string, error) {
+	if t.Broadcast {
+		p, err := svc.SelectProplet(ctx, t)
+		if err != nil {
+			return "", err
+		}
+
+		return p.ID, nil
+	}
+
+	return svc.taskPropletRepo.Get(ctx, t.ID)
+}
+
+func (svc *service) publishInvoke(ctx context.Context, taskID, propletID string, inputs []string) error {
 	payload := map[string]any{
-		"id":         t.ID,
-		"broadcast":  t.Broadcast,
+		"id":         taskID,
+		"broadcast":  false,
 		"proplet_id": propletID,
 		"inputs":     inputs,
 	}

--- a/manager/service.go
+++ b/manager/service.go
@@ -831,6 +831,32 @@ func (svc *service) StopTask(ctx context.Context, taskID string) error {
 	return nil
 }
 
+func (svc *service) InvokeTask(ctx context.Context, taskID string, inputs []string) error {
+	if svc.shuttingDown.Load() {
+		return errShuttingDown
+	}
+
+	t, err := svc.GetTask(ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	if !t.Latent {
+		return fmt.Errorf("task %s is not a latent task and cannot be invoked", taskID)
+	}
+
+	if t.Broadcast {
+		return svc.publishInvoke(ctx, t, "", inputs)
+	}
+
+	propletID, err := svc.taskPropletRepo.Get(ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	return svc.publishInvoke(ctx, t, propletID, inputs)
+}
+
 func (svc *service) StartJob(ctx context.Context, jobID string) error {
 	if svc.shuttingDown.Load() {
 		return errShuttingDown
@@ -1239,6 +1265,8 @@ func (svc *service) handle(ctx context.Context) func(topic string, msg map[strin
 			return svc.updateLivenessHandler(ctx, msg)
 		case svc.baseTopic + "/control/proplet/results":
 			return svc.updateResultsHandler(ctx, msg)
+		case svc.baseTopic + "/control/proplet/invoke_results":
+			return svc.updateInvokeResultsHandler(ctx, msg)
 		case svc.baseTopic + "/control/proplet/task_metrics":
 			return svc.handleTaskMetrics(ctx, msg)
 		case svc.baseTopic + "/control/proplet/metrics":
@@ -1397,6 +1425,29 @@ func (svc *service) updateResultsHandler(ctx context.Context, msg map[string]any
 	}
 
 	return nil
+}
+
+func (svc *service) updateInvokeResultsHandler(ctx context.Context, msg map[string]any) error {
+	taskID, ok := msg["task_id"].(string)
+	if !ok {
+		return errors.New("invalid task_id")
+	}
+	if taskID == "" {
+		return errors.New("task id is empty")
+	}
+
+	t, err := svc.GetTask(ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	t.Results = msg["results"]
+	t.UpdatedAt = time.Now()
+	if errMsg, ok := msg["error"].(string); ok && errMsg != "" {
+		t.Error = errMsg
+	}
+
+	return svc.taskRepo.Update(ctx, t)
 }
 
 func (svc *service) startJobDependentTasks(ctx context.Context, jobTasks []task.Task, completedTaskID string) {
@@ -1853,6 +1904,7 @@ type startPayload struct {
 	CLIArgs           []string                   `json:"cli_args"`
 	Broadcast         bool                       `json:"broadcast"`
 	Daemon            bool                       `json:"daemon"`
+	Latent            bool                       `json:"latent"`
 	Env               map[string]string          `json:"env,omitempty"`
 	Encrypted         bool                       `json:"encrypted"`
 	KBSResourcePath   string                     `json:"kbs_resource_path,omitempty"`
@@ -1875,6 +1927,7 @@ func (svc *service) publishStart(ctx context.Context, t task.Task, propletID str
 		CLIArgs:           t.CLIArgs,
 		Broadcast:         t.Broadcast,
 		Daemon:            t.Daemon,
+		Latent:            t.Latent,
 		Env:               t.Env,
 		Encrypted:         t.Encrypted,
 		KBSResourcePath:   t.KBSResourcePath,
@@ -1906,6 +1959,18 @@ func (svc *service) publishStop(ctx context.Context, t task.Task, propletID stri
 	topic := svc.baseTopic + "/control/manager/stop"
 
 	return svc.pubsub.Publish(ctx, topic, stopPayload)
+}
+
+func (svc *service) publishInvoke(ctx context.Context, t task.Task, propletID string, inputs []string) error {
+	payload := map[string]any{
+		"id":         t.ID,
+		"broadcast":  t.Broadcast,
+		"proplet_id": propletID,
+		"inputs":     inputs,
+	}
+	topic := svc.baseTopic + "/control/manager/invoke"
+
+	return svc.pubsub.Publish(ctx, topic, payload)
 }
 
 func (svc *service) runOnBeforePropletSelect(ctx context.Context, t task.Task) (plugin.PropletSelectResponse, error) {

--- a/manager/service.go
+++ b/manager/service.go
@@ -69,7 +69,16 @@ type service struct {
 	plugins          plugin.Registry
 	shuttingDown     atomic.Bool
 	wg               sync.WaitGroup
+	pendingInvokes   map[string]chan invokeResult
+	pendingInvokesMu sync.Mutex
 }
+
+type invokeResult struct {
+	results string
+	err     string
+}
+
+const invokeTimeout = 30 * time.Second
 
 func NewService(
 	repos *storage.Repositories,
@@ -99,6 +108,7 @@ func NewService(
 		flCoordinatorURL: coordinatorURL,
 		httpClient:       httpClient,
 		plugins:          plugins,
+		pendingInvokes:   make(map[string]chan invokeResult),
 	}
 	coordinator := NewWorkflowCoordinator(repos.Tasks, svc, logger)
 	svc.coordinator = coordinator
@@ -831,26 +841,52 @@ func (svc *service) StopTask(ctx context.Context, taskID string) error {
 	return nil
 }
 
-func (svc *service) InvokeTask(ctx context.Context, taskID string, inputs []string) error {
+func (svc *service) InvokeTask(ctx context.Context, taskID string, inputs []string) (string, error) {
 	if svc.shuttingDown.Load() {
-		return errShuttingDown
+		return "", errShuttingDown
 	}
 
 	t, err := svc.GetTask(ctx, taskID)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if !t.Latent {
-		return fmt.Errorf("task %s is not a latent task and cannot be invoked", taskID)
+		return "", fmt.Errorf("task %s is not a latent task and cannot be invoked", taskID)
 	}
 
 	propletID, err := svc.invocationProplet(ctx, t)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return svc.publishInvoke(ctx, taskID, propletID, inputs)
+	invocationID := uuid.NewString()
+	resultCh := make(chan invokeResult, 1)
+	svc.pendingInvokesMu.Lock()
+	svc.pendingInvokes[invocationID] = resultCh
+	svc.pendingInvokesMu.Unlock()
+	defer func() {
+		svc.pendingInvokesMu.Lock()
+		delete(svc.pendingInvokes, invocationID)
+		svc.pendingInvokesMu.Unlock()
+	}()
+
+	if err := svc.publishInvoke(ctx, taskID, propletID, invocationID, inputs); err != nil {
+		return "", err
+	}
+
+	select {
+	case res := <-resultCh:
+		if res.err != "" {
+			return "", errors.New(res.err)
+		}
+
+		return res.results, nil
+	case <-time.After(invokeTimeout):
+		return "", fmt.Errorf("invocation of task %s timed out after %s", taskID, invokeTimeout)
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
 }
 
 func (svc *service) StartJob(ctx context.Context, jobID string) error {
@@ -1432,6 +1468,21 @@ func (svc *service) updateInvokeResultsHandler(ctx context.Context, msg map[stri
 		return errors.New("task id is empty")
 	}
 
+	results, _ := msg["results"].(string)
+	errMsg, _ := msg["error"].(string)
+
+	if invocationID, ok := msg["invocation_id"].(string); ok && invocationID != "" {
+		svc.pendingInvokesMu.Lock()
+		ch, waiting := svc.pendingInvokes[invocationID]
+		svc.pendingInvokesMu.Unlock()
+		if waiting {
+			select {
+			case ch <- invokeResult{results: results, err: errMsg}:
+			default:
+			}
+		}
+	}
+
 	t, err := svc.GetTask(ctx, taskID)
 	if err != nil {
 		return err
@@ -1439,7 +1490,7 @@ func (svc *service) updateInvokeResultsHandler(ctx context.Context, msg map[stri
 
 	t.Results = msg["results"]
 	t.UpdatedAt = time.Now()
-	if errMsg, ok := msg["error"].(string); ok && errMsg != "" {
+	if errMsg != "" {
 		t.Error = errMsg
 	}
 
@@ -1970,12 +2021,13 @@ func (svc *service) invocationProplet(ctx context.Context, t task.Task) (string,
 	return svc.taskPropletRepo.Get(ctx, t.ID)
 }
 
-func (svc *service) publishInvoke(ctx context.Context, taskID, propletID string, inputs []string) error {
+func (svc *service) publishInvoke(ctx context.Context, taskID, propletID, invocationID string, inputs []string) error {
 	payload := map[string]any{
-		"id":         taskID,
-		"broadcast":  false,
-		"proplet_id": propletID,
-		"inputs":     inputs,
+		"id":            taskID,
+		"broadcast":     false,
+		"proplet_id":    propletID,
+		"invocation_id": invocationID,
+		"inputs":        inputs,
 	}
 	topic := svc.baseTopic + "/control/manager/invoke"
 

--- a/manager/service.go
+++ b/manager/service.go
@@ -40,6 +40,7 @@ const (
 	ExecutionModeConfigurable = "configurable"
 	EnvJobExecutionMode       = "JOB_EXECUTION_MODE"
 	shutdownTaskStopWait      = 200 * time.Millisecond
+	keyBroadcast              = "broadcast"
 )
 
 var (
@@ -801,8 +802,8 @@ func (svc *service) StopTask(ctx context.Context, taskID string) error {
 	}
 
 	stopPayload := map[string]any{
-		"id":        t.ID,
-		"broadcast": t.Broadcast,
+		"id":         t.ID,
+		keyBroadcast: t.Broadcast,
 	}
 
 	if t.Broadcast {
@@ -1987,7 +1988,7 @@ func (svc *service) publishStart(ctx context.Context, t task.Task, propletID str
 func (svc *service) publishStop(ctx context.Context, t task.Task, propletID string) error {
 	stopPayload := map[string]any{
 		"id":         t.ID,
-		"broadcast":  t.Broadcast,
+		keyBroadcast: t.Broadcast,
 		"proplet_id": propletID,
 	}
 	topic := svc.baseTopic + "/control/manager/stop"
@@ -2011,7 +2012,7 @@ func (svc *service) invocationProplet(ctx context.Context, t task.Task) (string,
 func (svc *service) publishInvoke(ctx context.Context, taskID, propletID, invocationID string, inputs []string, env map[string]string) error {
 	payload := map[string]any{
 		"id":            taskID,
-		"broadcast":     false,
+		keyBroadcast:    false,
 		"proplet_id":    propletID,
 		"invocation_id": invocationID,
 		"inputs":        inputs,

--- a/manager/service_workflow_test.go
+++ b/manager/service_workflow_test.go
@@ -6,6 +6,7 @@ package manager_test
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -319,7 +320,7 @@ func TestInvokeTask(t *testing.T) {
 		created, err := svc.CreateTask(context.Background(), task.Task{Name: "standard"})
 		require.NoError(t, err)
 
-		_, err = svc.InvokeTask(context.Background(), created.ID, []string{"1"})
+		_, err = svc.InvokeTask(context.Background(), created.ID, []string{"1"}, nil)
 		require.Error(t, err)
 	})
 
@@ -342,7 +343,7 @@ func TestInvokeTask(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 
-		_, err = svc.InvokeTask(ctx, created.ID, []string{"\"world\""})
+		_, err = svc.InvokeTask(ctx, created.ID, []string{"\"world\""}, nil)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
@@ -356,14 +357,113 @@ func TestInvokeTask(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = svc.InvokeTask(context.Background(), created.ID, []string{"\"world\""})
+		_, err = svc.InvokeTask(context.Background(), created.ID, []string{"\"world\""}, nil)
 		require.Error(t, err)
 	})
 
 	t.Run("invoke unknown task fails", func(t *testing.T) {
 		t.Parallel()
 		svc := newService(t)
-		_, err := svc.InvokeTask(context.Background(), "nonexistent", nil)
+		_, err := svc.InvokeTask(context.Background(), "nonexistent", nil, nil)
 		require.Error(t, err)
+	})
+
+	t.Run("invoke forwards inputs and env to the proplet", func(t *testing.T) {
+		t.Parallel()
+
+		repos, err := storage.NewRepositories(storage.Config{Type: "memory"})
+		require.NoError(t, err)
+		require.NoError(t, repos.Proplets.Create(context.Background(), proplet.Proplet{
+			ID:           uuid.NewString(),
+			Name:         uuid.NewString(),
+			AliveHistory: []time.Time{time.Now()},
+		}))
+
+		var invokePayload map[string]any
+		pubsub := mqttmocks.NewMockPubSub(t)
+		pubsub.On("Publish", mock.Anything, mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				topic, _ := args.Get(1).(string)
+				if !strings.HasSuffix(topic, "/control/manager/invoke") {
+					return
+				}
+				invokePayload, _ = args.Get(2).(map[string]any)
+			}).
+			Return(nil).Maybe()
+		pubsub.On("Subscribe", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		pubsub.On("Unsubscribe", mock.Anything, mock.Anything).Return(nil).Maybe()
+		pubsub.On("Disconnect", mock.Anything).Return(nil).Maybe()
+
+		svc, _, _ := manager.NewService(
+			repos, scheduler.NewRoundRobin(), pubsub,
+			"test-tenant", "test-channel", "", slog.Default(), nil,
+		)
+
+		created, err := svc.CreateTask(context.Background(), task.Task{
+			Name:      "latent-fn",
+			Latent:    true,
+			Broadcast: true,
+		})
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		_, err = svc.InvokeTask(ctx, created.ID, []string{"\"world\""}, map[string]string{"GREETING": "hola"})
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+
+		require.NotNil(t, invokePayload, "no invoke message was published")
+		assert.Equal(t, created.ID, invokePayload["id"])
+		assert.Equal(t, []string{"\"world\""}, invokePayload["inputs"])
+		assert.Equal(t, map[string]string{"GREETING": "hola"}, invokePayload["env"])
+		assert.NotEmpty(t, invokePayload["invocation_id"])
+	})
+
+	t.Run("invoke omits env when none is supplied", func(t *testing.T) {
+		t.Parallel()
+
+		repos, err := storage.NewRepositories(storage.Config{Type: "memory"})
+		require.NoError(t, err)
+		require.NoError(t, repos.Proplets.Create(context.Background(), proplet.Proplet{
+			ID:           uuid.NewString(),
+			Name:         uuid.NewString(),
+			AliveHistory: []time.Time{time.Now()},
+		}))
+
+		var invokePayload map[string]any
+		pubsub := mqttmocks.NewMockPubSub(t)
+		pubsub.On("Publish", mock.Anything, mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				topic, _ := args.Get(1).(string)
+				if !strings.HasSuffix(topic, "/control/manager/invoke") {
+					return
+				}
+				invokePayload, _ = args.Get(2).(map[string]any)
+			}).
+			Return(nil).Maybe()
+		pubsub.On("Subscribe", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		pubsub.On("Unsubscribe", mock.Anything, mock.Anything).Return(nil).Maybe()
+		pubsub.On("Disconnect", mock.Anything).Return(nil).Maybe()
+
+		svc, _, _ := manager.NewService(
+			repos, scheduler.NewRoundRobin(), pubsub,
+			"test-tenant", "test-channel", "", slog.Default(), nil,
+		)
+
+		created, err := svc.CreateTask(context.Background(), task.Task{
+			Name:      "latent-fn",
+			Latent:    true,
+			Broadcast: true,
+		})
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		_, err = svc.InvokeTask(ctx, created.ID, nil, nil)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+
+		require.NotNil(t, invokePayload, "no invoke message was published")
+		assert.NotContains(t, invokePayload, "env")
 	})
 }

--- a/manager/service_workflow_test.go
+++ b/manager/service_workflow_test.go
@@ -306,3 +306,38 @@ func TestStartTask(t *testing.T) {
 		})
 	}
 }
+
+func TestInvokeTask(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invoke non-latent task fails", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(t)
+		created, err := svc.CreateTask(context.Background(), task.Task{Name: "standard"})
+		require.NoError(t, err)
+
+		err = svc.InvokeTask(context.Background(), created.ID, []string{"1"})
+		require.Error(t, err)
+	})
+
+	t.Run("invoke latent broadcast task succeeds", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(t)
+		created, err := svc.CreateTask(context.Background(), task.Task{
+			Name:      "latent-fn",
+			Latent:    true,
+			Broadcast: true,
+		})
+		require.NoError(t, err)
+
+		err = svc.InvokeTask(context.Background(), created.ID, []string{"\"world\""})
+		require.NoError(t, err)
+	})
+
+	t.Run("invoke unknown task fails", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(t)
+		err := svc.InvokeTask(context.Background(), "nonexistent", nil)
+		require.Error(t, err)
+	})
+}

--- a/manager/service_workflow_test.go
+++ b/manager/service_workflow_test.go
@@ -7,14 +7,17 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/dag"
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
 	mqttmocks "github.com/absmach/propeller/pkg/mqtt/mocks"
+	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/scheduler"
 	"github.com/absmach/propeller/pkg/storage"
 	"github.com/absmach/propeller/pkg/task"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -320,7 +323,29 @@ func TestInvokeTask(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("invoke latent broadcast task succeeds", func(t *testing.T) {
+	t.Run("invoke broadcast latent task load-balances to an active proplet", func(t *testing.T) {
+		t.Parallel()
+		svc, repos := newServiceWithRepos(t)
+		ctx := context.Background()
+
+		require.NoError(t, repos.Proplets.Create(ctx, proplet.Proplet{
+			ID:           uuid.NewString(),
+			Name:         uuid.NewString(),
+			AliveHistory: []time.Time{time.Now()},
+		}))
+
+		created, err := svc.CreateTask(ctx, task.Task{
+			Name:      "latent-fn",
+			Latent:    true,
+			Broadcast: true,
+		})
+		require.NoError(t, err)
+
+		err = svc.InvokeTask(ctx, created.ID, []string{"\"world\""})
+		require.NoError(t, err)
+	})
+
+	t.Run("invoke broadcast latent task with no proplets fails", func(t *testing.T) {
 		t.Parallel()
 		svc := newService(t)
 		created, err := svc.CreateTask(context.Background(), task.Task{
@@ -331,7 +356,7 @@ func TestInvokeTask(t *testing.T) {
 		require.NoError(t, err)
 
 		err = svc.InvokeTask(context.Background(), created.ID, []string{"\"world\""})
-		require.NoError(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("invoke unknown task fails", func(t *testing.T) {

--- a/manager/service_workflow_test.go
+++ b/manager/service_workflow_test.go
@@ -319,30 +319,31 @@ func TestInvokeTask(t *testing.T) {
 		created, err := svc.CreateTask(context.Background(), task.Task{Name: "standard"})
 		require.NoError(t, err)
 
-		err = svc.InvokeTask(context.Background(), created.ID, []string{"1"})
+		_, err = svc.InvokeTask(context.Background(), created.ID, []string{"1"})
 		require.Error(t, err)
 	})
 
-	t.Run("invoke broadcast latent task load-balances to an active proplet", func(t *testing.T) {
+	t.Run("invoke broadcast latent task selects a proplet then awaits result", func(t *testing.T) {
 		t.Parallel()
 		svc, repos := newServiceWithRepos(t)
-		ctx := context.Background()
-
-		require.NoError(t, repos.Proplets.Create(ctx, proplet.Proplet{
+		require.NoError(t, repos.Proplets.Create(context.Background(), proplet.Proplet{
 			ID:           uuid.NewString(),
 			Name:         uuid.NewString(),
 			AliveHistory: []time.Time{time.Now()},
 		}))
 
-		created, err := svc.CreateTask(ctx, task.Task{
+		created, err := svc.CreateTask(context.Background(), task.Task{
 			Name:      "latent-fn",
 			Latent:    true,
 			Broadcast: true,
 		})
 		require.NoError(t, err)
 
-		err = svc.InvokeTask(ctx, created.ID, []string{"\"world\""})
-		require.NoError(t, err)
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		_, err = svc.InvokeTask(ctx, created.ID, []string{"\"world\""})
+		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
 	t.Run("invoke broadcast latent task with no proplets fails", func(t *testing.T) {
@@ -355,14 +356,14 @@ func TestInvokeTask(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = svc.InvokeTask(context.Background(), created.ID, []string{"\"world\""})
+		_, err = svc.InvokeTask(context.Background(), created.ID, []string{"\"world\""})
 		require.Error(t, err)
 	})
 
 	t.Run("invoke unknown task fails", func(t *testing.T) {
 		t.Parallel()
 		svc := newService(t)
-		err := svc.InvokeTask(context.Background(), "nonexistent", nil)
+		_, err := svc.InvokeTask(context.Background(), "nonexistent", nil)
 		require.Error(t, err)
 	})
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -13,6 +13,7 @@ const (
 	ActionCreate Action = "create"
 	ActionStart  Action = "start"
 	ActionStop   Action = "stop"
+	ActionInvoke Action = "invoke"
 	ActionDelete Action = "delete"
 	ActionUpdate Action = "update"
 )

--- a/pkg/scheduler/roundrobin.go
+++ b/pkg/scheduler/roundrobin.go
@@ -1,11 +1,14 @@
 package scheduler
 
 import (
+	"sync"
+
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/task"
 )
 
 type roundRobin struct {
+	mu          sync.Mutex
 	LastProplet int
 }
 
@@ -29,6 +32,9 @@ func (r *roundRobin) SelectProplet(t task.Task, proplets []proplet.Proplet) (pro
 	if alive == 0 {
 		return proplet.Proplet{}, ErrDeadProplers
 	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	for range proplets {
 		r.LastProplet = (r.LastProplet + 1) % len(proplets)

--- a/pkg/scheduler/roundrobin_test.go
+++ b/pkg/scheduler/roundrobin_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/scheduler"
+	"github.com/absmach/propeller/pkg/task"
+)
+
+func TestRoundRobinConcurrentSelect(t *testing.T) {
+	t.Parallel()
+
+	rr := scheduler.NewRoundRobin()
+	proplets := []proplet.Proplet{
+		{ID: "a", Alive: true},
+		{ID: "b", Alive: true},
+		{ID: "c", Alive: true},
+	}
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			for range 100 {
+				if _, err := rr.SelectProplet(task.Task{}, proplets); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -97,7 +97,7 @@ type SDK interface {
 	//  fmt.Println(task)
 	StopTask(id string) error
 
-	InvokeTask(id string, inputs []string) error
+	InvokeTask(id string, inputs []string) (string, error)
 
 	// CreateJob creates a new job with multiple tasks.
 	//

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -97,6 +97,8 @@ type SDK interface {
 	//  fmt.Println(task)
 	StopTask(id string) error
 
+	InvokeTask(id string, inputs []string) error
+
 	// CreateJob creates a new job with multiple tasks.
 	//
 	// example:

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -97,7 +97,7 @@ type SDK interface {
 	//  fmt.Println(task)
 	StopTask(id string) error
 
-	InvokeTask(id string, inputs []string) (string, error)
+	InvokeTask(id string, inputs []string, env map[string]string) (string, error)
 
 	// CreateJob creates a new job with multiple tasks.
 	//

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -194,12 +194,20 @@ func (sdk *propSDK) StopTask(id string) error {
 	return nil
 }
 
-func (sdk *propSDK) InvokeTask(id string, inputs []string) (string, error) {
+func (sdk *propSDK) InvokeTask(id string, inputs []string, env map[string]string) (string, error) {
 	reqURL := fmt.Sprintf("%s/tasks/%s/invoke", sdk.managerURL, id)
 
 	var data []byte
-	if len(inputs) > 0 {
-		body, err := json.Marshal(map[string]any{"inputs": inputs})
+	if len(inputs) > 0 || len(env) > 0 {
+		payload := make(map[string]any)
+		if len(inputs) > 0 {
+			payload["inputs"] = inputs
+		}
+		if len(env) > 0 {
+			payload["env"] = env
+		}
+
+		body, err := json.Marshal(payload)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -28,6 +28,7 @@ type Task struct {
 	File            string         `json:"file,omitempty"`
 	Inputs          []string       `json:"inputs,omitempty"`
 	Daemon          bool           `json:"daemon,omitempty"`
+	Latent          bool           `json:"latent,omitempty"`
 	Encrypted       bool           `json:"encrypted,omitempty"`
 	KBSResourcePath string         `json:"kbs_resource_path,omitempty"`
 	PropletID       string         `json:"proplet_id,omitempty"`

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -193,23 +193,31 @@ func (sdk *propSDK) StopTask(id string) error {
 	return nil
 }
 
-func (sdk *propSDK) InvokeTask(id string, inputs []string) error {
+func (sdk *propSDK) InvokeTask(id string, inputs []string) (string, error) {
 	reqURL := fmt.Sprintf("%s/tasks/%s/invoke", sdk.managerURL, id)
 
 	var data []byte
 	if len(inputs) > 0 {
 		body, err := json.Marshal(map[string]any{"inputs": inputs})
 		if err != nil {
-			return err
+			return "", err
 		}
 		data = body
 	}
 
-	if _, err := sdk.processRequest(http.MethodPost, reqURL, data, http.StatusOK); err != nil {
-		return err
+	body, err := sdk.processRequest(http.MethodPost, reqURL, data, http.StatusOK)
+	if err != nil {
+		return "", err
 	}
 
-	return nil
+	var resp struct {
+		Results string `json:"results"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", err
+	}
+
+	return resp.Results, nil
 }
 
 const jobsEndpoint = "/jobs"

--- a/pkg/sdk/task.go
+++ b/pkg/sdk/task.go
@@ -193,6 +193,25 @@ func (sdk *propSDK) StopTask(id string) error {
 	return nil
 }
 
+func (sdk *propSDK) InvokeTask(id string, inputs []string) error {
+	reqURL := fmt.Sprintf("%s/tasks/%s/invoke", sdk.managerURL, id)
+
+	var data []byte
+	if len(inputs) > 0 {
+		body, err := json.Marshal(map[string]any{"inputs": inputs})
+		if err != nil {
+			return err
+		}
+		data = body
+	}
+
+	if _, err := sdk.processRequest(http.MethodPost, reqURL, data, http.StatusOK); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 const jobsEndpoint = "/jobs"
 
 type JobSummary struct {

--- a/pkg/sdk/task_test.go
+++ b/pkg/sdk/task_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -90,5 +91,30 @@ func TestTaskJSONFieldNames(t *testing.T) {
 	}
 	if task.Env["KEY"] != "VAL" {
 		t.Errorf("unexpected env: %v", task.Env)
+	}
+}
+
+func TestTaskLatentJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(sdk.Task{Name: "greet", Latent: true})
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var latent sdk.Task
+	if err := json.Unmarshal(data, &latent); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if !latent.Latent {
+		t.Errorf("expected latent to survive the round trip, got %s", data)
+	}
+
+	data, err = json.Marshal(sdk.Task{Name: "greet"})
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if bytes.Contains(data, []byte("latent")) {
+		t.Errorf("latent should be omitted when false, got %s", data)
 	}
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -167,6 +167,7 @@ type Task struct {
 	Inputs            FlexStrings                `json:"inputs,omitempty"`
 	Env               map[string]string          `json:"env,omitempty"`
 	Daemon            bool                       `json:"daemon"`
+	Latent            bool                       `json:"latent,omitempty"`
 	Encrypted         bool                       `json:"encrypted"`
 	KBSResourcePath   string                     `json:"kbs_resource_path,omitempty"`
 	PropletID         string                     `json:"proplet_id,omitempty"`

--- a/proplet/src/runtime/mod.rs
+++ b/proplet/src/runtime/mod.rs
@@ -41,6 +41,23 @@ pub trait Runtime: Send + Sync {
     /// - The task does not exist or is not running
     /// - The platform does not support PID retrieval
     async fn get_pid(&self, id: &str) -> Result<Option<u32>>;
+
+    async fn precompile(&self, _config: StartConfig) -> Result<()> {
+        Err(anyhow::anyhow!(
+            "latent tasks are not supported by this runtime"
+        ))
+    }
+
+    async fn invoke(
+        &self,
+        _id: String,
+        _args: Vec<String>,
+        _env: HashMap<String, String>,
+    ) -> Result<Vec<u8>> {
+        Err(anyhow::anyhow!(
+            "latent task invocation is not supported by this runtime"
+        ))
+    }
 }
 
 #[derive(Clone)]

--- a/proplet/src/runtime/wasmtime_runtime.rs
+++ b/proplet/src/runtime/wasmtime_runtime.rs
@@ -440,11 +440,18 @@ impl WasiUsbView for StoreData {
     }
 }
 
+struct PrecompiledComponent {
+    component: component::Component,
+    config: StartConfig,
+    is_proxy: bool,
+}
+
 pub struct WasmtimeRuntime {
     engine: Engine,
     tasks: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     proxy_ports: Arc<Mutex<HashMap<u16, String>>>,
     proxy_cancellers: Arc<Mutex<HashMap<String, watch::Sender<bool>>>>,
+    precompiled: Arc<Mutex<HashMap<String, PrecompiledComponent>>>,
     hal_enabled: bool,
     hal: Arc<PropletHal>,
     http_enabled: bool,
@@ -498,6 +505,7 @@ impl WasmtimeRuntime {
             tasks: Arc::new(Mutex::new(HashMap::new())),
             proxy_ports: Arc::new(Mutex::new(HashMap::new())),
             proxy_cancellers: Arc::new(Mutex::new(HashMap::new())),
+            precompiled: Arc::new(Mutex::new(HashMap::new())),
             hal_enabled,
             hal: PropletHal::new(),
             http_enabled,
@@ -579,6 +587,8 @@ impl Runtime for WasmtimeRuntime {
     async fn stop_app(&self, id: String) -> Result<()> {
         info!("Stopping Wasmtime runtime app: task_id={}", id);
 
+        let was_latent = self.precompiled.lock().await.remove(&id).is_some();
+
         self.proxy_ports
             .lock()
             .await
@@ -596,6 +606,9 @@ impl Runtime for WasmtimeRuntime {
             handle.abort();
             info!("Task {} aborted and removed from tasks", id);
             Ok(())
+        } else if was_latent {
+            info!("Latent task {} removed from precompiled cache", id);
+            Ok(())
         } else {
             Err(anyhow::anyhow!("Task {id} not found in running tasks"))
         }
@@ -608,6 +621,89 @@ impl Runtime for WasmtimeRuntime {
         }
 
         Ok(Some(std::process::id()))
+    }
+
+    async fn precompile(&self, config: StartConfig) -> Result<()> {
+        if !is_wasm_component(&config.wasm_binary) {
+            return Err(anyhow::anyhow!(
+                "latent tasks require a WASM component; task {} is not a component",
+                config.id
+            ));
+        }
+
+        info!("Precompiling latent component for task: {}", config.id);
+
+        let component = component::Component::from_binary(&self.engine, &config.wasm_binary)
+            .map_err(|e| anyhow::anyhow!("Failed to precompile WASM component: {e}"))?;
+
+        let is_proxy = is_proxy_component(&config.wasm_binary);
+        let task_id = config.id.clone();
+
+        self.precompiled.lock().await.insert(
+            task_id.clone(),
+            PrecompiledComponent {
+                component,
+                config,
+                is_proxy,
+            },
+        );
+
+        info!("Precompiled latent component cached for task: {}", task_id);
+
+        Ok(())
+    }
+
+    async fn invoke(
+        &self,
+        id: String,
+        args: Vec<String>,
+        env: HashMap<String, String>,
+    ) -> Result<Vec<u8>> {
+        let (component, mut config, is_proxy) = {
+            let precompiled = self.precompiled.lock().await;
+            match precompiled.get(&id) {
+                Some(entry) => (
+                    entry.component.clone(),
+                    entry.config.clone(),
+                    entry.is_proxy,
+                ),
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "task {id} has not been precompiled; deploy it as a latent task first"
+                    ))
+                }
+            }
+        };
+
+        if is_proxy {
+            return Err(anyhow::anyhow!(
+                "task {id} is an HTTP proxy component; it is served by its listener, not by direct invocation"
+            ));
+        }
+
+        for (k, v) in env {
+            config.env.insert(k, v);
+        }
+        if !args.is_empty() {
+            config.args = args;
+        }
+        config.daemon = false;
+        config.id = format!("{id}-inv-{}", uuid::Uuid::new_v4());
+
+        let has_custom_export = !config.function_name.is_empty()
+            && config.function_name != "_start"
+            && !config.function_name.starts_with("fl-round-");
+
+        info!(
+            "Invoking latent task {} as {} (custom_export={})",
+            id, config.id, has_custom_export
+        );
+
+        if has_custom_export {
+            self.run_component_export(config, component).await
+        } else {
+            self.run_component_command(config, component).await
+        }
     }
 }
 
@@ -678,6 +774,14 @@ impl WasmtimeRuntime {
 
         info!("Component compiled successfully for task: {}", config.id);
 
+        self.run_component_command(config, component).await
+    }
+
+    async fn run_component_command(
+        &self,
+        config: StartConfig,
+        component: component::Component,
+    ) -> Result<Vec<u8>> {
         let mut wasi_builder = WasiCtxBuilder::new();
         wasi_builder.inherit_stdio();
 
@@ -805,6 +909,14 @@ impl WasmtimeRuntime {
             }
         };
 
+        self.run_component_export(config, component).await
+    }
+
+    async fn run_component_export(
+        &self,
+        config: StartConfig,
+        component: component::Component,
+    ) -> Result<Vec<u8>> {
         let mut wasi_builder = WasiCtxBuilder::new();
         wasi_builder.inherit_stdio();
         for (key, value) in &config.env {
@@ -1584,5 +1696,136 @@ mod tests {
         );
         let output = result.unwrap();
         assert!(!output.is_empty());
+    }
+
+    fn latent_config(id: &str, function_name: &str, wasm_binary: Vec<u8>) -> StartConfig {
+        StartConfig {
+            id: id.to_string(),
+            function_name: function_name.to_string(),
+            daemon: false,
+            wasm_binary,
+            cli_args: Vec::new(),
+            env: HashMap::new(),
+            args: Vec::new(),
+            mode: None,
+            hal_storage_path: None,
+        }
+    }
+
+    fn greet_component() -> Option<Vec<u8>> {
+        let wasm_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../examples/greet-component/target/wasm32-wasip2/release/greet_component.wasm"
+        );
+        match std::fs::read(wasm_path) {
+            Ok(b) => Some(b),
+            Err(e) => {
+                eprintln!(
+                    "Skipping: WASM binary not found at {wasm_path}: {e}. \
+                     Build it with: make greet-component"
+                );
+                None
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_precompile_rejects_non_component() {
+        let runtime =
+            WasmtimeRuntime::new_with_options(false, false, false, Vec::new(), 8222, None, false)
+                .unwrap();
+        let config = latent_config(
+            &uuid::Uuid::new_v4().to_string(),
+            "run",
+            vec![0xFF, 0xFF, 0xFF, 0xFF],
+        );
+        assert!(runtime.precompile(config).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_invoke_unknown_task_errors() {
+        let runtime =
+            WasmtimeRuntime::new_with_options(false, false, false, Vec::new(), 8222, None, false)
+                .unwrap();
+        let result = runtime
+            .invoke("does-not-exist".to_string(), Vec::new(), HashMap::new())
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_precompile_then_invoke_component_export() {
+        let Some(wasm_binary) = greet_component() else {
+            return;
+        };
+        let runtime =
+            WasmtimeRuntime::new_with_options(false, false, false, Vec::new(), 8222, None, false)
+                .unwrap();
+        let task_id = uuid::Uuid::new_v4().to_string();
+
+        runtime
+            .precompile(latent_config(&task_id, "greet", wasm_binary))
+            .await
+            .expect("precompile should succeed");
+
+        let output = runtime
+            .invoke(
+                task_id.clone(),
+                vec!["\"world\"".to_string()],
+                HashMap::new(),
+            )
+            .await
+            .expect("invoke should succeed");
+        assert!(
+            String::from_utf8_lossy(&output).contains("Hello, world"),
+            "unexpected invoke output: {}",
+            String::from_utf8_lossy(&output)
+        );
+
+        let output2 = runtime
+            .invoke(task_id, vec!["\"again\"".to_string()], HashMap::new())
+            .await
+            .expect("second invoke should succeed");
+        assert!(String::from_utf8_lossy(&output2).contains("Hello, again"));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_invocations_run_in_parallel() {
+        let Some(wasm_binary) = greet_component() else {
+            return;
+        };
+        let runtime = Arc::new(
+            WasmtimeRuntime::new_with_options(false, false, false, Vec::new(), 8222, None, false)
+                .unwrap(),
+        );
+        let task_id = uuid::Uuid::new_v4().to_string();
+
+        runtime
+            .precompile(latent_config(&task_id, "greet", wasm_binary))
+            .await
+            .expect("precompile should succeed");
+
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let runtime = runtime.clone();
+            let task_id = task_id.clone();
+            handles.push(tokio::spawn(async move {
+                runtime
+                    .invoke(task_id, vec![format!("\"caller-{i}\"")], HashMap::new())
+                    .await
+            }));
+        }
+
+        for (i, handle) in handles.into_iter().enumerate() {
+            let output = handle
+                .await
+                .expect("task join")
+                .expect("invoke should succeed");
+            assert!(
+                String::from_utf8_lossy(&output).contains(&format!("Hello, caller-{i}")),
+                "invocation {i} returned unexpected output: {}",
+                String::from_utf8_lossy(&output)
+            );
+        }
     }
 }

--- a/proplet/src/runtime/wasmtime_runtime.rs
+++ b/proplet/src/runtime/wasmtime_runtime.rs
@@ -444,6 +444,7 @@ struct PrecompiledComponent {
     component: component::Component,
     config: StartConfig,
     is_proxy: bool,
+    wasm_binary: Arc<Vec<u8>>,
 }
 
 pub struct WasmtimeRuntime {
@@ -623,7 +624,7 @@ impl Runtime for WasmtimeRuntime {
         Ok(Some(std::process::id()))
     }
 
-    async fn precompile(&self, config: StartConfig) -> Result<()> {
+    async fn precompile(&self, mut config: StartConfig) -> Result<()> {
         if !is_wasm_component(&config.wasm_binary) {
             return Err(anyhow::anyhow!(
                 "latent tasks require a WASM component; task {} is not a component",
@@ -637,6 +638,7 @@ impl Runtime for WasmtimeRuntime {
             .map_err(|e| anyhow::anyhow!("Failed to precompile WASM component: {e}"))?;
 
         let is_proxy = is_proxy_component(&config.wasm_binary);
+        let wasm_binary = Arc::new(std::mem::take(&mut config.wasm_binary));
         let task_id = config.id.clone();
 
         self.precompiled.lock().await.insert(
@@ -645,6 +647,7 @@ impl Runtime for WasmtimeRuntime {
                 component,
                 config,
                 is_proxy,
+                wasm_binary,
             },
         );
 
@@ -659,13 +662,14 @@ impl Runtime for WasmtimeRuntime {
         args: Vec<String>,
         env: HashMap<String, String>,
     ) -> Result<Vec<u8>> {
-        let (component, mut config, is_proxy) = {
+        let (component, mut config, is_proxy, wasm_binary) = {
             let precompiled = self.precompiled.lock().await;
             match precompiled.get(&id) {
                 Some(entry) => (
                     entry.component.clone(),
                     entry.config.clone(),
                     entry.is_proxy,
+                    entry.wasm_binary.clone(),
                 ),
                 None => {
                     return Err(anyhow::anyhow!(
@@ -700,7 +704,8 @@ impl Runtime for WasmtimeRuntime {
         );
 
         if has_custom_export {
-            self.run_component_export(config, component).await
+            self.run_component_export(config, component, wasm_binary)
+                .await
         } else {
             self.run_component_command(config, component).await
         }
@@ -894,7 +899,7 @@ impl WasmtimeRuntime {
         }
     }
 
-    async fn start_app_component_export(&self, config: StartConfig) -> Result<Vec<u8>> {
+    async fn start_app_component_export(&self, mut config: StartConfig) -> Result<Vec<u8>> {
         info!(
             "Compiling WASM component for custom export '{}' for task: {}",
             config.function_name, config.id
@@ -909,13 +914,17 @@ impl WasmtimeRuntime {
             }
         };
 
-        self.run_component_export(config, component).await
+        let wasm_binary = Arc::new(std::mem::take(&mut config.wasm_binary));
+
+        self.run_component_export(config, component, wasm_binary)
+            .await
     }
 
     async fn run_component_export(
         &self,
         config: StartConfig,
         component: component::Component,
+        wasm_binary: Arc<Vec<u8>>,
     ) -> Result<Vec<u8>> {
         let mut wasi_builder = WasiCtxBuilder::new();
         wasi_builder.inherit_stdio();
@@ -965,7 +974,6 @@ impl WasmtimeRuntime {
         let function_name = config.function_name.clone();
         let args = config.args.clone();
         let tasks = self.tasks.clone();
-        let wasm_binary = config.wasm_binary.clone();
 
         let (result_tx, result_rx) = oneshot::channel();
 

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -1116,6 +1116,7 @@ impl PropletService {
         let qos = self.config.qos();
         let proplet_id = self.config.entity_id.clone();
         let task_id = req.id.clone();
+        let invocation_id = req.invocation_id.clone().unwrap_or_default();
         let inputs = req.inputs.clone();
         let env = req.env.unwrap_or_default();
         let metrics = self.metrics.clone();
@@ -1144,8 +1145,9 @@ impl PropletService {
                     }
                 };
 
-                let result_msg = ResultMessage {
+                let result_msg = InvokeResultMessage {
                     task_id: task_id.clone(),
+                    invocation_id,
                     proplet_id,
                     results,
                     error,

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -222,6 +222,13 @@ impl PropletService {
         );
         self.pubsub.subscribe(&stop_topic, qos).await?;
 
+        let invoke_topic = build_topic(
+            &self.config.tenant_id,
+            &self.config.channel_id,
+            "control/manager/invoke",
+        );
+        self.pubsub.subscribe(&invoke_topic, qos).await?;
+
         let chunk_topic = build_topic(
             &self.config.tenant_id,
             &self.config.channel_id,
@@ -442,6 +449,8 @@ impl PropletService {
 
         if msg.topic.contains("control/manager/start") {
             self.handle_start_command(msg).await
+        } else if msg.topic.contains("control/manager/invoke") {
+            self.handle_invoke_command(msg).await
         } else if msg.topic.contains("control/manager/stop") {
             self.handle_stop_command(msg).await
         } else if msg.topic.contains("registry/server") {
@@ -658,6 +667,43 @@ impl PropletService {
         }
         for (k, v) in plugin_env_additions {
             env.insert(k, v);
+        }
+
+        if req.latent {
+            let mut latent_env = env;
+            latent_env
+                .entry("PROPLET_ID".to_string())
+                .or_insert_with(|| proplet_id.clone());
+
+            let config = StartConfig {
+                id: task_id.clone(),
+                function_name: task_name.clone(),
+                daemon: false,
+                wasm_binary,
+                cli_args: req.cli_args.clone(),
+                env: latent_env,
+                args: req.inputs.clone(),
+                mode: req.mode.clone(),
+                hal_storage_path: req.hal_storage_path.clone(),
+            };
+
+            if let Err(e) = runtime.precompile(config).await {
+                error!("Failed to precompile latent task {}: {:#}", task_id, e);
+                self.running_tasks.lock().await.remove(&task_id);
+                self.metrics.tasks_failed.inc();
+                self.metrics.tasks_running.dec();
+                self.publish_result(&task_id, Vec::new(), Some(e.to_string()))
+                    .await?;
+
+                return Err(e);
+            }
+
+            info!(
+                "Latent task {} precompiled and ready for on-demand invocation",
+                task_id
+            );
+
+            return Ok(());
         }
 
         let daemon = req.daemon;
@@ -1042,6 +1088,81 @@ impl PropletService {
                 metrics.tasks_running.dec();
             }
         }.instrument(execute_span));
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self, msg), name = "task.invoke", fields(task_id))]
+    async fn handle_invoke_command(&self, msg: MqttMessage) -> Result<()> {
+        let req: InvokeRequest = msg.decode()?;
+        req.validate()?;
+
+        tracing::Span::current().record("task_id", req.id.as_str());
+
+        if !req.broadcast {
+            if let Some(ref target_id) = req.proplet_id {
+                if target_id != &self.config.entity_id {
+                    return Ok(());
+                }
+            }
+        }
+
+        info!("Received invoke command for task: {}", req.id);
+
+        let runtime = self.runtime.clone();
+        let pubsub = self.pubsub.clone();
+        let tenant_id = self.config.tenant_id.clone();
+        let channel_id = self.config.channel_id.clone();
+        let qos = self.config.qos();
+        let proplet_id = self.config.entity_id.clone();
+        let task_id = req.id.clone();
+        let inputs = req.inputs.clone();
+        let env = req.env.unwrap_or_default();
+        let metrics = self.metrics.clone();
+
+        let invoke_span = tracing::info_span!("task.invoke.execute", task_id = %task_id);
+        tokio::spawn(
+            async move {
+                metrics.tasks_started.inc();
+                metrics.tasks_running.inc();
+
+                let result = runtime.invoke(task_id.clone(), inputs, env).await;
+
+                metrics.tasks_running.dec();
+
+                let (results, error) = match result {
+                    Ok(data) => {
+                        let results = String::from_utf8_lossy(&data).to_string();
+                        info!("Invocation of task {} completed: {}", task_id, results);
+                        metrics.tasks_completed.inc();
+                        (results, None)
+                    }
+                    Err(e) => {
+                        error!("Invocation of task {} failed: {:#}", task_id, e);
+                        metrics.tasks_failed.inc();
+                        (String::new(), Some(e.to_string()))
+                    }
+                };
+
+                let result_msg = ResultMessage {
+                    task_id: task_id.clone(),
+                    proplet_id,
+                    results,
+                    error,
+                };
+
+                let topic = build_topic(&tenant_id, &channel_id, "control/proplet/invoke_results");
+                if let Err(e) = pubsub.publish(&topic, &result_msg, qos).await {
+                    error!(
+                        "Failed to publish invoke result for task {}: {}",
+                        task_id, e
+                    );
+                } else {
+                    info!("Published invoke result for task {}", task_id);
+                }
+            }
+            .instrument(invoke_span),
+        );
 
         Ok(())
     }

--- a/proplet/src/types.rs
+++ b/proplet/src/types.rs
@@ -113,6 +113,8 @@ impl StartRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InvokeRequest {
     pub id: String,
+    #[serde(default)]
+    pub invocation_id: Option<String>,
     #[serde(default, deserialize_with = "deserialize_null_default")]
     pub inputs: Vec<String>,
     #[serde(default)]
@@ -205,6 +207,15 @@ pub struct DiscoveryMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResultMessage {
     pub task_id: String,
+    pub proplet_id: String,
+    pub results: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvokeResultMessage {
+    pub task_id: String,
+    pub invocation_id: String,
     pub proplet_id: String,
     pub results: String,
     pub error: Option<String>,

--- a/proplet/src/types.rs
+++ b/proplet/src/types.rs
@@ -70,6 +70,8 @@ pub struct StartRequest {
     pub broadcast: bool,
     #[serde(default)]
     pub hal_storage_path: Option<String>,
+    #[serde(default)]
+    pub latent: bool,
 }
 
 fn deserialize_null_default<'de, D, T>(deserializer: D) -> std::result::Result<T, D::Error>
@@ -104,6 +106,29 @@ impl StartRequest {
         } else if self.file.is_empty() && self.image_url.is_empty() {
             return Err(anyhow::anyhow!("either file or image_url must be provided"));
         }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvokeRequest {
+    pub id: String,
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    pub inputs: Vec<String>,
+    #[serde(default)]
+    pub env: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub proplet_id: Option<String>,
+    #[serde(default)]
+    pub broadcast: bool,
+}
+
+impl InvokeRequest {
+    pub fn validate(&self) -> Result<()> {
+        if self.id.is_empty() {
+            return Err(anyhow::anyhow!("id is required"));
+        }
+
         Ok(())
     }
 }
@@ -318,6 +343,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         assert!(req.validate().is_ok());
@@ -342,6 +368,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         assert!(req.validate().is_ok());
@@ -366,6 +393,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         let result = req.validate();
@@ -392,6 +420,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         let result = req.validate();
@@ -418,6 +447,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         let result = req.validate();
@@ -447,6 +477,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         assert!(req.validate().is_ok());
@@ -471,6 +502,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         let result = req.validate();
@@ -500,6 +532,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         let result = req.validate();
@@ -579,6 +612,65 @@ mod tests {
         let result = req.validate();
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().to_string(), "id is required");
+    }
+
+    #[test]
+    fn test_invoke_request_deserialize_and_validate() {
+        let json_data = json!({
+            "id": "task-invoke-1",
+            "inputs": ["10", "20"],
+            "env": {"KEY": "value"},
+            "proplet_id": "proplet-7",
+            "broadcast": false
+        });
+
+        let req: InvokeRequest = serde_json::from_value(json_data).unwrap();
+
+        assert_eq!(req.id, "task-invoke-1");
+        assert_eq!(req.inputs, vec!["10", "20"]);
+        assert_eq!(
+            req.env.as_ref().unwrap().get("KEY"),
+            Some(&"value".to_string())
+        );
+        assert_eq!(req.proplet_id, Some("proplet-7".to_string()));
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn test_invoke_request_defaults_and_empty_id() {
+        let req: InvokeRequest = serde_json::from_value(json!({ "id": "task-1" })).unwrap();
+        assert!(req.inputs.is_empty());
+        assert!(req.env.is_none());
+        assert!(req.proplet_id.is_none());
+        assert!(!req.broadcast);
+        assert!(req.validate().is_ok());
+
+        let empty: InvokeRequest = serde_json::from_value(json!({ "id": "" })).unwrap();
+        let result = empty.validate();
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "id is required");
+    }
+
+    #[test]
+    fn test_start_request_latent_defaults_false() {
+        let req: StartRequest = serde_json::from_value(json!({
+            "id": "task-latent",
+            "name": "func",
+            "image_url": "registry.example.com/app:v1",
+            "state": 0
+        }))
+        .unwrap();
+        assert!(!req.latent);
+
+        let latent: StartRequest = serde_json::from_value(json!({
+            "id": "task-latent",
+            "name": "func",
+            "image_url": "registry.example.com/app:v1",
+            "latent": true,
+            "state": 0
+        }))
+        .unwrap();
+        assert!(latent.latent);
     }
 
     #[test]
@@ -759,6 +851,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         assert_eq!(req.env.as_ref().unwrap().len(), 2);
@@ -826,6 +919,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         let json = serde_json::to_string(&req).unwrap();
@@ -857,6 +951,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         assert!(req.validate().is_ok());
@@ -881,6 +976,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         assert!(req.validate().is_ok());
@@ -905,6 +1001,7 @@ mod tests {
             proplet_id: None,
             broadcast: false,
             hal_storage_path: None,
+            latent: false,
         };
 
         let result = req.validate();


### PR DESCRIPTION
# What type of PR is this?

Feature: adds latent FaaS tasks that precompile on deploy and instantiate on demand.

## What does this do?

Deploys a task that precompiles its WASM component without running, then instantiates it per request in parallel.

## Which issue(s) does this PR fix/relate to?

Resolves #239

## Have you included tests for your changes?

Yes. Proplet precompile/invoke and concurrent-invocation tests, plus a manager InvokeTask service test.

## Did you document any new/modified features?

No README/API docs changed; usage is the new `tasks invoke <id>` CLI command.

### Notes

Latent flag persists only in memory/badger stores, matching existing Priority and Schedule handling.
