### PR TITLE
fix(ssl): create certificate output directory

### DIFF
--- a/docker/ssl/Makefile
+++ b/docker/ssl/Makefile
@@ -44,6 +44,11 @@ etc, etc.
 endef
 all: clean_certs ca server_cert client_cert coap_dtls_certs
 
+$(CRT_LOCATION):
+	mkdir -p $@
+
+ca server_cert client_cert: | $(CRT_LOCATION)
+
 # CA name and key is "ca".
 ca:
 	openssl req -newkey rsa:2048 -x509 -nodes -sha512 -days 1095 \


### PR DESCRIPTION
## What type of PR is this?

Bug fix.

## What does this do?

Closes #257.

A fresh clone does not contain `docker/ssl/certs`, so certificate targets fail when their first writer tries to create a file under `$(CRT_LOCATION)`.

This adds one idempotent `$(CRT_LOCATION)` directory target and makes every currently implemented certificate-producing target (`ca`, `server_cert`, and `client_cert`) use it as an order-only prerequisite. Existing directories are left untouched, and directory timestamps do not regenerate certificates.

The patch is rebased onto current `main`. Certificate-generation settings and the existing CA dependency of server/client certificates are unchanged.

## Verification

- Generated CA, server, and client certificates with real OpenSSL 3.6.3 from a missing nested output directory.
- Verified the generated server and client certificates against the generated CA.
- Confirmed a pre-existing output directory does not schedule another `mkdir`.
- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint v2.12.2 run --config ./.golangci.yaml` — 0 issues
- `git diff --check`

Documentation is unchanged because this restores the existing documented setup behavior.