### PR TITLE
fix(compose): stop creating config.toml as a directory

### DIFF
--- a/docker/compose.propeller.yaml
+++ b/docker/compose.propeller.yaml
@@ -57,7 +57,11 @@ services:
       # MANAGER_MQTT_TLS_CLIENT_KEY: ${MANAGER_MQTT_TLS_CLIENT_KEY}
       # MANAGER_MQTT_TLS_INSECURE_SKIP_VERIFY: ${MANAGER_MQTT_TLS_INSECURE_SKIP_VERIFY}
     volumes:
-      - ./config.toml:/config.toml
+      - type: bind
+        source: ./config.toml
+        target: /config.toml
+        bind:
+          create_host_path: false
       # MQTT TLS certs (uncomment and change source paths when using ssl://):
       # - type: bind
       #   source: ./ssl/certs/ca.crt
@@ -141,7 +145,11 @@ services:
       # PROPLET_HTTP_TLS_CA_CERT: ${PROPLET_HTTP_TLS_CA_CERT}
       # PROPLET_HTTP_TLS_INSECURE_SKIP_VERIFY: ${PROPLET_HTTP_TLS_INSECURE_SKIP_VERIFY}
     volumes:
-      - ./config.toml:/home/proplet/config.toml
+      - type: bind
+        source: ./config.toml
+        target: /home/proplet/config.toml
+        bind:
+          create_host_path: false
       # MQTT TLS certs (uncomment and change source paths when using ssl://):
       # - type: bind
       #   source: ./ssl/certs/ca.crt
@@ -209,7 +217,11 @@ services:
       # PROXY_MQTT_TLS_CLIENT_KEY: ${PROXY_MQTT_TLS_CLIENT_KEY}
       # PROXY_MQTT_TLS_INSECURE_SKIP_VERIFY: ${PROXY_MQTT_TLS_INSECURE_SKIP_VERIFY}
     volumes:
-      - ./config.toml:/config.toml
+      - type: bind
+        source: ./config.toml
+        target: /config.toml
+        bind:
+          create_host_path: false
       # MQTT TLS certs (uncomment and change source paths when using ssl://):
       # - type: bind
       #   source: ./ssl/certs/ca.crt


### PR DESCRIPTION
## What does this do?

Closes #258.

The provision wizard writes `docker/config.toml` as a regular file, but the Propeller Compose file used short bind-mount syntax for that path. If Compose is started before provisioning, Docker creates a missing bind source as a directory. The wizard then cannot replace that directory with the generated TOML file and reports `failed to create docker/config.toml file`.

This converts all three config mounts (manager, proplet, and proxy) to long bind syntax with `bind.create_host_path: false`.

Compose will now fail clearly when the provisioned config is missing instead of mutating the host path into a directory. Existing mount targets and runtime behavior are unchanged once the file exists.

Users who already have an empty `docker/config.toml/` directory still need to remove it once before running the provision command; Compose will not recreate it afterward.

## Verification

- Parsed `docker/compose.propeller.yaml` with Docker Compose v5.1.2.
- Inspected normalized Compose JSON and verified all 3 config mounts have `bind.create_host_path == false`.
- Ran `go test ./...` successfully.
- Ran `git diff --check` successfully.
