### PR TITLE
Fix Docker config `start-base`

### DIFF
--- a/docker/compose.propeller.yaml
+++ b/docker/compose.propeller.yaml
@@ -11,6 +11,7 @@ networks:
 services:
   manager:
     image: ghcr.io/absmach/propeller/manager:${PROP_RELEASE_TAG}
+    pull_policy: always
     container_name: propeller-manager
     restart: on-failure
     healthcheck:
@@ -89,6 +90,7 @@ services:
   #   3. PROPLET_EXTERNAL_WASM_RUNTIME=wasmtime
   proplet:
     image: ${PROPLET_IMAGE}:${PROPLET_IMAGE_TAG}
+    pull_policy: always
     container_name: propeller-proplet
     restart: on-failure
     healthcheck:
@@ -174,6 +176,7 @@ services:
 
   proxy:
     image: ghcr.io/absmach/propeller/proxy:${PROP_RELEASE_TAG}
+    pull_policy: always
     container_name: propeller-proxy
     restart: on-failure
     healthcheck:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -36,6 +36,7 @@ services:
 
   atom:
     image: ghcr.io/absmach/atom:${ATOM_IMAGE_TAG}
+    pull_policy: always
     container_name: propeller-atom
     restart: on-failure
     depends_on:
@@ -69,6 +70,7 @@ services:
 
   atom-ui:
     image: ghcr.io/absmach/atom-ui:${ATOM_UI_IMAGE_TAG:-latest}
+    pull_policy: always
     container_name: propeller-atom-ui
     restart: on-failure
     depends_on:
@@ -82,6 +84,7 @@ services:
 
   fluxmq-node1:
     image: ghcr.io/absmach/fluxmq:${FLUXMQ_IMAGE_TAG}
+    pull_policy: always
     container_name: propeller-fluxmq-node1
     user: "0:0"
     command: ["-config", "/etc/fluxmq/config.yaml"]
@@ -100,6 +103,7 @@ services:
 
   fluxmq-auth:
     image: ghcr.io/absmach/magistrala/fluxmq:${MG_RELEASE_TAG}
+    pull_policy: always
     container_name: propeller-fluxmq-auth
     restart: on-failure
     depends_on:

--- a/docker/fluxmq/node1.yaml
+++ b/docker/fluxmq/node1.yaml
@@ -103,12 +103,13 @@ queues:
       max_length_bytes: 1073741824
 
 auth:
-  url: "http://fluxmq-auth:7016"
-  transport: "grpc"
-  timeout: 15s
-  protocols:
-    mqtt: true
-    http: true
-    coap: true
-    amqp: true
-    amqp091: false
+  external:
+    url: "http://fluxmq-auth:7016"
+    transport: "grpc"
+    timeout: 15s
+    protocols:
+      mqtt: true
+      http: true
+      coap: true
+      amqp: true
+      amqp091: false


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

Bug fixes

<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?

Fixes several issues when trying to set up from scratch:

- Running `make start-base` throws an error because of a missing `certs` directory.
- Because a lot of images are being tagged `latest`, local Docker image cache does not check for newer versions. This causes issues when you previously ran the stack and you have an outdated `latest` image cached locally that is incompatible with the upstream commit.
  - Best solution would be to use version tags instead of `latest`, but easiest fix is to require checking for new versions and pulling if necessary with `pull_policy: always`
- The `fluxmq` config is outdated causing these errors:

```
❯ docker logs propeller-fluxmq-node1
2026/08/04 13:21:18 ERROR Failed to load configuration error="failed to parse config file: auth.url is no longer supported; use auth.external.url"
```

```
❯ docker logs propeller-manager
{"time":"2026-08-04T13:23:26.100549859Z","level":"WARN","msg":"MANAGER_COORDINATOR_URL not configured - FL features will not be available"}
{"time":"2026-08-04T13:23:26.100696005Z","level":"WARN","msg":"failed to subscribe to topic, retrying","topic":"m/170dbc69-d8fc-4518-a359-6c00e85eeeea/c/23b7c989-5953-4ad8-a572-83f8dc497dc8/#","attempt":1,"max_retries":10,"error":"not Connected"}
{"time":"2026-08-04T13:23:29.101345174Z","level":"WARN","msg":"failed to subscribe to topic, retrying","topic":"m/170dbc69-d8fc-4518-a359-6c00e85eeeea/c/23b7c989-5953-4ad8-a572-83f8dc497dc8/#","attempt":2,"max_retries":10,"error":"not Connected"}
{"time":"2026-08-04T13:23:32.1024289Z","level":"WARN","msg":"failed to subscribe to topic, retrying","topic":"m/170dbc69-d8fc-4518-a359-6c00e85eeeea/c/23b7c989-5953-4ad8-a572-83f8dc497dc8/#","attempt":3,"max_retries":10,"error":"not Connected"}
...
```

After the fix:

```
❯ docker logs propeller-fluxmq-node1
time=2026-08-04T13:25:41.808Z level=INFO msg="Starting MQTT broker" local_node_id=broker-1 version=v0.50.0
time=2026-08-04T13:25:41.808Z level=INFO msg="Configuration loaded" local_node_id=broker-1 tcp_v3_listener=0.0.0.0:1883 tcp_v5_listener=0.0.0.0:1884 tcp_tls_listener="" tcp_mtls_listener="" ws_v3_listener=0.0.0.0:8883 ws_v5_listener=0.0.0.0:8884 ws_tls_listener="" ws_mtls_listener="" http_plain_listener=0.0.0.0:8090 http_tls_listener="" http_mtls_listener="" coap_plain_listener=0.0.0.0:5683 coap_dtls_listener="" coap_mdtls_listener="" amqp_plain_listener=0.0.0.0:5672 amqp_tls_listener="" amqp_mtls_listener="" amqp091_plain_listener=0.0.0.0:5682 amqp091_tls_listener="" amqp091_mtls_listener="" amqp091_local_listener="" amqp091_internal_listener="" amqp091_service_listener="" admin_api_addr=:8082 health_enabled=true cluster_enabled=false log_level=info

...

time=2026-08-04T13:25:41.826Z level=INFO msg="AMQP server started" local_node_id=broker-1 address=0.0.0.0:5672
time=2026-08-04T13:25:41.826Z level=INFO msg="TCP server started" local_node_id=broker-1 address=0.0.0.0:1884
time=2026-08-04T13:25:41.827Z level=INFO msg="MQTT broker started successfully" local_node_id=broker-1
time=2026-08-04T13:25:41.827Z level=INFO msg="Starting admin API server" local_node_id=broker-1 address=:8082
time=2026-08-04T13:25:41.827Z level=INFO msg="Starting API server (h2c)" local_node_id=broker-1 address=:8082
time=2026-08-04T13:25:45.275Z level=INFO msg="AMQP 0.9.1 connection opened" local_node_id=broker-1 remote=172.30.0.7:55122@1
```

```
❯ docker logs propeller-manager
{"time":"2026-08-04T13:26:45.542430694Z","level":"INFO","msg":"MQTT connection established"}
{"time":"2026-08-04T13:26:45.553004425Z","level":"WARN","msg":"MANAGER_COORDINATOR_URL not configured - FL features will not be available"}
{"time":"2026-08-04T13:26:45.717158741Z","level":"INFO","msg":"Subscribe to MQTT topic completed successfully","duration":"163.9905ms"}
{"time":"2026-08-04T13:26:45.717244903Z","level":"INFO","msg":"Recover interrupted tasks completed successfully","duration":"12.699µs"}
{"time":"2026-08-04T13:26:45.717426287Z","level":"INFO","msg":"cron scheduler started","check_interval":60000000000}
{"time":"2026-08-04T13:26:45.71748795Z","level":"INFO","msg":"manager service HTTP server listening at manager:7070"}
```


## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->


