### PR TITLE
Add JSON-RPC 2.0 across the manager API, control plane and proplet

### DIFF
--- a/cli/rpc.go
+++ b/cli/rpc.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/cobra"
+)
+
+func NewRPCCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rpc [call|methods]",
+		Short: "JSON-RPC client",
+		Long:  `Call manager methods over JSON-RPC.`,
+	}
+
+	cmd.AddCommand(newRPCCallCmd())
+
+	return cmd
+}
+
+func newRPCCallCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "call <method> [params]",
+		Short: "Call a JSON-RPC method",
+		Long: `Call a JSON-RPC method on the manager.
+
+Params are a JSON object or array. When omitted the method is called
+without params.
+
+Examples:
+  propeller-cli rpc call proplet.list
+  propeller-cli rpc call task.start '{"id":"b1d10738-c5d7-4ff1-8f4d-b9328ce6f040"}'
+  propeller-cli rpc call task.list '{"limit":5}'`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 || len(args) > 2 {
+				logUsageCmd(*cmd, cmd.Use)
+
+				return
+			}
+
+			var params any
+			if len(args) == 2 {
+				if err := json.Unmarshal([]byte(args[1]), &params); err != nil {
+					logErrorCmd(*cmd, err)
+
+					return
+				}
+			}
+
+			result, err := psdk.Call(args[0], params)
+			if err != nil {
+				logErrorCmd(*cmd, err)
+
+				return
+			}
+
+			var decoded any
+			if err := json.Unmarshal(result, &decoded); err != nil {
+				logErrorCmd(*cmd, err)
+
+				return
+			}
+			logJSONCmd(*cmd, decoded)
+		},
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -42,8 +42,9 @@ func main() {
 	workflowsCmd := cli.NewWorkflowsCmd()
 	flCmd := cli.NewFLCmd()
 	healthCmd := cli.NewHealthCmd()
+	rpcCmd := cli.NewRPCCmd()
 
-	rootCmd.AddCommand(tasksCmd, provisionCmd, propletsCmd, jobsCmd, workflowsCmd, flCmd, healthCmd)
+	rootCmd.AddCommand(tasksCmd, provisionCmd, propletsCmd, jobsCmd, workflowsCmd, flCmd, healthCmd, rpcCmd)
 
 	rootCmd.PersistentFlags().StringVarP(
 		&managerURL,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -56,6 +56,7 @@ type config struct {
 	OTELURL         url.URL `env:"MANAGER_OTEL_URL"`
 	TraceRatio      float64 `env:"MANAGER_TRACE_RATIO" envDefault:"0"`
 	PluginDir       string  `env:"MANAGER_PLUGIN_DIR"`
+	JSONRPCControl  bool    `env:"MANAGER_JSONRPC_CONTROL_PLANE" envDefault:"false"`
 }
 
 func main() {
@@ -174,6 +175,7 @@ func main() {
 		cfg.CoordinatorURL,
 		logger,
 		pluginRegistry,
+		manager.WithJSONRPCControlPlane(cfg.JSONRPCControl),
 	)
 	svc = middleware.Plugin(pluginRegistry, logger, svc)
 	svc = middleware.Logging(logger, svc)

--- a/manager/api/jsonrpc.go
+++ b/manager/api/jsonrpc.go
@@ -1,0 +1,317 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	"github.com/absmach/propeller/manager"
+	"github.com/absmach/propeller/pkg/api"
+	"github.com/absmach/propeller/pkg/jsonrpc"
+	"github.com/absmach/propeller/pkg/task"
+)
+
+func NewRPCServer(svc manager.Service) *jsonrpc.Server {
+	srv := jsonrpc.NewServer()
+	registerTaskMethods(srv, svc)
+	registerPropletMethods(srv, svc)
+	registerJobMethods(srv, svc)
+
+	return srv
+}
+
+func decodeParams(raw json.RawMessage, v any) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	if err := json.Unmarshal(trimmed, v); err != nil {
+		return jsonrpc.InvalidParams("params could not be decoded")
+	}
+
+	return nil
+}
+
+func decodeID(raw json.RawMessage) (string, error) {
+	var params jsonrpc.IDParams
+	if err := decodeParams(raw, &params); err != nil {
+		return "", err
+	}
+	if params.ID == "" {
+		return "", jsonrpc.InvalidParams("id is required")
+	}
+
+	return params.ID, nil
+}
+
+func decodeList(raw json.RawMessage) (jsonrpc.ListParams, error) {
+	var params jsonrpc.ListParams
+	if err := decodeParams(raw, &params); err != nil {
+		return params, err
+	}
+	if params.Limit == 0 {
+		params.Limit = api.DefLimit
+	}
+
+	return params, nil
+}
+
+func decodeEntityList(raw json.RawMessage) (jsonrpc.EntityListParams, error) {
+	var params jsonrpc.EntityListParams
+	if err := decodeParams(raw, &params); err != nil {
+		return params, err
+	}
+	if params.ID == "" {
+		return params, jsonrpc.InvalidParams("id is required")
+	}
+	if params.Limit == 0 {
+		params.Limit = api.DefLimit
+	}
+
+	return params, nil
+}
+
+func registerTaskMethods(srv *jsonrpc.Server, svc manager.Service) {
+	srv.Register(jsonrpc.MethodTaskCreate, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		var t task.Task
+		if err := decodeParams(raw, &t); err != nil {
+			return nil, err
+		}
+		if t.Name == "" {
+			return nil, jsonrpc.InvalidParams("name is required")
+		}
+
+		return svc.CreateTask(ctx, t)
+	})
+
+	srv.Register(jsonrpc.MethodTaskGet, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		return svc.GetTask(ctx, id)
+	})
+
+	srv.Register(jsonrpc.MethodTaskList, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		params, err := decodeList(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		return svc.ListTasks(ctx, manager.PageMetadata{
+			Offset:   params.Offset,
+			Limit:    params.Limit,
+			Metadata: params.Metadata,
+		})
+	})
+
+	srv.Register(jsonrpc.MethodTaskUpdate, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		var t task.Task
+		if err := decodeParams(raw, &t); err != nil {
+			return nil, err
+		}
+		if t.ID == "" {
+			return nil, jsonrpc.InvalidParams("id is required")
+		}
+
+		return svc.UpdateTask(ctx, t)
+	})
+
+	srv.Register(jsonrpc.MethodTaskDelete, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := svc.DeleteTask(ctx, id); err != nil {
+			return nil, err
+		}
+
+		return jsonrpc.NewAck(), nil
+	})
+
+	srv.Register(jsonrpc.MethodTaskStart, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := svc.StartTask(ctx, id); err != nil {
+			return nil, err
+		}
+
+		return jsonrpc.NewAck(), nil
+	})
+
+	srv.Register(jsonrpc.MethodTaskStop, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := svc.StopTask(ctx, id); err != nil {
+			return nil, err
+		}
+
+		return jsonrpc.NewAck(), nil
+	})
+
+	srv.Register(jsonrpc.MethodTaskResults, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+		results, err := svc.GetTaskResults(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+
+		return jsonrpc.ResultsResult{Results: results}, nil
+	})
+
+	srv.Register(jsonrpc.MethodTaskMetrics, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		params, err := decodeEntityList(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		return svc.GetTaskMetrics(ctx, params.ID, params.Offset, params.Limit)
+	})
+}
+
+func registerPropletMethods(srv *jsonrpc.Server, svc manager.Service) {
+	srv.Register(jsonrpc.MethodPropletGet, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		return svc.GetProplet(ctx, id)
+	})
+
+	srv.Register(jsonrpc.MethodPropletList, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		params, err := decodeList(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		return svc.ListProplets(ctx, params.Offset, params.Limit, params.Status)
+	})
+
+	srv.Register(jsonrpc.MethodPropletDelete, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := svc.DeleteProplet(ctx, id); err != nil {
+			return nil, err
+		}
+
+		return jsonrpc.NewAck(), nil
+	})
+
+	srv.Register(jsonrpc.MethodPropletSDF, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		return svc.GetPropletSDF(ctx, id)
+	})
+
+	srv.Register(jsonrpc.MethodPropletMetrics, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		params, err := decodeEntityList(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		return svc.GetPropletMetrics(ctx, params.ID, params.Offset, params.Limit)
+	})
+
+	srv.Register(jsonrpc.MethodPropletAliveHistory, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		params, err := decodeEntityList(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		return svc.GetPropletAliveHistory(ctx, params.ID, params.Offset, params.Limit)
+	})
+}
+
+func registerJobMethods(srv *jsonrpc.Server, svc manager.Service) {
+	srv.Register(jsonrpc.MethodJobCreate, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		var params jsonrpc.JobParams
+		if err := decodeParams(raw, &params); err != nil {
+			return nil, err
+		}
+		if len(params.Tasks) == 0 {
+			return nil, jsonrpc.InvalidParams("tasks must not be empty")
+		}
+
+		jobID, tasks, err := svc.CreateJob(ctx, params.Name, params.Tasks, params.ExecutionMode)
+		if err != nil {
+			return nil, err
+		}
+
+		return jsonrpc.JobResult{JobID: jobID, Tasks: tasks}, nil
+	})
+
+	srv.Register(jsonrpc.MethodJobGet, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+		tasks, err := svc.GetJob(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+
+		return jsonrpc.JobResult{JobID: id, Tasks: tasks}, nil
+	})
+
+	srv.Register(jsonrpc.MethodJobList, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		params, err := decodeList(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		return svc.ListJobs(ctx, params.Offset, params.Limit, params.Status)
+	})
+
+	srv.Register(jsonrpc.MethodJobStart, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := svc.StartJob(ctx, id); err != nil {
+			return nil, err
+		}
+
+		return jsonrpc.NewAck(), nil
+	})
+
+	srv.Register(jsonrpc.MethodJobStop, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		id, err := decodeID(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := svc.StopJob(ctx, id); err != nil {
+			return nil, err
+		}
+
+		return jsonrpc.NewAck(), nil
+	})
+
+	srv.Register(jsonrpc.MethodWorkflowCreate, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		var params jsonrpc.WorkflowParams
+		if err := decodeParams(raw, &params); err != nil {
+			return nil, err
+		}
+		if len(params.Tasks) == 0 {
+			return nil, jsonrpc.InvalidParams("tasks must not be empty")
+		}
+
+		return svc.CreateWorkflow(ctx, params.Tasks)
+	})
+}

--- a/manager/api/jsonrpc_test.go
+++ b/manager/api/jsonrpc_test.go
@@ -60,98 +60,96 @@ func TestRPCDispatch(t *testing.T) {
 	propletID := uuid.NewString()
 
 	cases := []struct {
-		desc    string
-		payload string
-		setup   func(svc *mocks.MockService)
-		want    string
+		desc       string
+		payload    string
+		svcMethod  string
+		svcArgs    []any
+		svcReturns []any
+		want       string
 	}{
 		{
-			desc:    "task.get returns the task",
-			payload: `{"jsonrpc":"2.0","method":"task.get","params":{"id":"` + taskID + `"},"id":1}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("GetTask", mock.Anything, taskID).Return(task.Task{ID: taskID, Name: "t"}, nil)
-			},
-			want: `{"jsonrpc":"2.0","result":{"id":"` + taskID + `","name":"t","state":0,"cli_args":null,"daemon":false,"encrypted":false,"start_time":"0001-01-01T00:00:00Z","finish_time":"0001-01-01T00:00:00Z","created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","next_run":"0001-01-01T00:00:00Z"},"id":1}`,
+			desc:       "task.get returns the task",
+			payload:    `{"jsonrpc":"2.0","method":"task.get","params":{"id":"` + taskID + `"},"id":1}`,
+			svcMethod:  "GetTask",
+			svcArgs:    []any{mock.Anything, taskID},
+			svcReturns: []any{task.Task{ID: taskID, Name: "t"}, nil},
+			want:       `{"jsonrpc":"2.0","result":{"id":"` + taskID + `","name":"t","state":0,"cli_args":null,"daemon":false,"encrypted":false,"start_time":"0001-01-01T00:00:00Z","finish_time":"0001-01-01T00:00:00Z","created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","next_run":"0001-01-01T00:00:00Z"},"id":1}`,
 		},
 		{
-			desc:    "task.start acknowledges",
-			payload: `{"jsonrpc":"2.0","method":"task.start","params":{"id":"` + taskID + `"},"id":2}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("StartTask", mock.Anything, taskID).Return(nil)
-			},
-			want: `{"jsonrpc":"2.0","result":{"ok":true},"id":2}`,
+			desc:       "task.start acknowledges",
+			payload:    `{"jsonrpc":"2.0","method":"task.start","params":{"id":"` + taskID + `"},"id":2}`,
+			svcMethod:  "StartTask",
+			svcArgs:    []any{mock.Anything, taskID},
+			svcReturns: []any{nil},
+			want:       `{"jsonrpc":"2.0","result":{"ok":true},"id":2}`,
 		},
 		{
-			desc:    "task.stop acknowledges",
-			payload: `{"jsonrpc":"2.0","method":"task.stop","params":{"id":"` + taskID + `"},"id":3}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("StopTask", mock.Anything, taskID).Return(nil)
-			},
-			want: `{"jsonrpc":"2.0","result":{"ok":true},"id":3}`,
+			desc:       "task.stop acknowledges",
+			payload:    `{"jsonrpc":"2.0","method":"task.stop","params":{"id":"` + taskID + `"},"id":3}`,
+			svcMethod:  "StopTask",
+			svcArgs:    []any{mock.Anything, taskID},
+			svcReturns: []any{nil},
+			want:       `{"jsonrpc":"2.0","result":{"ok":true},"id":3}`,
 		},
 		{
-			desc:    "task.delete acknowledges",
-			payload: `{"jsonrpc":"2.0","method":"task.delete","params":{"id":"` + taskID + `"},"id":4}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("DeleteTask", mock.Anything, taskID).Return(nil)
-			},
-			want: `{"jsonrpc":"2.0","result":{"ok":true},"id":4}`,
+			desc:       "task.delete acknowledges",
+			payload:    `{"jsonrpc":"2.0","method":"task.delete","params":{"id":"` + taskID + `"},"id":4}`,
+			svcMethod:  "DeleteTask",
+			svcArgs:    []any{mock.Anything, taskID},
+			svcReturns: []any{nil},
+			want:       `{"jsonrpc":"2.0","result":{"ok":true},"id":4}`,
 		},
 		{
-			desc:    "task.results wraps the results",
-			payload: `{"jsonrpc":"2.0","method":"task.results","params":{"id":"` + taskID + `"},"id":5}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("GetTaskResults", mock.Anything, taskID).Return("42", nil)
-			},
-			want: `{"jsonrpc":"2.0","result":{"results":"42"},"id":5}`,
+			desc:       "task.results wraps the results",
+			payload:    `{"jsonrpc":"2.0","method":"task.results","params":{"id":"` + taskID + `"},"id":5}`,
+			svcMethod:  "GetTaskResults",
+			svcArgs:    []any{mock.Anything, taskID},
+			svcReturns: []any{"42", nil},
+			want:       `{"jsonrpc":"2.0","result":{"results":"42"},"id":5}`,
 		},
 		{
-			desc:    "a missing task maps to the not found code",
-			payload: `{"jsonrpc":"2.0","method":"task.get","params":{"id":"` + taskID + `"},"id":6}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("GetTask", mock.Anything, taskID).Return(task.Task{}, pkgerrors.ErrNotFound)
-			},
-			want: `{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":6}`,
+			desc:       "a missing task maps to the not found code",
+			payload:    `{"jsonrpc":"2.0","method":"task.get","params":{"id":"` + taskID + `"},"id":6}`,
+			svcMethod:  "GetTask",
+			svcArgs:    []any{mock.Anything, taskID},
+			svcReturns: []any{task.Task{}, pkgerrors.ErrNotFound},
+			want:       `{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":6}`,
 		},
 		{
 			desc:    "a missing id is rejected before the service is called",
 			payload: `{"jsonrpc":"2.0","method":"task.start","params":{},"id":7}`,
-			setup:   func(_ *mocks.MockService) {},
 			want:    `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"id is required"},"id":7}`,
 		},
 		{
 			desc:    "task.create requires a name",
 			payload: `{"jsonrpc":"2.0","method":"task.create","params":{},"id":8}`,
-			setup:   func(_ *mocks.MockService) {},
 			want:    `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"name is required"},"id":8}`,
 		},
 		{
 			desc:    "malformed params are rejected without leaking internals",
 			payload: `{"jsonrpc":"2.0","method":"task.get","params":{"id":5},"id":9}`,
-			setup:   func(_ *mocks.MockService) {},
 			want:    `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"params could not be decoded"},"id":9}`,
 		},
 		{
-			desc:    "proplet.delete acknowledges",
-			payload: `{"jsonrpc":"2.0","method":"proplet.delete","params":{"id":"` + propletID + `"},"id":10}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("DeleteProplet", mock.Anything, propletID).Return(nil)
-			},
-			want: `{"jsonrpc":"2.0","result":{"ok":true},"id":10}`,
+			desc:       "proplet.delete acknowledges",
+			payload:    `{"jsonrpc":"2.0","method":"proplet.delete","params":{"id":"` + propletID + `"},"id":10}`,
+			svcMethod:  "DeleteProplet",
+			svcArgs:    []any{mock.Anything, propletID},
+			svcReturns: []any{nil},
+			want:       `{"jsonrpc":"2.0","result":{"ok":true},"id":10}`,
 		},
 		{
 			desc:    "workflow.create requires tasks",
 			payload: `{"jsonrpc":"2.0","method":"workflow.create","params":{"tasks":[]},"id":11}`,
-			setup:   func(_ *mocks.MockService) {},
 			want:    `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"tasks must not be empty"},"id":11}`,
 		},
 		{
-			desc:    "job.get wraps the job id with its tasks",
-			payload: `{"jsonrpc":"2.0","method":"job.get","params":{"id":"job-1"},"id":12}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("GetJob", mock.Anything, "job-1").Return([]task.Task{}, nil)
-			},
-			want: `{"jsonrpc":"2.0","result":{"job_id":"job-1","tasks":[]},"id":12}`,
+			desc:       "job.get wraps the job id with its tasks",
+			payload:    `{"jsonrpc":"2.0","method":"job.get","params":{"id":"job-1"},"id":12}`,
+			svcMethod:  "GetJob",
+			svcArgs:    []any{mock.Anything, "job-1"},
+			svcReturns: []any{[]task.Task{}, nil},
+			want:       `{"jsonrpc":"2.0","result":{"job_id":"job-1","tasks":[]},"id":12}`,
 		},
 	}
 
@@ -160,7 +158,9 @@ func TestRPCDispatch(t *testing.T) {
 			t.Parallel()
 
 			svc := new(mocks.MockService)
-			tc.setup(svc)
+			if tc.svcMethod != "" {
+				svc.On(tc.svcMethod, tc.svcArgs...).Return(tc.svcReturns...)
+			}
 
 			out := managerapi.NewRPCServer(svc).Handle(context.Background(), []byte(tc.payload))
 			require.NotNil(t, out)

--- a/manager/api/jsonrpc_test.go
+++ b/manager/api/jsonrpc_test.go
@@ -1,0 +1,224 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	managerapi "github.com/absmach/propeller/manager/api"
+	"github.com/absmach/propeller/manager/mocks"
+	pkgerrors "github.com/absmach/propeller/pkg/errors"
+	"github.com/absmach/propeller/pkg/jsonrpc"
+	"github.com/absmach/propeller/pkg/proplet"
+	"github.com/absmach/propeller/pkg/task"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRPCServerMethods(t *testing.T) {
+	t.Parallel()
+
+	svc := new(mocks.MockService)
+	methods := managerapi.NewRPCServer(svc).Methods()
+
+	for _, method := range []string{
+		jsonrpc.MethodTaskCreate,
+		jsonrpc.MethodTaskGet,
+		jsonrpc.MethodTaskList,
+		jsonrpc.MethodTaskUpdate,
+		jsonrpc.MethodTaskDelete,
+		jsonrpc.MethodTaskStart,
+		jsonrpc.MethodTaskStop,
+		jsonrpc.MethodTaskResults,
+		jsonrpc.MethodTaskMetrics,
+		jsonrpc.MethodPropletGet,
+		jsonrpc.MethodPropletList,
+		jsonrpc.MethodPropletDelete,
+		jsonrpc.MethodPropletSDF,
+		jsonrpc.MethodPropletMetrics,
+		jsonrpc.MethodPropletAliveHistory,
+		jsonrpc.MethodJobCreate,
+		jsonrpc.MethodJobGet,
+		jsonrpc.MethodJobList,
+		jsonrpc.MethodJobStart,
+		jsonrpc.MethodJobStop,
+		jsonrpc.MethodWorkflowCreate,
+	} {
+		assert.Contains(t, methods, method)
+	}
+}
+
+func TestRPCDispatch(t *testing.T) {
+	t.Parallel()
+
+	taskID := uuid.NewString()
+	propletID := uuid.NewString()
+
+	cases := []struct {
+		desc    string
+		payload string
+		setup   func(svc *mocks.MockService)
+		want    string
+	}{
+		{
+			desc:    "task.get returns the task",
+			payload: `{"jsonrpc":"2.0","method":"task.get","params":{"id":"` + taskID + `"},"id":1}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("GetTask", mock.Anything, taskID).Return(task.Task{ID: taskID, Name: "t"}, nil)
+			},
+			want: `{"jsonrpc":"2.0","result":{"id":"` + taskID + `","name":"t","state":0,"cli_args":null,"daemon":false,"encrypted":false,"start_time":"0001-01-01T00:00:00Z","finish_time":"0001-01-01T00:00:00Z","created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","next_run":"0001-01-01T00:00:00Z"},"id":1}`,
+		},
+		{
+			desc:    "task.start acknowledges",
+			payload: `{"jsonrpc":"2.0","method":"task.start","params":{"id":"` + taskID + `"},"id":2}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("StartTask", mock.Anything, taskID).Return(nil)
+			},
+			want: `{"jsonrpc":"2.0","result":{"ok":true},"id":2}`,
+		},
+		{
+			desc:    "task.stop acknowledges",
+			payload: `{"jsonrpc":"2.0","method":"task.stop","params":{"id":"` + taskID + `"},"id":3}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("StopTask", mock.Anything, taskID).Return(nil)
+			},
+			want: `{"jsonrpc":"2.0","result":{"ok":true},"id":3}`,
+		},
+		{
+			desc:    "task.delete acknowledges",
+			payload: `{"jsonrpc":"2.0","method":"task.delete","params":{"id":"` + taskID + `"},"id":4}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("DeleteTask", mock.Anything, taskID).Return(nil)
+			},
+			want: `{"jsonrpc":"2.0","result":{"ok":true},"id":4}`,
+		},
+		{
+			desc:    "task.results wraps the results",
+			payload: `{"jsonrpc":"2.0","method":"task.results","params":{"id":"` + taskID + `"},"id":5}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("GetTaskResults", mock.Anything, taskID).Return("42", nil)
+			},
+			want: `{"jsonrpc":"2.0","result":{"results":"42"},"id":5}`,
+		},
+		{
+			desc:    "a missing task maps to the not found code",
+			payload: `{"jsonrpc":"2.0","method":"task.get","params":{"id":"` + taskID + `"},"id":6}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("GetTask", mock.Anything, taskID).Return(task.Task{}, pkgerrors.ErrNotFound)
+			},
+			want: `{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":6}`,
+		},
+		{
+			desc:    "a missing id is rejected before the service is called",
+			payload: `{"jsonrpc":"2.0","method":"task.start","params":{},"id":7}`,
+			setup:   func(_ *mocks.MockService) {},
+			want:    `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"id is required"},"id":7}`,
+		},
+		{
+			desc:    "task.create requires a name",
+			payload: `{"jsonrpc":"2.0","method":"task.create","params":{},"id":8}`,
+			setup:   func(_ *mocks.MockService) {},
+			want:    `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"name is required"},"id":8}`,
+		},
+		{
+			desc:    "malformed params are rejected without leaking internals",
+			payload: `{"jsonrpc":"2.0","method":"task.get","params":{"id":5},"id":9}`,
+			setup:   func(_ *mocks.MockService) {},
+			want:    `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"params could not be decoded"},"id":9}`,
+		},
+		{
+			desc:    "proplet.delete acknowledges",
+			payload: `{"jsonrpc":"2.0","method":"proplet.delete","params":{"id":"` + propletID + `"},"id":10}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("DeleteProplet", mock.Anything, propletID).Return(nil)
+			},
+			want: `{"jsonrpc":"2.0","result":{"ok":true},"id":10}`,
+		},
+		{
+			desc:    "workflow.create requires tasks",
+			payload: `{"jsonrpc":"2.0","method":"workflow.create","params":{"tasks":[]},"id":11}`,
+			setup:   func(_ *mocks.MockService) {},
+			want:    `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params","data":"tasks must not be empty"},"id":11}`,
+		},
+		{
+			desc:    "job.get wraps the job id with its tasks",
+			payload: `{"jsonrpc":"2.0","method":"job.get","params":{"id":"job-1"},"id":12}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("GetJob", mock.Anything, "job-1").Return([]task.Task{}, nil)
+			},
+			want: `{"jsonrpc":"2.0","result":{"job_id":"job-1","tasks":[]},"id":12}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			svc := new(mocks.MockService)
+			tc.setup(svc)
+
+			out := managerapi.NewRPCServer(svc).Handle(context.Background(), []byte(tc.payload))
+			require.NotNil(t, out)
+			assert.JSONEq(t, tc.want, string(out))
+		})
+	}
+}
+
+func TestRPCListAppliesDefaultLimit(t *testing.T) {
+	t.Parallel()
+
+	svc := new(mocks.MockService)
+	svc.On("ListProplets", mock.Anything, uint64(0), uint64(100), "").
+		Return(proplet.PropletPage{Offset: 0, Limit: 100}, nil)
+
+	out := managerapi.NewRPCServer(svc).Handle(
+		context.Background(),
+		[]byte(`{"jsonrpc":"2.0","method":"proplet.list","id":1}`),
+	)
+
+	var resp jsonrpc.Response
+	require.NoError(t, json.Unmarshal(out, &resp))
+	require.Nil(t, resp.Error)
+	svc.AssertExpectations(t)
+}
+
+func TestRPCBatchAcrossServices(t *testing.T) {
+	t.Parallel()
+
+	taskID := uuid.NewString()
+	svc := new(mocks.MockService)
+	svc.On("StartTask", mock.Anything, taskID).Return(nil)
+	svc.On("GetTaskResults", mock.Anything, taskID).Return("done", nil)
+
+	payload := `[{"jsonrpc":"2.0","method":"task.start","params":{"id":"` + taskID + `"},"id":1},` +
+		`{"jsonrpc":"2.0","method":"task.results","params":{"id":"` + taskID + `"},"id":2}]`
+
+	out := managerapi.NewRPCServer(svc).Handle(context.Background(), []byte(payload))
+	assert.JSONEq(
+		t,
+		`[{"jsonrpc":"2.0","result":{"ok":true},"id":1},{"jsonrpc":"2.0","result":{"results":"done"},"id":2}]`,
+		string(out),
+	)
+	svc.AssertExpectations(t)
+}
+
+func TestRPCNotificationProducesNoResponse(t *testing.T) {
+	t.Parallel()
+
+	taskID := uuid.NewString()
+	svc := new(mocks.MockService)
+	svc.On("StartTask", mock.Anything, taskID).Return(nil)
+
+	out := managerapi.NewRPCServer(svc).Handle(
+		context.Background(),
+		[]byte(`{"jsonrpc":"2.0","method":"task.start","params":{"id":"`+taskID+`"}}`),
+	)
+
+	assert.Nil(t, out)
+	svc.AssertExpectations(t)
+}

--- a/manager/api/rpc_transport_test.go
+++ b/manager/api/rpc_transport_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/absmach/propeller/manager/mocks"
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
 	"github.com/absmach/propeller/pkg/jsonrpc"
 	"github.com/absmach/propeller/pkg/task"
@@ -46,7 +45,9 @@ func TestRPCEndpoint(t *testing.T) {
 		desc        string
 		contentType string
 		body        string
-		setup       func(svc *mocks.MockService)
+		svcMethod   string
+		svcArgs     []any
+		svcReturns  []any
 		status      int
 		want        string
 	}{
@@ -54,27 +55,26 @@ func TestRPCEndpoint(t *testing.T) {
 			desc:        "a call returns its result",
 			contentType: "application/json",
 			body:        `{"jsonrpc":"2.0","method":"task.start","params":{"id":"` + taskID + `"},"id":1}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("StartTask", mock.Anything, taskID).Return(nil)
-			},
-			status: http.StatusOK,
-			want:   `{"jsonrpc":"2.0","result":{"ok":true},"id":1}`,
+			svcMethod:   "StartTask",
+			svcArgs:     []any{mock.Anything, taskID},
+			svcReturns:  []any{nil},
+			status:      http.StatusOK,
+			want:        `{"jsonrpc":"2.0","result":{"ok":true},"id":1}`,
 		},
 		{
 			desc:        "a service error becomes a jsonrpc error with a 200 status",
 			contentType: "application/json",
 			body:        `{"jsonrpc":"2.0","method":"task.get","params":{"id":"` + taskID + `"},"id":2}`,
-			setup: func(svc *mocks.MockService) {
-				svc.On("GetTask", mock.Anything, taskID).Return(task.Task{}, pkgerrors.ErrNotFound)
-			},
-			status: http.StatusOK,
-			want:   `{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":2}`,
+			svcMethod:   "GetTask",
+			svcArgs:     []any{mock.Anything, taskID},
+			svcReturns:  []any{task.Task{}, pkgerrors.ErrNotFound},
+			status:      http.StatusOK,
+			want:        `{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":2}`,
 		},
 		{
 			desc:        "malformed json returns a parse error",
 			contentType: "application/json",
 			body:        `{"jsonrpc":"2.0",`,
-			setup:       func(_ *mocks.MockService) {},
 			status:      http.StatusOK,
 			want:        `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}`,
 		},
@@ -82,7 +82,6 @@ func TestRPCEndpoint(t *testing.T) {
 			desc:        "an unknown method is reported",
 			contentType: "application/json",
 			body:        `{"jsonrpc":"2.0","method":"task.explode","id":3}`,
-			setup:       func(_ *mocks.MockService) {},
 			status:      http.StatusOK,
 			want:        `{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":"task.explode"},"id":3}`,
 		},
@@ -94,7 +93,9 @@ func TestRPCEndpoint(t *testing.T) {
 
 			ts, svc := newServer(t)
 			defer ts.Close()
-			tc.setup(svc)
+			if tc.svcMethod != "" {
+				svc.On(tc.svcMethod, tc.svcArgs...).Return(tc.svcReturns...)
+			}
 
 			status, body := postRPC(t, ts.URL, tc.contentType, tc.body)
 			assert.Equal(t, tc.status, status)

--- a/manager/api/rpc_transport_test.go
+++ b/manager/api/rpc_transport_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package api_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/absmach/propeller/manager/mocks"
+	pkgerrors "github.com/absmach/propeller/pkg/errors"
+	"github.com/absmach/propeller/pkg/jsonrpc"
+	"github.com/absmach/propeller/pkg/task"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func postRPC(t *testing.T, url, contentType, body string) (status int, payload string) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, url+"/rpc", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return resp.StatusCode, string(data)
+}
+
+func TestRPCEndpoint(t *testing.T) {
+	t.Parallel()
+
+	taskID := uuid.NewString()
+
+	cases := []struct {
+		desc        string
+		contentType string
+		body        string
+		setup       func(svc *mocks.MockService)
+		status      int
+		want        string
+	}{
+		{
+			desc:        "a call returns its result",
+			contentType: "application/json",
+			body:        `{"jsonrpc":"2.0","method":"task.start","params":{"id":"` + taskID + `"},"id":1}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("StartTask", mock.Anything, taskID).Return(nil)
+			},
+			status: http.StatusOK,
+			want:   `{"jsonrpc":"2.0","result":{"ok":true},"id":1}`,
+		},
+		{
+			desc:        "a service error becomes a jsonrpc error with a 200 status",
+			contentType: "application/json",
+			body:        `{"jsonrpc":"2.0","method":"task.get","params":{"id":"` + taskID + `"},"id":2}`,
+			setup: func(svc *mocks.MockService) {
+				svc.On("GetTask", mock.Anything, taskID).Return(task.Task{}, pkgerrors.ErrNotFound)
+			},
+			status: http.StatusOK,
+			want:   `{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":2}`,
+		},
+		{
+			desc:        "malformed json returns a parse error",
+			contentType: "application/json",
+			body:        `{"jsonrpc":"2.0",`,
+			setup:       func(_ *mocks.MockService) {},
+			status:      http.StatusOK,
+			want:        `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}`,
+		},
+		{
+			desc:        "an unknown method is reported",
+			contentType: "application/json",
+			body:        `{"jsonrpc":"2.0","method":"task.explode","id":3}`,
+			setup:       func(_ *mocks.MockService) {},
+			status:      http.StatusOK,
+			want:        `{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":"task.explode"},"id":3}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ts, svc := newServer(t)
+			defer ts.Close()
+			tc.setup(svc)
+
+			status, body := postRPC(t, ts.URL, tc.contentType, tc.body)
+			assert.Equal(t, tc.status, status)
+			assert.JSONEq(t, tc.want, body)
+		})
+	}
+}
+
+func TestRPCEndpointRejectsWrongContentType(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := newServer(t)
+	defer ts.Close()
+
+	status, _ := postRPC(t, ts.URL, "text/plain", `{"jsonrpc":"2.0","method":"task.list","id":1}`)
+	assert.Equal(t, http.StatusBadRequest, status)
+}
+
+func TestRPCEndpointNotificationReturnsNoContent(t *testing.T) {
+	t.Parallel()
+
+	taskID := uuid.NewString()
+	ts, svc := newServer(t)
+	defer ts.Close()
+	svc.On("StartTask", mock.Anything, taskID).Return(nil)
+
+	status, body := postRPC(t, ts.URL, "application/json",
+		`{"jsonrpc":"2.0","method":"task.start","params":{"id":"`+taskID+`"}}`)
+
+	assert.Equal(t, http.StatusNoContent, status)
+	assert.Empty(t, body)
+	svc.AssertExpectations(t)
+}
+
+func TestRPCEndpointBatch(t *testing.T) {
+	t.Parallel()
+
+	taskID := uuid.NewString()
+	ts, svc := newServer(t)
+	defer ts.Close()
+	svc.On("StartTask", mock.Anything, taskID).Return(nil)
+	svc.On("StopTask", mock.Anything, taskID).Return(nil)
+
+	body := `[{"jsonrpc":"2.0","method":"task.start","params":{"id":"` + taskID + `"},"id":1},` +
+		`{"jsonrpc":"2.0","method":"task.stop","params":{"id":"` + taskID + `"},"id":2}]`
+
+	status, out := postRPC(t, ts.URL, "application/json", body)
+	assert.Equal(t, http.StatusOK, status)
+
+	var responses []jsonrpc.Response
+	require.NoError(t, json.Unmarshal([]byte(out), &responses))
+	require.Len(t, responses, 2)
+	for _, r := range responses {
+		assert.Nil(t, r.Error)
+	}
+	svc.AssertExpectations(t)
+}
+
+func TestRESTRoutesStillWork(t *testing.T) {
+	t.Parallel()
+
+	taskID := uuid.NewString()
+	ts, svc := newServer(t)
+	defer ts.Close()
+	svc.On("GetTask", mock.Anything, taskID).Return(task.Task{ID: taskID, Name: "t"}, nil)
+
+	resp, err := http.Get(ts.URL + "/tasks/" + taskID)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	svc.AssertExpectations(t)
+}

--- a/manager/api/transport.go
+++ b/manager/api/transport.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/absmach/propeller/manager"
 	"github.com/absmach/propeller/pkg/api"
+	"github.com/absmach/propeller/pkg/jsonrpc"
 	"github.com/absmach/propeller/pkg/plugin"
 	"github.com/absmach/propeller/pkg/task"
 	"github.com/go-chi/chi/v5"
@@ -257,10 +258,40 @@ func MakeHandler(svc manager.Service, logger *slog.Logger, instanceID string) ht
 		})
 	})
 
+	mux.Post("/rpc", otelhttp.NewHandler(rpcHandler(NewRPCServer(svc)), "rpc").ServeHTTP)
+
 	mux.Get("/health", api.HealthHandler("manager", instanceID))
 	mux.Handle("/metrics", promhttp.Handler())
 
 	return mux
+}
+
+func rpcHandler(srv *jsonrpc.Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Content-Type"), api.ContentType) {
+			api.EncodeError(r.Context(), errors.Join(api.ErrValidation, api.ErrUnsupportedContentType), w)
+
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			body = nil
+		}
+
+		out := srv.Handle(r.Context(), body)
+		if out == nil {
+			w.WriteHeader(http.StatusNoContent)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", api.ContentType)
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(out); err != nil {
+			return
+		}
+	}
 }
 
 func decodeEntityReq(key string) kithttp.DecodeRequestFunc {

--- a/manager/controlplane.go
+++ b/manager/controlplane.go
@@ -1,0 +1,78 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package manager
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/absmach/propeller/pkg/jsonrpc"
+)
+
+type Option func(*service)
+
+func WithJSONRPCControlPlane(enabled bool) Option {
+	return func(svc *service) {
+		svc.jsonrpcControlPlane = enabled
+	}
+}
+
+func (svc *service) publishControl(ctx context.Context, topic, method, taskID string, payload any) error {
+	msg, err := svc.controlPayload(method, jsonrpc.StringID(taskID), payload)
+	if err != nil {
+		return err
+	}
+
+	return svc.pubsub.Publish(ctx, topic, msg)
+}
+
+func (svc *service) controlPayload(method string, id *jsonrpc.ID, payload any) (any, error) {
+	if !svc.jsonrpcControlPlane {
+		return payload, nil
+	}
+
+	req, err := jsonrpc.NewRequest(id, method, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func decodeControlMessage(msg map[string]any) (map[string]any, *jsonrpc.ID) {
+	version, ok := msg["jsonrpc"].(string)
+	if !ok || version != jsonrpc.Version {
+		return msg, nil
+	}
+
+	var id *jsonrpc.ID
+	if raw, ok := msg["id"]; ok {
+		encoded, err := json.Marshal(raw)
+		if err == nil {
+			parsed := &jsonrpc.ID{}
+			if err := parsed.UnmarshalJSON(encoded); err == nil {
+				id = parsed
+			}
+		}
+	}
+
+	if result, ok := msg["result"].(map[string]any); ok {
+		return result, id
+	}
+
+	if params, ok := msg["params"].(map[string]any); ok {
+		return params, id
+	}
+
+	if rpcErr, ok := msg["error"].(map[string]any); ok {
+		unwrapped := map[string]any{}
+		if message, ok := rpcErr["message"].(string); ok {
+			unwrapped["error"] = message
+		}
+
+		return unwrapped, id
+	}
+
+	return msg, id
+}

--- a/manager/controlplane_test.go
+++ b/manager/controlplane_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package manager_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/absmach/propeller/manager"
+	"github.com/absmach/propeller/pkg/jsonrpc"
+	mqttmocks "github.com/absmach/propeller/pkg/mqtt/mocks"
+	"github.com/absmach/propeller/pkg/scheduler"
+	"github.com/absmach/propeller/pkg/storage"
+	"github.com/absmach/propeller/pkg/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func captureControlPublish(t *testing.T, suffix string, opts ...manager.Option) (svc manager.Service, captured func() map[string]any) {
+	t.Helper()
+
+	repos, err := storage.NewRepositories(storage.Config{Type: "memory"})
+	require.NoError(t, err)
+
+	var capturedMsg map[string]any
+	pubsub := mqttmocks.NewMockPubSub(t)
+	pubsub.On("Publish", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			topic, _ := args.Get(1).(string)
+			if !strings.HasSuffix(topic, suffix) {
+				return
+			}
+			raw, err := json.Marshal(args.Get(2))
+			require.NoError(t, err)
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(raw, &decoded))
+			capturedMsg = decoded
+		}).
+		Return(nil).Maybe()
+	pubsub.On("Subscribe", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	pubsub.On("Unsubscribe", mock.Anything, mock.Anything).Return(nil).Maybe()
+	pubsub.On("Disconnect", mock.Anything).Return(nil).Maybe()
+
+	service, _, _ := manager.NewService(
+		repos, scheduler.NewRoundRobin(), pubsub,
+		"test-tenant", "test-channel", "", slog.Default(), nil,
+		opts...,
+	)
+
+	return service, func() map[string]any { return capturedMsg }
+}
+
+func TestPublishStopEncoding(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc    string
+		opts    []manager.Option
+		wrapped bool
+	}{
+		{
+			desc:    "legacy flat payload by default",
+			wrapped: false,
+		},
+		{
+			desc:    "jsonrpc envelope when the control plane is enabled",
+			opts:    []manager.Option{manager.WithJSONRPCControlPlane(true)},
+			wrapped: true,
+		},
+		{
+			desc:    "explicitly disabled stays flat",
+			opts:    []manager.Option{manager.WithJSONRPCControlPlane(false)},
+			wrapped: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			svc, captured := captureControlPublish(t, "/control/manager/stop", tc.opts...)
+
+			created, err := svc.CreateTask(context.Background(), task.Task{Name: "t", Broadcast: true})
+			require.NoError(t, err)
+			require.NoError(t, svc.StopTask(context.Background(), created.ID))
+
+			payload := captured()
+			require.NotNil(t, payload, "no stop message was published")
+
+			if !tc.wrapped {
+				assert.NotContains(t, payload, "jsonrpc")
+				assert.Equal(t, created.ID, payload["id"])
+
+				return
+			}
+
+			assert.Equal(t, jsonrpc.Version, payload["jsonrpc"])
+			assert.Equal(t, jsonrpc.MethodTaskStop, payload["method"])
+			assert.Equal(t, created.ID, payload["id"])
+
+			params, ok := payload["params"].(map[string]any)
+			require.True(t, ok, "params must be an object")
+			assert.Equal(t, created.ID, params["id"])
+		})
+	}
+}
+
+func TestPublishStartEncoding(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc    string
+		opts    []manager.Option
+		wrapped bool
+	}{
+		{
+			desc:    "legacy flat payload by default",
+			wrapped: false,
+		},
+		{
+			desc:    "jsonrpc envelope when the control plane is enabled",
+			opts:    []manager.Option{manager.WithJSONRPCControlPlane(true)},
+			wrapped: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			svc, captured := captureControlPublish(t, "/control/manager/start", tc.opts...)
+
+			created, err := svc.CreateTask(context.Background(), task.Task{Name: "t", Broadcast: true})
+			require.NoError(t, err)
+			require.NoError(t, svc.StartTask(context.Background(), created.ID))
+
+			payload := captured()
+			require.NotNil(t, payload, "no start message was published")
+
+			if !tc.wrapped {
+				assert.NotContains(t, payload, "jsonrpc")
+				assert.Equal(t, created.ID, payload["id"])
+				assert.Equal(t, "t", payload["name"])
+
+				return
+			}
+
+			assert.Equal(t, jsonrpc.Version, payload["jsonrpc"])
+			assert.Equal(t, jsonrpc.MethodTaskStart, payload["method"])
+
+			params, ok := payload["params"].(map[string]any)
+			require.True(t, ok, "params must be an object")
+			assert.Equal(t, created.ID, params["id"])
+			assert.Equal(t, "t", params["name"])
+		})
+	}
+}

--- a/manager/service.go
+++ b/manager/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/absmach/propeller/pkg/dag"
 	pkgerrors "github.com/absmach/propeller/pkg/errors"
 	"github.com/absmach/propeller/pkg/job"
+	"github.com/absmach/propeller/pkg/jsonrpc"
 	"github.com/absmach/propeller/pkg/maps"
 	"github.com/absmach/propeller/pkg/mqtt"
 	"github.com/absmach/propeller/pkg/plugin"
@@ -73,6 +74,8 @@ type service struct {
 	wg               sync.WaitGroup
 	pendingInvokes   map[string]chan invokeResult
 	pendingInvokesMu sync.Mutex
+
+	jsonrpcControlPlane bool
 }
 
 type invokeResult struct {
@@ -86,6 +89,7 @@ func NewService(
 	repos *storage.Repositories,
 	s scheduler.Scheduler, pubsub mqtt.PubSub,
 	tenantID, channelID, coordinatorURL string, logger *slog.Logger, plugins plugin.Registry,
+	opts ...Option,
 ) (Service, CronScheduler, *WorkflowCoordinator) {
 	var httpClient *http.Client
 	if coordinatorURL != "" {
@@ -112,6 +116,10 @@ func NewService(
 		plugins:          plugins,
 		pendingInvokes:   make(map[string]chan invokeResult),
 	}
+	for _, opt := range opts {
+		opt(svc)
+	}
+
 	coordinator := NewWorkflowCoordinator(repos.Tasks, svc, logger)
 	svc.coordinator = coordinator
 
@@ -809,7 +817,7 @@ func (svc *service) StopTask(ctx context.Context, taskID string) error {
 
 	if t.Broadcast {
 		topic := svc.baseTopic + "/control/manager/stop"
-		if err := svc.pubsub.Publish(ctx, topic, stopPayload); err != nil {
+		if err := svc.publishControl(ctx, topic, jsonrpc.MethodTaskStop, t.ID, stopPayload); err != nil {
 			return err
 		}
 
@@ -828,7 +836,7 @@ func (svc *service) StopTask(ctx context.Context, taskID string) error {
 	stopPayload["proplet_id"] = propletID
 
 	topic := svc.baseTopic + "/control/manager/stop"
-	if err := svc.pubsub.Publish(ctx, topic, stopPayload); err != nil {
+	if err := svc.publishControl(ctx, topic, jsonrpc.MethodTaskStop, t.ID, stopPayload); err != nil {
 		return err
 	}
 
@@ -1094,7 +1102,7 @@ func (svc *service) RecoverInterruptedTasks(ctx context.Context) error {
 					"id":         t.ID,
 					"proplet_id": propletID,
 				}
-				if err := svc.pubsub.Publish(ctx, stopTopic, stopPayload); err != nil {
+				if err := svc.publishControl(ctx, stopTopic, jsonrpc.MethodTaskStop, t.ID, stopPayload); err != nil {
 					svc.logger.Warn("failed to send stop command for interrupted task", slog.String("task_id", t.ID), slog.Any("error", err))
 				} else {
 					// Give proplets a small window to observe the stop signal before marking failed.
@@ -1365,6 +1373,8 @@ func (svc *service) stopJobTasks(ctx context.Context, tasks []task.Task) {
 
 func (svc *service) handle(ctx context.Context) func(topic string, msg map[string]any) error {
 	return func(topic string, msg map[string]any) error {
+		msg, _ = decodeControlMessage(msg)
+
 		switch topic {
 		case svc.baseTopic + "/control/proplet/create":
 			if err := svc.createPropletHandler(ctx, msg); err != nil {
@@ -2069,7 +2079,7 @@ func (svc *service) publishStart(ctx context.Context, t task.Task, propletID str
 
 	topic := svc.baseTopic + "/control/manager/start"
 
-	return svc.pubsub.Publish(ctx, topic, payload)
+	return svc.publishControl(ctx, topic, jsonrpc.MethodTaskStart, t.ID, payload)
 }
 
 func (svc *service) publishStop(ctx context.Context, t task.Task, propletID string) error {
@@ -2080,7 +2090,7 @@ func (svc *service) publishStop(ctx context.Context, t task.Task, propletID stri
 	}
 	topic := svc.baseTopic + "/control/manager/stop"
 
-	return svc.pubsub.Publish(ctx, topic, stopPayload)
+	return svc.publishControl(ctx, topic, jsonrpc.MethodTaskStop, t.ID, stopPayload)
 }
 
 func (svc *service) invocationProplet(ctx context.Context, t task.Task) (string, error) {
@@ -2349,7 +2359,7 @@ func (svc *service) signalStopToActiveTasks(ctx context.Context) error {
 			"id":         t.ID,
 			"proplet_id": propletID,
 		}
-		if err := svc.pubsub.Publish(ctx, stopTopic, stopPayload); err != nil {
+		if err := svc.publishControl(ctx, stopTopic, jsonrpc.MethodTaskStop, t.ID, stopPayload); err != nil {
 			svc.logger.Warn("failed to send stop command for active task", slog.String("task_id", t.ID), slog.Any("error", err))
 
 			continue

--- a/pkg/jsonrpc/errors.go
+++ b/pkg/jsonrpc/errors.go
@@ -1,0 +1,93 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonrpc
+
+import (
+	"errors"
+	"fmt"
+
+	pkgerrors "github.com/absmach/propeller/pkg/errors"
+)
+
+const (
+	CodeParseError     = -32700
+	CodeInvalidRequest = -32600
+	CodeMethodNotFound = -32601
+	CodeInvalidParams  = -32602
+	CodeInternalError  = -32603
+
+	CodeNotFound    = -32001
+	CodeConflict    = -32002
+	CodeValidation  = -32003
+	CodeTimeout     = -32004
+	CodeUnavailable = -32005
+)
+
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+func NewError(code int, message string, data any) *Error {
+	return &Error{
+		Code:    code,
+		Message: message,
+		Data:    data,
+	}
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("jsonrpc error %d: %s", e.Code, e.Message)
+}
+
+func ParseError(data any) *Error {
+	return NewError(CodeParseError, "Parse error", data)
+}
+
+func InvalidRequest(data any) *Error {
+	return NewError(CodeInvalidRequest, "Invalid Request", data)
+}
+
+func MethodNotFound(method string) *Error {
+	return NewError(CodeMethodNotFound, "Method not found", method)
+}
+
+func InvalidParams(data any) *Error {
+	return NewError(CodeInvalidParams, "Invalid params", data)
+}
+
+func InternalError(data any) *Error {
+	return NewError(CodeInternalError, "Internal error", data)
+}
+
+func ErrorFrom(err error) *Error {
+	if err == nil {
+		return nil
+	}
+
+	var rpcErr *Error
+	if errors.As(err, &rpcErr) {
+		return rpcErr
+	}
+
+	switch {
+	case errors.Is(err, pkgerrors.ErrNotFound):
+		return NewError(CodeNotFound, err.Error(), nil)
+	case errors.Is(err, pkgerrors.ErrConflict), errors.Is(err, pkgerrors.ErrEntityExists):
+		return NewError(CodeConflict, err.Error(), nil)
+	case errors.Is(err, pkgerrors.ErrInvalidParams), errors.Is(err, pkgerrors.ErrInvalidData):
+		return NewError(CodeInvalidParams, err.Error(), nil)
+	case errors.Is(err, pkgerrors.ErrInvalidValue),
+		errors.Is(err, pkgerrors.ErrMissingValue),
+		errors.Is(err, pkgerrors.ErrEmptyKey):
+		return NewError(CodeValidation, err.Error(), nil)
+	case errors.Is(err, pkgerrors.ErrInvalidMethod):
+		return NewError(CodeMethodNotFound, err.Error(), nil)
+	case errors.Is(err, pkgerrors.ErrTimeout):
+		return NewError(CodeTimeout, err.Error(), nil)
+	default:
+		return NewError(CodeInternalError, err.Error(), nil)
+	}
+}

--- a/pkg/jsonrpc/errors_test.go
+++ b/pkg/jsonrpc/errors_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonrpc_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	pkgerrors "github.com/absmach/propeller/pkg/errors"
+	"github.com/absmach/propeller/pkg/jsonrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorFrom(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc string
+		err  error
+		code int
+	}{
+		{
+			desc: "not found maps to the not found code",
+			err:  pkgerrors.ErrNotFound,
+			code: jsonrpc.CodeNotFound,
+		},
+		{
+			desc: "wrapped not found maps to the not found code",
+			err:  fmt.Errorf("looking up task: %w", pkgerrors.ErrNotFound),
+			code: jsonrpc.CodeNotFound,
+		},
+		{
+			desc: "conflict maps to the conflict code",
+			err:  pkgerrors.ErrConflict,
+			code: jsonrpc.CodeConflict,
+		},
+		{
+			desc: "entity exists maps to the conflict code",
+			err:  pkgerrors.ErrEntityExists,
+			code: jsonrpc.CodeConflict,
+		},
+		{
+			desc: "invalid data maps to invalid params",
+			err:  pkgerrors.ErrInvalidData,
+			code: jsonrpc.CodeInvalidParams,
+		},
+		{
+			desc: "invalid value maps to validation",
+			err:  pkgerrors.ErrInvalidValue,
+			code: jsonrpc.CodeValidation,
+		},
+		{
+			desc: "missing value maps to validation",
+			err:  pkgerrors.ErrMissingValue,
+			code: jsonrpc.CodeValidation,
+		},
+		{
+			desc: "invalid method maps to method not found",
+			err:  pkgerrors.ErrInvalidMethod,
+			code: jsonrpc.CodeMethodNotFound,
+		},
+		{
+			desc: "timeout maps to the timeout code",
+			err:  pkgerrors.ErrTimeout,
+			code: jsonrpc.CodeTimeout,
+		},
+		{
+			desc: "unknown errors map to internal error",
+			err:  errors.New("boom"),
+			code: jsonrpc.CodeInternalError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			rpcErr := jsonrpc.ErrorFrom(tc.err)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, tc.code, rpcErr.Code)
+			assert.Equal(t, tc.err.Error(), rpcErr.Message)
+		})
+	}
+}
+
+func TestErrorFromNil(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, jsonrpc.ErrorFrom(nil))
+}
+
+func TestErrorFromPreservesRPCError(t *testing.T) {
+	t.Parallel()
+
+	original := jsonrpc.InvalidParams("inputs must be an array")
+	wrapped := fmt.Errorf("dispatching: %w", original)
+
+	assert.Same(t, original, jsonrpc.ErrorFrom(wrapped))
+}
+
+func TestErrorImplementsError(t *testing.T) {
+	t.Parallel()
+
+	err := jsonrpc.NewError(jsonrpc.CodeInternalError, "boom", nil)
+	assert.Equal(t, "jsonrpc error -32603: boom", err.Error())
+}
+
+func TestConstructorCodes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc string
+		err  *jsonrpc.Error
+		code int
+	}{
+		{desc: "parse error", err: jsonrpc.ParseError(nil), code: jsonrpc.CodeParseError},
+		{desc: "invalid request", err: jsonrpc.InvalidRequest(nil), code: jsonrpc.CodeInvalidRequest},
+		{desc: "method not found", err: jsonrpc.MethodNotFound("m"), code: jsonrpc.CodeMethodNotFound},
+		{desc: "invalid params", err: jsonrpc.InvalidParams(nil), code: jsonrpc.CodeInvalidParams},
+		{desc: "internal error", err: jsonrpc.InternalError(nil), code: jsonrpc.CodeInternalError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.code, tc.err.Code)
+			assert.NotEmpty(t, tc.err.Message)
+		})
+	}
+}

--- a/pkg/jsonrpc/jsonrpc.go
+++ b/pkg/jsonrpc/jsonrpc.go
@@ -1,0 +1,233 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonrpc
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+)
+
+const Version = "2.0"
+
+var (
+	ErrInvalidVersion = errors.New("jsonrpc version must be 2.0")
+	ErrMissingMethod  = errors.New("method is required")
+	ErrInvalidID      = errors.New("id must be a string, a number, or null")
+	ErrInvalidParams  = errors.New("params must be an object or an array")
+)
+
+type ID struct {
+	raw json.RawMessage
+}
+
+func StringID(s string) *ID {
+	raw, err := json.Marshal(s)
+	if err != nil {
+		return &ID{}
+	}
+
+	return &ID{raw: raw}
+}
+
+func NumberID(n int64) *ID {
+	raw, err := json.Marshal(n)
+	if err != nil {
+		return &ID{}
+	}
+
+	return &ID{raw: raw}
+}
+
+func NullID() *ID {
+	return &ID{raw: json.RawMessage("null")}
+}
+
+func (id *ID) MarshalJSON() ([]byte, error) {
+	if id == nil || len(id.raw) == 0 {
+		return []byte("null"), nil
+	}
+
+	return id.raw, nil
+}
+
+func (id *ID) UnmarshalJSON(data []byte) error {
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	switch v.(type) {
+	case string, float64, nil:
+		id.raw = append(json.RawMessage(nil), bytes.TrimSpace(data)...)
+
+		return nil
+	default:
+		return ErrInvalidID
+	}
+}
+
+func (id *ID) String() string {
+	if id.IsNull() {
+		return "null"
+	}
+
+	var s string
+	if err := json.Unmarshal(id.raw, &s); err == nil {
+		return s
+	}
+
+	return string(id.raw)
+}
+
+func (id *ID) IsNull() bool {
+	return id == nil || len(id.raw) == 0 || bytes.Equal(bytes.TrimSpace(id.raw), []byte("null"))
+}
+
+func decodeID(data []byte, target **ID) error {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+
+	raw, ok := probe["id"]
+	if !ok {
+		*target = nil
+
+		return nil
+	}
+
+	id := &ID{}
+	if err := id.UnmarshalJSON(raw); err != nil {
+		return err
+	}
+	*target = id
+
+	return nil
+}
+
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	ID      *ID             `json:"id,omitempty"`
+}
+
+func NewRequest(id *ID, method string, params any) (*Request, error) {
+	req := &Request{
+		JSONRPC: Version,
+		Method:  method,
+		ID:      id,
+	}
+	if params == nil {
+		return req, nil
+	}
+
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+	req.Params = raw
+
+	return req, nil
+}
+
+func (r *Request) UnmarshalJSON(data []byte) error {
+	type alias Request
+	aux := (*alias)(r)
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	return decodeID(data, &r.ID)
+}
+
+func (r *Request) IsNotification() bool {
+	return r.ID == nil
+}
+
+func (r *Request) Validate() error {
+	if r.JSONRPC != Version {
+		return ErrInvalidVersion
+	}
+	if r.Method == "" {
+		return ErrMissingMethod
+	}
+	if len(r.Params) == 0 {
+		return nil
+	}
+
+	trimmed := bytes.TrimSpace(r.Params)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	if trimmed[0] != '{' && trimmed[0] != '[' {
+		return ErrInvalidParams
+	}
+
+	return nil
+}
+
+func (r *Request) UnmarshalParams(v any) error {
+	trimmed := bytes.TrimSpace(r.Params)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+
+	return json.Unmarshal(trimmed, v)
+}
+
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *Error          `json:"error,omitempty"`
+	ID      *ID             `json:"id"`
+}
+
+func NewResponse(id *ID, result any) (*Response, error) {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Response{
+		JSONRPC: Version,
+		Result:  raw,
+		ID:      id,
+	}, nil
+}
+
+func NewErrorResponse(id *ID, rpcErr *Error) *Response {
+	if id == nil {
+		id = NullID()
+	}
+
+	return &Response{
+		JSONRPC: Version,
+		Error:   rpcErr,
+		ID:      id,
+	}
+}
+
+func (r *Response) UnmarshalJSON(data []byte) error {
+	type alias Response
+	aux := (*alias)(r)
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	return decodeID(data, &r.ID)
+}
+
+func (r *Response) UnmarshalResult(v any) error {
+	if r.Error != nil {
+		return r.Error
+	}
+	trimmed := bytes.TrimSpace(r.Result)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+
+	return json.Unmarshal(trimmed, v)
+}

--- a/pkg/jsonrpc/jsonrpc_test.go
+++ b/pkg/jsonrpc/jsonrpc_test.go
@@ -1,0 +1,262 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonrpc_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/absmach/propeller/pkg/jsonrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc           string
+		payload        string
+		method         string
+		id             string
+		isNotification bool
+		decodeErr      bool
+		validateErr    error
+	}{
+		{
+			desc:    "request with object params and string id",
+			payload: `{"jsonrpc":"2.0","method":"task.start","params":{"id":"abc"},"id":"req-1"}`,
+			method:  "task.start",
+			id:      "req-1",
+		},
+		{
+			desc:    "request with array params and numeric id",
+			payload: `{"jsonrpc":"2.0","method":"task.stop","params":["abc"],"id":7}`,
+			method:  "task.stop",
+			id:      "7",
+		},
+		{
+			desc:           "notification has no id",
+			payload:        `{"jsonrpc":"2.0","method":"proplet.alive"}`,
+			method:         "proplet.alive",
+			isNotification: true,
+		},
+		{
+			desc:    "null id is not a notification",
+			payload: `{"jsonrpc":"2.0","method":"task.list","id":null}`,
+			method:  "task.list",
+			id:      "null",
+		},
+		{
+			desc:        "wrong version is rejected",
+			payload:     `{"jsonrpc":"1.0","method":"task.list","id":1}`,
+			method:      "task.list",
+			id:          "1",
+			validateErr: jsonrpc.ErrInvalidVersion,
+		},
+		{
+			desc:        "missing method is rejected",
+			payload:     `{"jsonrpc":"2.0","id":1}`,
+			id:          "1",
+			validateErr: jsonrpc.ErrMissingMethod,
+		},
+		{
+			desc:        "scalar params are rejected",
+			payload:     `{"jsonrpc":"2.0","method":"task.list","params":5,"id":1}`,
+			method:      "task.list",
+			id:          "1",
+			validateErr: jsonrpc.ErrInvalidParams,
+		},
+		{
+			desc:      "boolean id is rejected",
+			payload:   `{"jsonrpc":"2.0","method":"task.list","id":true}`,
+			decodeErr: true,
+		},
+		{
+			desc:      "object id is rejected",
+			payload:   `{"jsonrpc":"2.0","method":"task.list","id":{"a":1}}`,
+			decodeErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var req jsonrpc.Request
+			err := json.Unmarshal([]byte(tc.payload), &req)
+			if tc.decodeErr {
+				require.Error(t, err)
+
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.method, req.Method)
+			assert.Equal(t, tc.isNotification, req.IsNotification())
+			if !tc.isNotification {
+				require.NotNil(t, req.ID)
+				assert.Equal(t, tc.id, req.ID.String())
+			}
+
+			err = req.Validate()
+			if tc.validateErr != nil {
+				assert.ErrorIs(t, err, tc.validateErr)
+
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestRequestUnmarshalParams(t *testing.T) {
+	t.Parallel()
+
+	type params struct {
+		ID     string   `json:"id"`
+		Inputs []string `json:"inputs"`
+	}
+
+	cases := []struct {
+		desc    string
+		payload string
+		want    params
+	}{
+		{
+			desc:    "object params are decoded",
+			payload: `{"jsonrpc":"2.0","method":"m","params":{"id":"a","inputs":["x"]},"id":1}`,
+			want:    params{ID: "a", Inputs: []string{"x"}},
+		},
+		{
+			desc:    "absent params leave the target untouched",
+			payload: `{"jsonrpc":"2.0","method":"m","id":1}`,
+			want:    params{},
+		},
+		{
+			desc:    "null params leave the target untouched",
+			payload: `{"jsonrpc":"2.0","method":"m","params":null,"id":1}`,
+			want:    params{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var req jsonrpc.Request
+			require.NoError(t, json.Unmarshal([]byte(tc.payload), &req))
+
+			var got params
+			require.NoError(t, req.UnmarshalParams(&got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNewRequest(t *testing.T) {
+	t.Parallel()
+
+	req, err := jsonrpc.NewRequest(jsonrpc.StringID("req-1"), "task.start", map[string]string{"id": "abc"})
+	require.NoError(t, err)
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"jsonrpc":"2.0","method":"task.start","params":{"id":"abc"},"id":"req-1"}`, string(data))
+}
+
+func TestNewRequestNotificationOmitsID(t *testing.T) {
+	t.Parallel()
+
+	req, err := jsonrpc.NewRequest(nil, "proplet.alive", nil)
+	require.NoError(t, err)
+	assert.True(t, req.IsNotification())
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"jsonrpc":"2.0","method":"proplet.alive"}`, string(data))
+}
+
+func TestResponseRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc     string
+		response *jsonrpc.Response
+		want     string
+	}{
+		{
+			desc: "success response carries a result",
+			response: func() *jsonrpc.Response {
+				resp, err := jsonrpc.NewResponse(jsonrpc.StringID("req-1"), map[string]bool{"started": true})
+				require.NoError(t, err)
+
+				return resp
+			}(),
+			want: `{"jsonrpc":"2.0","result":{"started":true},"id":"req-1"}`,
+		},
+		{
+			desc:     "error response carries an error",
+			response: jsonrpc.NewErrorResponse(jsonrpc.NumberID(3), jsonrpc.MethodNotFound("nope")),
+			want:     `{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":"nope"},"id":3}`,
+		},
+		{
+			desc:     "error response without an id serialises a null id",
+			response: jsonrpc.NewErrorResponse(nil, jsonrpc.ParseError(nil)),
+			want:     `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := json.Marshal(tc.response)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(data))
+		})
+	}
+}
+
+func TestResponseUnmarshalResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("result is decoded", func(t *testing.T) {
+		t.Parallel()
+
+		var resp jsonrpc.Response
+		require.NoError(t, json.Unmarshal([]byte(`{"jsonrpc":"2.0","result":{"started":true},"id":1}`), &resp))
+
+		var out struct {
+			Started bool `json:"started"`
+		}
+		require.NoError(t, resp.UnmarshalResult(&out))
+		assert.True(t, out.Started)
+	})
+
+	t.Run("error responses surface the error", func(t *testing.T) {
+		t.Parallel()
+
+		var resp jsonrpc.Response
+		require.NoError(t, json.Unmarshal([]byte(`{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":1}`), &resp))
+
+		var out map[string]any
+		err := resp.UnmarshalResult(&out)
+		require.Error(t, err)
+
+		var rpcErr *jsonrpc.Error
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Equal(t, jsonrpc.CodeNotFound, rpcErr.Code)
+	})
+}
+
+func TestIDHelpers(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "abc", jsonrpc.StringID("abc").String())
+	assert.Equal(t, "42", jsonrpc.NumberID(42).String())
+	assert.True(t, jsonrpc.NullID().IsNull())
+	assert.False(t, jsonrpc.StringID("abc").IsNull())
+}

--- a/pkg/jsonrpc/methods.go
+++ b/pkg/jsonrpc/methods.go
@@ -1,0 +1,77 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonrpc
+
+import "github.com/absmach/propeller/pkg/task"
+
+const (
+	MethodTaskCreate  = "task.create"
+	MethodTaskGet     = "task.get"
+	MethodTaskList    = "task.list"
+	MethodTaskUpdate  = "task.update"
+	MethodTaskDelete  = "task.delete"
+	MethodTaskStart   = "task.start"
+	MethodTaskStop    = "task.stop"
+	MethodTaskResults = "task.results"
+	MethodTaskMetrics = "task.metrics"
+
+	MethodPropletGet          = "proplet.get"
+	MethodPropletList         = "proplet.list"
+	MethodPropletDelete       = "proplet.delete"
+	MethodPropletSDF          = "proplet.sdf"
+	MethodPropletMetrics      = "proplet.metrics"
+	MethodPropletAliveHistory = "proplet.aliveHistory"
+
+	MethodJobCreate = "job.create"
+	MethodJobGet    = "job.get"
+	MethodJobList   = "job.list"
+	MethodJobStart  = "job.start"
+	MethodJobStop   = "job.stop"
+
+	MethodWorkflowCreate = "workflow.create"
+)
+
+type IDParams struct {
+	ID string `json:"id"`
+}
+
+type ListParams struct {
+	Offset   uint64         `json:"offset,omitempty"`
+	Limit    uint64         `json:"limit,omitempty"`
+	Status   string         `json:"status,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+type EntityListParams struct {
+	ID     string `json:"id"`
+	Offset uint64 `json:"offset,omitempty"`
+	Limit  uint64 `json:"limit,omitempty"`
+}
+
+type JobParams struct {
+	Name          string      `json:"name"`
+	Tasks         []task.Task `json:"tasks"`
+	ExecutionMode string      `json:"execution_mode,omitempty"`
+}
+
+type WorkflowParams struct {
+	Tasks []task.Task `json:"tasks"`
+}
+
+type JobResult struct {
+	JobID string      `json:"job_id"`
+	Tasks []task.Task `json:"tasks"`
+}
+
+type ResultsResult struct {
+	Results any `json:"results"`
+}
+
+type Ack struct {
+	OK bool `json:"ok"`
+}
+
+func NewAck() Ack {
+	return Ack{OK: true}
+}

--- a/pkg/jsonrpc/methods_test.go
+++ b/pkg/jsonrpc/methods_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonrpc_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/absmach/propeller/pkg/jsonrpc"
+	"github.com/absmach/propeller/pkg/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMethodNamesAreNamespaced(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc   string
+		method string
+		want   string
+	}{
+		{desc: "task create", method: jsonrpc.MethodTaskCreate, want: "task.create"},
+		{desc: "task start", method: jsonrpc.MethodTaskStart, want: "task.start"},
+		{desc: "task stop", method: jsonrpc.MethodTaskStop, want: "task.stop"},
+		{desc: "task results", method: jsonrpc.MethodTaskResults, want: "task.results"},
+		{desc: "proplet list", method: jsonrpc.MethodPropletList, want: "proplet.list"},
+		{desc: "proplet alive history", method: jsonrpc.MethodPropletAliveHistory, want: "proplet.aliveHistory"},
+		{desc: "job create", method: jsonrpc.MethodJobCreate, want: "job.create"},
+		{desc: "workflow create", method: jsonrpc.MethodWorkflowCreate, want: "workflow.create"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, tc.method)
+		})
+	}
+}
+
+func TestParamShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc   string
+		params any
+		want   string
+	}{
+		{
+			desc:   "id params",
+			params: jsonrpc.IDParams{ID: "abc"},
+			want:   `{"id":"abc"}`,
+		},
+		{
+			desc:   "list params omit empty fields",
+			params: jsonrpc.ListParams{Limit: 10},
+			want:   `{"limit":10}`,
+		},
+		{
+			desc:   "list params carry a status filter",
+			params: jsonrpc.ListParams{Offset: 5, Limit: 10, Status: "alive"},
+			want:   `{"offset":5,"limit":10,"status":"alive"}`,
+		},
+		{
+			desc:   "entity list params always carry an id",
+			params: jsonrpc.EntityListParams{ID: "abc"},
+			want:   `{"id":"abc"}`,
+		},
+		{
+			desc:   "ack is a stable shape",
+			params: jsonrpc.NewAck(),
+			want:   `{"ok":true}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := json.Marshal(tc.params)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(data))
+		})
+	}
+}
+
+func TestTaskCarryingParamsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc   string
+		params any
+		decode func(t *testing.T, raw []byte) []task.Task
+	}{
+		{
+			desc:   "workflow params",
+			params: jsonrpc.WorkflowParams{Tasks: []task.Task{{Name: "a"}, {Name: "b"}}},
+			decode: func(t *testing.T, raw []byte) []task.Task {
+				t.Helper()
+				var out jsonrpc.WorkflowParams
+				require.NoError(t, json.Unmarshal(raw, &out))
+
+				return out.Tasks
+			},
+		},
+		{
+			desc:   "job params",
+			params: jsonrpc.JobParams{Name: "j", Tasks: []task.Task{{Name: "a"}, {Name: "b"}}, ExecutionMode: "parallel"},
+			decode: func(t *testing.T, raw []byte) []task.Task {
+				t.Helper()
+				var out jsonrpc.JobParams
+				require.NoError(t, json.Unmarshal(raw, &out))
+				assert.Equal(t, "j", out.Name)
+				assert.Equal(t, "parallel", out.ExecutionMode)
+
+				return out.Tasks
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := json.Marshal(tc.params)
+			require.NoError(t, err)
+
+			var envelope map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(raw, &envelope))
+			require.Contains(t, envelope, "tasks")
+
+			tasks := tc.decode(t, raw)
+			require.Len(t, tasks, 2)
+			assert.Equal(t, "a", tasks[0].Name)
+			assert.Equal(t, "b", tasks[1].Name)
+		})
+	}
+}
+
+func TestParamsRoundTripThroughRequest(t *testing.T) {
+	t.Parallel()
+
+	req, err := jsonrpc.NewRequest(jsonrpc.NumberID(1), jsonrpc.MethodTaskMetrics, jsonrpc.EntityListParams{
+		ID:     "abc",
+		Offset: 2,
+		Limit:  5,
+	})
+	require.NoError(t, err)
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var decoded jsonrpc.Request
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, jsonrpc.MethodTaskMetrics, decoded.Method)
+
+	var params jsonrpc.EntityListParams
+	require.NoError(t, decoded.UnmarshalParams(&params))
+	assert.Equal(t, jsonrpc.EntityListParams{ID: "abc", Offset: 2, Limit: 5}, params)
+}

--- a/pkg/jsonrpc/server.go
+++ b/pkg/jsonrpc/server.go
@@ -1,0 +1,142 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonrpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	"sync"
+)
+
+type Handler func(ctx context.Context, params json.RawMessage) (any, error)
+
+type Server struct {
+	mu      sync.RWMutex
+	methods map[string]Handler
+}
+
+func NewServer() *Server {
+	return &Server{methods: make(map[string]Handler)}
+}
+
+func (s *Server) Register(method string, handler Handler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.methods[method] = handler
+}
+
+func (s *Server) Methods() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	methods := make([]string, 0, len(s.methods))
+	for method := range s.methods {
+		methods = append(methods, method)
+	}
+	sort.Strings(methods)
+
+	return methods
+}
+
+func (s *Server) Handle(ctx context.Context, data []byte) []byte {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || !json.Valid(trimmed) {
+		return marshalResponse(NewErrorResponse(nil, ParseError(nil)))
+	}
+
+	if trimmed[0] != '[' {
+		return marshalResponse(s.handleOne(ctx, trimmed))
+	}
+
+	var batch []json.RawMessage
+	if err := json.Unmarshal(trimmed, &batch); err != nil {
+		return marshalResponse(NewErrorResponse(nil, InvalidRequest(err.Error())))
+	}
+	if len(batch) == 0 {
+		return marshalResponse(NewErrorResponse(nil, InvalidRequest("batch must not be empty")))
+	}
+
+	responses := make([]*Response, 0, len(batch))
+	for _, raw := range batch {
+		if resp := s.handleOne(ctx, raw); resp != nil {
+			responses = append(responses, resp)
+		}
+	}
+	if len(responses) == 0 {
+		return nil
+	}
+
+	out, err := json.Marshal(responses)
+	if err != nil {
+		return marshalResponse(NewErrorResponse(nil, InternalError(err.Error())))
+	}
+
+	return out
+}
+
+func (s *Server) handleOne(ctx context.Context, raw []byte) *Response {
+	var req Request
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return NewErrorResponse(nil, InvalidRequest(decodeMessage(raw, err)))
+	}
+	if err := req.Validate(); err != nil {
+		return NewErrorResponse(req.ID, InvalidRequest(err.Error()))
+	}
+
+	s.mu.RLock()
+	handler, ok := s.methods[req.Method]
+	s.mu.RUnlock()
+
+	if !ok {
+		if req.IsNotification() {
+			return nil
+		}
+
+		return NewErrorResponse(req.ID, MethodNotFound(req.Method))
+	}
+
+	result, err := handler(ctx, req.Params)
+	if req.IsNotification() {
+		return nil
+	}
+	if err != nil {
+		return NewErrorResponse(req.ID, ErrorFrom(err))
+	}
+
+	resp, err := NewResponse(req.ID, result)
+	if err != nil {
+		return NewErrorResponse(req.ID, InternalError(err.Error()))
+	}
+
+	return resp
+}
+
+func decodeMessage(raw []byte, err error) string {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return "request must be a JSON object"
+	}
+	if errors.Is(err, ErrInvalidID) {
+		return ErrInvalidID.Error()
+	}
+
+	return "request could not be decoded"
+}
+
+func marshalResponse(resp *Response) []byte {
+	if resp == nil {
+		return nil
+	}
+
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return []byte(`{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error"},"id":null}`)
+	}
+
+	return out
+}

--- a/pkg/jsonrpc/server_test.go
+++ b/pkg/jsonrpc/server_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonrpc_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+
+	pkgerrors "github.com/absmach/propeller/pkg/errors"
+	"github.com/absmach/propeller/pkg/jsonrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testServer() *jsonrpc.Server {
+	srv := jsonrpc.NewServer()
+	srv.Register("echo", func(_ context.Context, params json.RawMessage) (any, error) {
+		var in struct {
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(params, &in); err != nil {
+			return nil, jsonrpc.InvalidParams(err.Error())
+		}
+
+		return map[string]string{"value": in.Value}, nil
+	})
+	srv.Register("boom", func(_ context.Context, _ json.RawMessage) (any, error) {
+		return nil, pkgerrors.ErrNotFound
+	})
+	srv.Register("noop", func(_ context.Context, _ json.RawMessage) (any, error) {
+		var empty any
+
+		return empty, nil
+	})
+
+	return srv
+}
+
+func TestServerHandle(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc     string
+		payload  string
+		want     string
+		wantNone bool
+	}{
+		{
+			desc:    "successful call returns a result",
+			payload: `{"jsonrpc":"2.0","method":"echo","params":{"value":"hi"},"id":1}`,
+			want:    `{"jsonrpc":"2.0","result":{"value":"hi"},"id":1}`,
+		},
+		{
+			desc:    "unknown method returns method not found",
+			payload: `{"jsonrpc":"2.0","method":"missing","id":1}`,
+			want:    `{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":"missing"},"id":1}`,
+		},
+		{
+			desc:    "handler error is mapped to a server code",
+			payload: `{"jsonrpc":"2.0","method":"boom","id":"x"}`,
+			want:    `{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":"x"}`,
+		},
+		{
+			desc:    "malformed json returns a parse error with a null id",
+			payload: `{"jsonrpc":"2.0",`,
+			want:    `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}`,
+		},
+		{
+			desc:    "wrong version returns invalid request",
+			payload: `{"jsonrpc":"1.0","method":"echo","id":1}`,
+			want:    `{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"jsonrpc version must be 2.0"},"id":1}`,
+		},
+		{
+			desc:     "notification produces no response",
+			payload:  `{"jsonrpc":"2.0","method":"echo","params":{"value":"hi"}}`,
+			wantNone: true,
+		},
+		{
+			desc:     "notification to an unknown method produces no response",
+			payload:  `{"jsonrpc":"2.0","method":"missing"}`,
+			wantNone: true,
+		},
+		{
+			desc:    "a success response always carries a result member",
+			payload: `{"jsonrpc":"2.0","method":"noop","id":9}`,
+			want:    `{"jsonrpc":"2.0","result":null,"id":9}`,
+		},
+		{
+			desc:    "an invalid id type is reported without leaking internals",
+			payload: `{"jsonrpc":"2.0","method":"echo","id":true}`,
+			want:    `{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"id must be a string, a number, or null"},"id":null}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			out := testServer().Handle(context.Background(), []byte(tc.payload))
+			if tc.wantNone {
+				assert.Nil(t, out)
+
+				return
+			}
+			require.NotNil(t, out)
+			assert.JSONEq(t, tc.want, string(out))
+		})
+	}
+}
+
+func TestServerHandleBatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc     string
+		payload  string
+		want     string
+		wantNone bool
+	}{
+		{
+			desc:    "batch returns one response per request",
+			payload: `[{"jsonrpc":"2.0","method":"echo","params":{"value":"a"},"id":1},{"jsonrpc":"2.0","method":"echo","params":{"value":"b"},"id":2}]`,
+			want:    `[{"jsonrpc":"2.0","result":{"value":"a"},"id":1},{"jsonrpc":"2.0","result":{"value":"b"},"id":2}]`,
+		},
+		{
+			desc:    "notifications are omitted from a mixed batch",
+			payload: `[{"jsonrpc":"2.0","method":"echo","params":{"value":"a"}},{"jsonrpc":"2.0","method":"echo","params":{"value":"b"},"id":2}]`,
+			want:    `[{"jsonrpc":"2.0","result":{"value":"b"},"id":2}]`,
+		},
+		{
+			desc:     "a batch of only notifications produces no response",
+			payload:  `[{"jsonrpc":"2.0","method":"echo","params":{"value":"a"}},{"jsonrpc":"2.0","method":"noop"}]`,
+			wantNone: true,
+		},
+		{
+			desc:    "an empty batch is an invalid request",
+			payload: `[]`,
+			want:    `{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"batch must not be empty"},"id":null}`,
+		},
+		{
+			desc:    "invalid members are reported individually",
+			payload: `[1,{"jsonrpc":"2.0","method":"echo","params":{"value":"a"},"id":2}]`,
+			want:    `[{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"request must be a JSON object"},"id":null},{"jsonrpc":"2.0","result":{"value":"a"},"id":2}]`,
+		},
+		{
+			desc:    "errors and results coexist in one batch",
+			payload: `[{"jsonrpc":"2.0","method":"boom","id":1},{"jsonrpc":"2.0","method":"echo","params":{"value":"a"},"id":2}]`,
+			want:    `[{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":1},{"jsonrpc":"2.0","result":{"value":"a"},"id":2}]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			out := testServer().Handle(context.Background(), []byte(tc.payload))
+			if tc.wantNone {
+				assert.Nil(t, out)
+
+				return
+			}
+			require.NotNil(t, out)
+			assert.JSONEq(t, tc.want, string(out))
+		})
+	}
+}
+
+func TestServerNotificationStillInvokesHandler(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	srv := jsonrpc.NewServer()
+	srv.Register("count", func(_ context.Context, _ json.RawMessage) (any, error) {
+		calls.Add(1)
+
+		var empty any
+
+		return empty, nil
+	})
+
+	out := srv.Handle(context.Background(), []byte(`{"jsonrpc":"2.0","method":"count"}`))
+	assert.Nil(t, out)
+	assert.Equal(t, int64(1), calls.Load())
+}
+
+func TestServerPassesContext(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey string
+	key := ctxKey("tenant")
+
+	srv := jsonrpc.NewServer()
+	srv.Register("tenant", func(ctx context.Context, _ json.RawMessage) (any, error) {
+		return ctx.Value(key), nil
+	})
+
+	ctx := context.WithValue(context.Background(), key, "acme")
+	out := srv.Handle(ctx, []byte(`{"jsonrpc":"2.0","method":"tenant","id":1}`))
+	assert.JSONEq(t, `{"jsonrpc":"2.0","result":"acme","id":1}`, string(out))
+}
+
+func TestServerMethods(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"boom", "echo", "noop"}, testServer().Methods())
+}

--- a/pkg/sdk/rpc.go
+++ b/pkg/sdk/rpc.go
@@ -1,0 +1,76 @@
+package sdk
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/absmach/propeller/pkg/jsonrpc"
+)
+
+var rpcCounter atomic.Int64
+
+func (sdk *propSDK) Call(method string, params any) (json.RawMessage, error) {
+	req, err := jsonrpc.NewRequest(jsonrpc.NumberID(rpcCounter.Add(1)), method, params)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := sdk.processRequest(http.MethodPost, sdk.managerURL+"/rpc", data, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp jsonrpc.Response
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return resp.Result, nil
+}
+
+func (sdk *propSDK) CallBatch(calls []RPCCall) ([]jsonrpc.Response, error) {
+	if len(calls) == 0 {
+		return nil, errors.New("batch must not be empty")
+	}
+
+	requests := make([]*jsonrpc.Request, 0, len(calls))
+	for _, call := range calls {
+		req, err := jsonrpc.NewRequest(jsonrpc.NumberID(rpcCounter.Add(1)), call.Method, call.Params)
+		if err != nil {
+			return nil, err
+		}
+		requests = append(requests, req)
+	}
+
+	data, err := json.Marshal(requests)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := sdk.processRequest(http.MethodPost, sdk.managerURL+"/rpc", data, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	var responses []jsonrpc.Response
+	if err := json.Unmarshal(body, &responses); err != nil {
+		return nil, err
+	}
+
+	return responses, nil
+}
+
+type RPCCall struct {
+	Method string
+	Params any
+}

--- a/pkg/sdk/rpc_test.go
+++ b/pkg/sdk/rpc_test.go
@@ -1,0 +1,171 @@
+package sdk_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/absmach/propeller/pkg/jsonrpc"
+	"github.com/absmach/propeller/pkg/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newRPCTestSDK(t *testing.T, handler http.HandlerFunc) sdk.SDK {
+	t.Helper()
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	return sdk.NewSDK(sdk.Config{ManagerURL: ts.URL})
+}
+
+func TestCall(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc     string
+		method   string
+		params   any
+		response string
+		want     string
+		wantErr  bool
+		errCode  int
+	}{
+		{
+			desc:     "a result is returned raw",
+			method:   jsonrpc.MethodPropletList,
+			response: `{"jsonrpc":"2.0","result":{"total":2},"id":1}`,
+			want:     `{"total":2}`,
+		},
+		{
+			desc:     "params are forwarded",
+			method:   jsonrpc.MethodTaskStart,
+			params:   map[string]string{"id": "abc"},
+			response: `{"jsonrpc":"2.0","result":{"ok":true},"id":1}`,
+			want:     `{"ok":true}`,
+		},
+		{
+			desc:     "an error response becomes an error",
+			method:   jsonrpc.MethodTaskGet,
+			params:   map[string]string{"id": "missing"},
+			response: `{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":1}`,
+			wantErr:  true,
+			errCode:  jsonrpc.CodeNotFound,
+		},
+		{
+			desc:     "an unknown method becomes an error",
+			method:   "task.explode",
+			response: `{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}`,
+			wantErr:  true,
+			errCode:  jsonrpc.CodeMethodNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var captured jsonrpc.Request
+			psdk := newRPCTestSDK(t, func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if !assert.NoError(t, err) {
+					return
+				}
+				assert.NoError(t, json.Unmarshal(body, &captured))
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.response))
+			})
+
+			result, err := psdk.Call(tc.method, tc.params)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				var rpcErr *jsonrpc.Error
+				require.ErrorAs(t, err, &rpcErr)
+				assert.Equal(t, tc.errCode, rpcErr.Code)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(result))
+			assert.Equal(t, jsonrpc.Version, captured.JSONRPC)
+			assert.Equal(t, tc.method, captured.Method)
+			require.NotNil(t, captured.ID)
+		})
+	}
+}
+
+func TestCallBatch(t *testing.T) {
+	t.Parallel()
+
+	psdk := newRPCTestSDK(t, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		var requests []jsonrpc.Request
+		assert.NoError(t, json.Unmarshal(body, &requests))
+		assert.Len(t, requests, 2)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(
+			`[{"jsonrpc":"2.0","result":{"ok":true},"id":1},` +
+				`{"jsonrpc":"2.0","error":{"code":-32001,"message":"not found"},"id":2}]`,
+		))
+	})
+
+	responses, err := psdk.CallBatch([]sdk.RPCCall{
+		{Method: jsonrpc.MethodTaskStart, Params: map[string]string{"id": "abc"}},
+		{Method: jsonrpc.MethodTaskGet, Params: map[string]string{"id": "missing"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, responses, 2)
+
+	assert.Nil(t, responses[0].Error)
+	require.NotNil(t, responses[1].Error)
+	assert.Equal(t, jsonrpc.CodeNotFound, responses[1].Error.Code)
+}
+
+func TestCallBatchRejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	psdk := newRPCTestSDK(t, func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("server should not be called for an empty batch")
+	})
+
+	_, err := psdk.CallBatch(nil)
+	require.Error(t, err)
+}
+
+func TestCallUsesUniqueIDs(t *testing.T) {
+	t.Parallel()
+
+	ids := make(chan string, 2)
+	psdk := newRPCTestSDK(t, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		var req jsonrpc.Request
+		assert.NoError(t, json.Unmarshal(body, &req))
+		ids <- req.ID.String()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","result":null,"id":1}`))
+	})
+
+	_, err := psdk.Call(jsonrpc.MethodPropletList, nil)
+	require.NoError(t, err)
+	_, err = psdk.Call(jsonrpc.MethodPropletList, nil)
+	require.NoError(t, err)
+
+	first, second := <-ids, <-ids
+	assert.NotEqual(t, first, second)
+}

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -3,10 +3,12 @@ package sdk
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 
+	"github.com/absmach/propeller/pkg/jsonrpc"
 	"github.com/absmach/propeller/pkg/proplet"
 	"github.com/absmach/propeller/pkg/sdf"
 	"github.com/absmach/propeller/pkg/task"
@@ -98,6 +100,22 @@ type SDK interface {
 	StopTask(id string) error
 
 	InvokeTask(id string, inputs []string, env map[string]string) (string, error)
+
+	// Call invokes a single JSON-RPC method on the manager and returns the
+	// raw result, leaving decoding to the caller.
+	//
+	// example:
+	//  result, _ := sdk.Call("task.start", map[string]string{"id": "b1d10738"})
+	//  fmt.Println(string(result))
+	Call(method string, params any) (json.RawMessage, error)
+
+	// CallBatch invokes several JSON-RPC methods in one request and returns
+	// one response per call.
+	//
+	// example:
+	//  responses, _ := sdk.CallBatch([]sdk.RPCCall{{Method: "proplet.list"}})
+	//  fmt.Println(len(responses))
+	CallBatch(calls []RPCCall) ([]jsonrpc.Response, error)
 
 	// CreateJob creates a new job with multiple tasks.
 	//

--- a/proplet/src/config.rs
+++ b/proplet/src/config.rs
@@ -75,6 +75,10 @@ pub struct PropletConfig {
     pub plugin_dir: Option<String>,
     pub metrics_port: u16,
     pub metrics_enabled: bool,
+    pub rpc_enabled: bool,
+    pub rpc_port: u16,
+    pub rpc_bind_address: String,
+    pub rpc_token: Option<String>,
     pub otel_url: Option<String>,
     pub trace_ratio: f64,
 }
@@ -122,6 +126,10 @@ impl Default for PropletConfig {
             plugin_dir: None,
             metrics_port: 9092,
             metrics_enabled: true,
+            rpc_enabled: false,
+            rpc_port: 9094,
+            rpc_bind_address: "127.0.0.1".to_string(),
+            rpc_token: None,
             otel_url: None,
             trace_ratio: 0.0,
         }
@@ -442,6 +450,32 @@ impl PropletConfig {
 
         if let Ok(val) = env::var("PROPLET_METRICS_ENABLED") {
             config.metrics_enabled = is_truthy(&val);
+        }
+
+        if let Ok(val) = env::var("PROPLET_RPC_ENABLED") {
+            config.rpc_enabled = is_truthy(&val);
+        }
+
+        if let Ok(val) = env::var("PROPLET_RPC_PORT") {
+            match val.parse::<u16>() {
+                Ok(0) | Err(_) => eprintln!(
+                    "warn: invalid PROPLET_RPC_PORT '{}', using default {}",
+                    val, config.rpc_port
+                ),
+                Ok(port) => config.rpc_port = port,
+            }
+        }
+
+        if let Ok(val) = env::var("PROPLET_RPC_BIND_ADDRESS") {
+            if !val.is_empty() {
+                config.rpc_bind_address = val;
+            }
+        }
+
+        if let Ok(val) = env::var("PROPLET_RPC_TOKEN") {
+            if !val.is_empty() {
+                config.rpc_token = Some(val);
+            }
         }
 
         if let Ok(val) = env::var("PROPLET_OTEL_URL") {

--- a/proplet/src/jsonrpc.rs
+++ b/proplet/src/jsonrpc.rs
@@ -1,0 +1,231 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const VERSION: &str = "2.0";
+
+pub const CODE_INVALID_REQUEST: i32 = -32600;
+pub const CODE_METHOD_NOT_FOUND: i32 = -32601;
+pub const CODE_INVALID_PARAMS: i32 = -32602;
+pub const CODE_INTERNAL_ERROR: i32 = -32603;
+
+pub const METHOD_TASK_START: &str = "task.start";
+pub const METHOD_TASK_STOP: &str = "task.stop";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Request {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Error {
+    pub code: i32,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl Error {
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    pub fn method_not_found(method: &str) -> Self {
+        Self {
+            code: CODE_METHOD_NOT_FOUND,
+            message: "Method not found".to_string(),
+            data: Some(Value::String(method.to_string())),
+        }
+    }
+
+    pub fn invalid_params(detail: impl Into<String>) -> Self {
+        Self {
+            code: CODE_INVALID_PARAMS,
+            message: "Invalid params".to_string(),
+            data: Some(Value::String(detail.into())),
+        }
+    }
+
+    pub fn internal(detail: impl Into<String>) -> Self {
+        Self {
+            code: CODE_INTERNAL_ERROR,
+            message: "Internal error".to_string(),
+            data: Some(Value::String(detail.into())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Response {
+    pub jsonrpc: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<Error>,
+    pub id: Value,
+}
+
+impl Response {
+    pub fn success(id: Option<Value>, result: Value) -> Self {
+        Self {
+            jsonrpc: VERSION.to_string(),
+            result: Some(result),
+            error: None,
+            id: id.unwrap_or(Value::Null),
+        }
+    }
+
+    pub fn failure(id: Option<Value>, error: Error) -> Self {
+        Self {
+            jsonrpc: VERSION.to_string(),
+            result: None,
+            error: Some(error),
+            id: id.unwrap_or(Value::Null),
+        }
+    }
+}
+
+pub struct Envelope {
+    pub payload: Value,
+    pub id: Option<Value>,
+    pub method: Option<String>,
+}
+
+pub fn unwrap(value: Value) -> Envelope {
+    let is_envelope = value
+        .get("jsonrpc")
+        .and_then(Value::as_str)
+        .is_some_and(|v| v == VERSION);
+
+    if !is_envelope {
+        return Envelope {
+            payload: value,
+            id: None,
+            method: None,
+        };
+    }
+
+    let id = value.get("id").cloned();
+    let method = value
+        .get("method")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    let payload = value
+        .get("params")
+        .or_else(|| value.get("result"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    Envelope {
+        payload,
+        id,
+        method,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_unwrap_passes_through_a_flat_payload() {
+        let flat = json!({"id": "task-1", "name": "fn"});
+        let envelope = unwrap(flat.clone());
+
+        assert_eq!(envelope.payload, flat);
+        assert!(envelope.id.is_none());
+        assert!(envelope.method.is_none());
+    }
+
+    #[test]
+    fn test_unwrap_extracts_params_from_an_envelope() {
+        let wrapped = json!({
+            "jsonrpc": "2.0",
+            "method": "task.start",
+            "params": {"id": "task-1", "name": "fn"},
+            "id": "task-1"
+        });
+        let envelope = unwrap(wrapped);
+
+        assert_eq!(envelope.payload, json!({"id": "task-1", "name": "fn"}));
+        assert_eq!(envelope.id, Some(json!("task-1")));
+        assert_eq!(envelope.method.as_deref(), Some(METHOD_TASK_START));
+    }
+
+    #[test]
+    fn test_unwrap_extracts_a_result() {
+        let wrapped = json!({
+            "jsonrpc": "2.0",
+            "result": {"ok": true},
+            "id": 7
+        });
+        let envelope = unwrap(wrapped);
+
+        assert_eq!(envelope.payload, json!({"ok": true}));
+        assert_eq!(envelope.id, Some(json!(7)));
+    }
+
+    #[test]
+    fn test_unwrap_ignores_a_wrong_version() {
+        let wrapped = json!({"jsonrpc": "1.0", "method": "task.start", "params": {"id": "x"}});
+        let envelope = unwrap(wrapped.clone());
+
+        assert_eq!(envelope.payload, wrapped);
+        assert!(envelope.method.is_none());
+    }
+
+    #[test]
+    fn test_unwrap_envelope_without_params_yields_null() {
+        let wrapped = json!({"jsonrpc": "2.0", "method": "task.stop", "id": "t"});
+        let envelope = unwrap(wrapped);
+
+        assert_eq!(envelope.payload, Value::Null);
+        assert_eq!(envelope.method.as_deref(), Some(METHOD_TASK_STOP));
+    }
+
+    #[test]
+    fn test_response_success_serialisation() {
+        let resp = Response::success(Some(json!("t-1")), json!({"ok": true}));
+        let encoded = serde_json::to_value(&resp).unwrap();
+
+        assert_eq!(
+            encoded,
+            json!({"jsonrpc": "2.0", "result": {"ok": true}, "id": "t-1"})
+        );
+    }
+
+    #[test]
+    fn test_response_failure_serialisation() {
+        let resp = Response::failure(None, Error::method_not_found("nope"));
+        let encoded = serde_json::to_value(&resp).unwrap();
+
+        assert_eq!(
+            encoded,
+            json!({
+                "jsonrpc": "2.0",
+                "error": {"code": -32601, "message": "Method not found", "data": "nope"},
+                "id": null
+            })
+        );
+    }
+
+    #[test]
+    fn test_error_constructors_carry_their_codes() {
+        assert_eq!(Error::invalid_params("bad").code, CODE_INVALID_PARAMS);
+        assert_eq!(Error::internal("boom").code, CODE_INTERNAL_ERROR);
+        assert_eq!(
+            Error::new(CODE_INVALID_REQUEST, "bad request").code,
+            CODE_INVALID_REQUEST
+        );
+    }
+}

--- a/proplet/src/main.rs
+++ b/proplet/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod hal;
 mod hal_component;
+mod jsonrpc;
 mod metrics;
 mod monitoring;
 mod mqtt;

--- a/proplet/src/main.rs
+++ b/proplet/src/main.rs
@@ -7,6 +7,7 @@ mod monitoring;
 mod mqtt;
 mod plugin;
 mod redact;
+mod rpc;
 mod runtime;
 mod service;
 mod task_handler;
@@ -194,6 +195,33 @@ async fn main() -> Result<()> {
         None
     };
 
+    let mut rpc_state_handle = None;
+    let rpc_shutdown = if config.rpc_enabled {
+        let state = Arc::new(rpc::RpcState::new(
+            runtime.clone(),
+            config.entity_id.clone(),
+            config.rpc_token.clone(),
+        ));
+        if state.token.is_none() {
+            tracing::warn!(
+                "RPC server enabled without PROPLET_RPC_TOKEN; \
+                 every caller that can reach {}:{} may invoke deployed functions",
+                config.rpc_bind_address,
+                config.rpc_port
+            );
+        }
+        let rpc_port = config.rpc_port;
+        let bind_address = config.rpc_bind_address.clone();
+        let (tx, rx) = oneshot::channel::<()>();
+        rpc_state_handle = Some(state.clone());
+        tokio::spawn(async move {
+            rpc::serve_rpc(rpc_port, bind_address, state, rx).await;
+        });
+        Some(tx)
+    } else {
+        None
+    };
+
     let service = if config.tee_enabled {
         match TeeWasmRuntime::new(&config).await {
             Ok(tee_runtime) => {
@@ -225,6 +253,16 @@ async fn main() -> Result<()> {
         ))
     };
 
+    let service = match rpc_state_handle {
+        Some(state) => {
+            let mut owned = Arc::try_unwrap(service)
+                .map_err(|_| anyhow::anyhow!("proplet service was already shared"))?;
+            owned.set_rpc_state(state);
+            Arc::new(owned)
+        }
+        None => service,
+    };
+
     let shutdown_handle = tokio::spawn(async move {
         tokio::signal::ctrl_c()
             .await
@@ -248,6 +286,10 @@ async fn main() -> Result<()> {
     }
 
     if let Some(tx) = telemetry_shutdown {
+        let _ = tx.send(());
+    }
+
+    if let Some(tx) = rpc_shutdown {
         let _ = tx.send(());
     }
 

--- a/proplet/src/mqtt.rs
+++ b/proplet/src/mqtt.rs
@@ -158,6 +158,12 @@ impl MqttMessage {
 
         crate::jsonrpc::unwrap(value).id
     }
+
+    pub fn envelope_method(&self) -> Option<String> {
+        let value: serde_json::Value = serde_json::from_slice(&self.payload).ok()?;
+
+        crate::jsonrpc::unwrap(value).method
+    }
 }
 
 pub async fn process_mqtt_events(mut eventloop: EventLoop, tx: mpsc::Sender<MqttMessage>) {

--- a/proplet/src/mqtt.rs
+++ b/proplet/src/mqtt.rs
@@ -140,10 +140,23 @@ pub struct MqttMessage {
 
 impl MqttMessage {
     pub fn decode<T: DeserializeOwned>(&self) -> Result<T> {
-        serde_json::from_slice(&self.payload).context(format!(
+        let value: serde_json::Value = serde_json::from_slice(&self.payload).context(format!(
+            "Failed to deserialize message payload from topic '{}'",
+            self.topic
+        ))?;
+
+        let envelope = crate::jsonrpc::unwrap(value);
+
+        serde_json::from_value(envelope.payload).context(format!(
             "Failed to deserialize message payload from topic '{}'",
             self.topic
         ))
+    }
+
+    pub fn correlation_id(&self) -> Option<serde_json::Value> {
+        let value: serde_json::Value = serde_json::from_slice(&self.payload).ok()?;
+
+        crate::jsonrpc::unwrap(value).id
     }
 }
 
@@ -251,6 +264,50 @@ fn parse_mqtt_address(address: &str) -> Result<(String, u16, bool)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::StartRequest;
+
+    fn message(payload: serde_json::Value) -> MqttMessage {
+        MqttMessage {
+            topic: "m/t/c/c/control/manager/start".to_string(),
+            payload: serde_json::to_vec(&payload).unwrap(),
+            is_reconnect: false,
+        }
+    }
+
+    #[test]
+    fn test_decode_accepts_a_legacy_flat_payload() {
+        let msg = message(serde_json::json!({
+            "id": "task-1",
+            "name": "fn",
+            "image_url": "registry.example.com/app:v1",
+            "state": 0
+        }));
+
+        let req: StartRequest = msg.decode().unwrap();
+        assert_eq!(req.id, "task-1");
+        assert_eq!(req.name, "fn");
+        assert!(msg.correlation_id().is_none());
+    }
+
+    #[test]
+    fn test_decode_accepts_a_jsonrpc_envelope() {
+        let msg = message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "task.start",
+            "params": {
+                "id": "task-1",
+                "name": "fn",
+                "image_url": "registry.example.com/app:v1",
+                "state": 0
+            },
+            "id": "task-1"
+        }));
+
+        let req: StartRequest = msg.decode().unwrap();
+        assert_eq!(req.id, "task-1");
+        assert_eq!(req.name, "fn");
+        assert_eq!(msg.correlation_id(), Some(serde_json::json!("task-1")));
+    }
 
     #[test]
     fn test_parse_mqtt_address_tcp_scheme() {

--- a/proplet/src/rpc.rs
+++ b/proplet/src/rpc.rs
@@ -1,0 +1,311 @@
+use crate::jsonrpc::{Error as RpcError, Request as RpcRequest, Response as RpcResponse};
+use crate::runtime::{Runtime, RuntimeContext, StartConfig};
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::{TokioIo, TokioTimer};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::{oneshot, Mutex};
+use tracing::{info, warn};
+
+const MAX_BODY_BYTES: u64 = 1024 * 1024;
+const CONNECTION_TIMEOUT_SECS: u64 = 120;
+
+#[derive(Clone)]
+pub struct DeployedFunction {
+    pub task_id: String,
+    pub wasm_binary: Arc<Vec<u8>>,
+}
+
+pub struct RpcState {
+    pub functions: Mutex<HashMap<String, DeployedFunction>>,
+    pub runtime: Arc<dyn Runtime>,
+    pub proplet_id: String,
+    pub token: Option<String>,
+}
+
+impl RpcState {
+    pub fn new(runtime: Arc<dyn Runtime>, proplet_id: String, token: Option<String>) -> Self {
+        Self {
+            functions: Mutex::new(HashMap::new()),
+            runtime,
+            proplet_id,
+            token,
+        }
+    }
+
+    pub async fn register(&self, name: String, function: DeployedFunction) {
+        self.functions.lock().await.insert(name, function);
+    }
+
+    pub async fn deregister(&self, task_id: &str) {
+        self.functions
+            .lock()
+            .await
+            .retain(|_, f| f.task_id != task_id);
+    }
+
+    async fn lookup(&self, method: &str) -> Option<DeployedFunction> {
+        self.functions.lock().await.get(method).cloned()
+    }
+}
+
+pub async fn serve_rpc(
+    port: u16,
+    bind_address: String,
+    state: Arc<RpcState>,
+    mut shutdown: oneshot::Receiver<()>,
+) {
+    let listener = match TcpListener::bind(format!("{bind_address}:{port}")).await {
+        Ok(l) => l,
+        Err(e) => {
+            warn!("Failed to bind RPC server on {bind_address}:{port}: {e}");
+            return;
+        }
+    };
+    info!("RPC server listening on {bind_address}:{port}");
+
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => {
+                info!("RPC server shutting down");
+                return;
+            }
+            accept = listener.accept() => {
+                match accept {
+                    Ok((stream, _)) => {
+                        let state = state.clone();
+                        tokio::spawn(async move {
+                            let io = TokioIo::new(stream);
+                            let svc = service_fn(move |req: Request<Incoming>| {
+                                let state = state.clone();
+                                async move { handle(req, state).await }
+                            });
+                            let conn = http1::Builder::new()
+                                .keep_alive(true)
+                                .timer(TokioTimer::new())
+                                .serve_connection(io, svc);
+                            match tokio::time::timeout(
+                                Duration::from_secs(CONNECTION_TIMEOUT_SECS), conn
+                            ).await {
+                                Ok(Err(e)) => warn!("RPC connection error: {e}"),
+                                Err(_elapsed) => tracing::debug!("RPC connection idle timeout"),
+                                Ok(Ok(())) => {}
+                            }
+                        });
+                    }
+                    Err(e) => warn!("RPC accept error: {e}"),
+                }
+            }
+        }
+    }
+}
+
+fn json_response(status: u16, body: String) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header("Content-Type", "application/json")
+        .body(Full::new(Bytes::from(body)))
+        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from("{}"))))
+}
+
+fn error_response(id: Option<Value>, error: RpcError) -> Response<Full<Bytes>> {
+    let response = RpcResponse::failure(id, error);
+    let body = serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string());
+
+    json_response(200, body)
+}
+
+fn authorized(req: &Request<Incoming>, token: &Option<String>) -> bool {
+    let Some(expected) = token else {
+        return true;
+    };
+
+    req.headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .is_some_and(|presented| presented == expected)
+}
+
+async fn handle(
+    req: Request<Incoming>,
+    state: Arc<RpcState>,
+) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
+    if req.uri().path() != "/rpc" {
+        return Ok(json_response(404, r#"{"error":"not found"}"#.to_string()));
+    }
+    if req.method() != hyper::Method::POST {
+        return Ok(json_response(
+            405,
+            r#"{"error":"method not allowed"}"#.to_string(),
+        ));
+    }
+    if !authorized(&req, &state.token) {
+        return Ok(json_response(
+            401,
+            r#"{"error":"unauthorized"}"#.to_string(),
+        ));
+    }
+
+    let body = match req.into_body().collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(e) => {
+            return Ok(error_response(
+                None,
+                RpcError::internal(format!("body read failed: {e}")),
+            ))
+        }
+    };
+    if body.len() as u64 > MAX_BODY_BYTES {
+        return Ok(error_response(
+            None,
+            RpcError::invalid_params("request body too large"),
+        ));
+    }
+
+    let rpc_req: RpcRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => {
+            return Ok(error_response(
+                None,
+                RpcError::new(crate::jsonrpc::CODE_INVALID_REQUEST, e.to_string()),
+            ))
+        }
+    };
+    if rpc_req.jsonrpc != crate::jsonrpc::VERSION {
+        return Ok(error_response(
+            rpc_req.id,
+            RpcError::new(
+                crate::jsonrpc::CODE_INVALID_REQUEST,
+                "jsonrpc version must be 2.0",
+            ),
+        ));
+    }
+
+    let Some(function) = state.lookup(&rpc_req.method).await else {
+        return Ok(error_response(
+            rpc_req.id,
+            RpcError::method_not_found(&rpc_req.method),
+        ));
+    };
+
+    let args = match params_to_args(rpc_req.params) {
+        Ok(a) => a,
+        Err(e) => return Ok(error_response(rpc_req.id, e)),
+    };
+
+    let config = StartConfig {
+        id: format!("{}-rpc-{}", function.task_id, uuid::Uuid::new_v4()),
+        function_name: rpc_req.method.clone(),
+        daemon: false,
+        wasm_binary: (*function.wasm_binary).clone(),
+        cli_args: Vec::new(),
+        env: HashMap::new(),
+        args,
+        mode: None,
+        hal_storage_path: None,
+    };
+
+    let ctx = RuntimeContext {
+        proplet_id: state.proplet_id.clone(),
+    };
+
+    match state.runtime.start_app(ctx, config).await {
+        Ok(output) => {
+            let text = String::from_utf8_lossy(&output).to_string();
+            let result = serde_json::from_str::<Value>(&text).unwrap_or(Value::String(text));
+            let response = RpcResponse::success(rpc_req.id, result);
+            let body = serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string());
+
+            Ok(json_response(200, body))
+        }
+        Err(e) => Ok(error_response(
+            rpc_req.id,
+            RpcError::internal(format!("{e:#}")),
+        )),
+    }
+}
+
+fn params_to_args(params: Option<Value>) -> Result<Vec<String>, RpcError> {
+    match params {
+        None | Some(Value::Null) => Ok(Vec::new()),
+        Some(Value::Array(values)) => values
+            .into_iter()
+            .map(|v| serde_json::to_string(&v).map_err(|e| RpcError::invalid_params(e.to_string())))
+            .collect(),
+        Some(Value::Object(map)) => map
+            .into_iter()
+            .map(|(_, v)| {
+                serde_json::to_string(&v).map_err(|e| RpcError::invalid_params(e.to_string()))
+            })
+            .collect(),
+        Some(_) => Err(RpcError::invalid_params(
+            "params must be an array or an object",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_params_to_args_accepts_an_array() {
+        let args = params_to_args(Some(json!(["world", 5]))).unwrap();
+        assert_eq!(args, vec!["\"world\"".to_string(), "5".to_string()]);
+    }
+
+    #[test]
+    fn test_params_to_args_accepts_absent_params() {
+        assert!(params_to_args(None).unwrap().is_empty());
+        assert!(params_to_args(Some(Value::Null)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_params_to_args_rejects_a_scalar() {
+        let err = params_to_args(Some(json!(5))).unwrap_err();
+        assert_eq!(err.code, crate::jsonrpc::CODE_INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn test_register_and_deregister() {
+        let state = RpcState::new(
+            Arc::new(
+                crate::runtime::wasmtime_runtime::WasmtimeRuntime::new_with_options(
+                    false,
+                    false,
+                    false,
+                    Vec::new(),
+                    8222,
+                    None,
+                    false,
+                )
+                .unwrap(),
+            ),
+            "proplet-1".to_string(),
+            None,
+        );
+
+        state
+            .register(
+                "greet".to_string(),
+                DeployedFunction {
+                    task_id: "task-1".to_string(),
+                    wasm_binary: Arc::new(Vec::new()),
+                },
+            )
+            .await;
+        assert!(state.lookup("greet").await.is_some());
+
+        state.deregister("task-1").await;
+        assert!(state.lookup("greet").await.is_none());
+    }
+}

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -500,11 +500,18 @@ impl PropletService {
             encrypted: req.encrypted,
         };
 
+        let correlation = msg.correlation_id();
+
         if let Some(ref registry) = self.plugin_registry {
             if let Some(reason) = registry.authorize(&plugin_task_info)? {
                 error!("Plugin denied task {}: {}", req.id, reason);
-                self.publish_result(&req.id, Vec::new(), Some(reason.clone()))
-                    .await?;
+                self.publish_result_correlated(
+                    &req.id,
+                    Vec::new(),
+                    Some(reason.clone()),
+                    correlation.clone(),
+                )
+                .await?;
                 return Err(anyhow::anyhow!("task denied by plugin: {}", reason));
             }
         }
@@ -521,10 +528,11 @@ impl PropletService {
                 tee_runtime.clone()
             } else {
                 error!("TEE runtime not available but encrypted workload requested");
-                self.publish_result(
+                self.publish_result_correlated(
                     &req.id,
                     Vec::new(),
                     Some("TEE runtime not available".to_string()),
+                    correlation.clone(),
                 )
                 .await?;
                 return Err(anyhow::anyhow!("TEE runtime not available"));
@@ -562,8 +570,13 @@ impl PropletService {
                     self.running_tasks.lock().await.remove(&req.id);
                     self.metrics.tasks_failed.inc();
                     self.metrics.tasks_running.dec();
-                    self.publish_result(&req.id, Vec::new(), Some(e.to_string()))
-                        .await?;
+                    self.publish_result_correlated(
+                        &req.id,
+                        Vec::new(),
+                        Some(e.to_string()),
+                        correlation.clone(),
+                    )
+                    .await?;
                     return Err(e.into());
                 }
             }
@@ -583,8 +596,13 @@ impl PropletService {
                         self.running_tasks.lock().await.remove(&req.id);
                         self.metrics.tasks_failed.inc();
                         self.metrics.tasks_running.dec();
-                        self.publish_result(&req.id, Vec::new(), Some(e.to_string()))
-                            .await?;
+                        self.publish_result_correlated(
+                            &req.id,
+                            Vec::new(),
+                            Some(e.to_string()),
+                            correlation.clone(),
+                        )
+                        .await?;
                         return Err(e);
                     }
                 }
@@ -598,8 +616,13 @@ impl PropletService {
                     self.running_tasks.lock().await.remove(&req.id);
                     self.metrics.tasks_failed.inc();
                     self.metrics.tasks_running.dec();
-                    self.publish_result(&req.id, Vec::new(), Some(e.to_string()))
-                        .await?;
+                    self.publish_result_correlated(
+                        &req.id,
+                        Vec::new(),
+                        Some(e.to_string()),
+                        correlation.clone(),
+                    )
+                    .await?;
                     return Err(e);
                 }
 
@@ -613,8 +636,13 @@ impl PropletService {
                         self.running_tasks.lock().await.remove(&req.id);
                         self.metrics.tasks_failed.inc();
                         self.metrics.tasks_running.dec();
-                        self.publish_result(&req.id, Vec::new(), Some(e.to_string()))
-                            .await?;
+                        self.publish_result_correlated(
+                            &req.id,
+                            Vec::new(),
+                            Some(e.to_string()),
+                            correlation.clone(),
+                        )
+                        .await?;
                         return Err(e);
                     }
                 }
@@ -625,8 +653,13 @@ impl PropletService {
             self.running_tasks.lock().await.remove(&req.id);
             self.metrics.tasks_failed.inc();
             self.metrics.tasks_running.dec();
-            self.publish_result(&req.id, Vec::new(), Some(err.to_string()))
-                .await?;
+            self.publish_result_correlated(
+                &req.id,
+                Vec::new(),
+                Some(err.to_string()),
+                correlation.clone(),
+            )
+            .await?;
             return Err(err);
         };
 
@@ -1306,6 +1339,17 @@ impl PropletService {
         results: Vec<u8>,
         error: Option<String>,
     ) -> Result<()> {
+        self.publish_result_correlated(task_id, results, error, None)
+            .await
+    }
+
+    async fn publish_result_correlated(
+        &self,
+        task_id: &str,
+        results: Vec<u8>,
+        error: Option<String>,
+        correlation: Option<serde_json::Value>,
+    ) -> Result<()> {
         let proplet_id = self.config.entity_id.clone();
         let result_str = String::from_utf8_lossy(&results).to_string();
 
@@ -1313,7 +1357,7 @@ impl PropletService {
             task_id: task_id.to_string(),
             proplet_id,
             results: result_str,
-            error,
+            error: error.clone(),
         };
 
         let topic = build_topic(
@@ -1322,9 +1366,29 @@ impl PropletService {
             "control/proplet/results",
         );
 
-        self.pubsub
-            .publish(&topic, &result_msg, self.config.qos())
-            .await?;
+        match correlation {
+            Some(id) => {
+                let response = match error {
+                    Some(message) => crate::jsonrpc::Response::failure(
+                        Some(id),
+                        crate::jsonrpc::Error::internal(message),
+                    ),
+                    None => crate::jsonrpc::Response::success(
+                        Some(id),
+                        serde_json::to_value(&result_msg)?,
+                    ),
+                };
+                self.pubsub
+                    .publish(&topic, &response, self.config.qos())
+                    .await?;
+            }
+            None => {
+                self.pubsub
+                    .publish(&topic, &result_msg, self.config.qos())
+                    .await?;
+            }
+        }
+
         Ok(())
     }
 

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -65,6 +65,7 @@ pub struct PropletService {
     http_client: HttpClient,
     plugin_registry: Option<Arc<PluginRegistry>>,
     metrics: Arc<PropletMetrics>,
+    rpc_state: Option<Arc<crate::rpc::RpcState>>,
 }
 
 impl PropletService {
@@ -96,6 +97,7 @@ impl PropletService {
             http_client,
             plugin_registry,
             metrics,
+            rpc_state: None,
         };
 
         service.start_chunk_expiry_task();
@@ -132,6 +134,7 @@ impl PropletService {
             http_client,
             plugin_registry,
             metrics,
+            rpc_state: None,
         };
 
         service.start_chunk_expiry_task();
@@ -142,6 +145,10 @@ impl PropletService {
     #[allow(dead_code)]
     pub fn set_tee_runtime(&mut self, tee_runtime: Arc<dyn Runtime>) {
         self.tee_runtime = Some(tee_runtime);
+    }
+
+    pub fn set_rpc_state(&mut self, rpc_state: Arc<crate::rpc::RpcState>) {
+        self.rpc_state = Some(rpc_state);
     }
 
     fn start_chunk_expiry_task(&self) {
@@ -447,6 +454,26 @@ impl PropletService {
             );
         }
 
+        if let Some(method) = msg.envelope_method() {
+            let expected = if msg.topic.contains("control/manager/start") {
+                Some(crate::jsonrpc::METHOD_TASK_START)
+            } else if msg.topic.contains("control/manager/stop") {
+                Some(crate::jsonrpc::METHOD_TASK_STOP)
+            } else {
+                None
+            };
+
+            if let Some(expected) = expected {
+                if method != expected {
+                    warn!(
+                        "Ignoring message on '{}': method '{}' does not match '{}'",
+                        msg.topic, method, expected
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
         if msg.topic.contains("control/manager/start") {
             self.handle_start_command(msg).await
         } else if msg.topic.contains("control/manager/invoke") {
@@ -702,6 +729,19 @@ impl PropletService {
             env.insert(k, v);
         }
 
+        if let Some(ref rpc_state) = self.rpc_state {
+            rpc_state
+                .register(
+                    task_name.clone(),
+                    crate::rpc::DeployedFunction {
+                        task_id: task_id.clone(),
+                        wasm_binary: Arc::new(wasm_binary.clone()),
+                    },
+                )
+                .await;
+            info!("Registered task {} as RPC method '{}'", task_id, task_name);
+        }
+
         if req.latent {
             let mut latent_env = env;
             latent_env
@@ -725,8 +765,13 @@ impl PropletService {
                 self.running_tasks.lock().await.remove(&task_id);
                 self.metrics.tasks_failed.inc();
                 self.metrics.tasks_running.dec();
-                self.publish_result(&task_id, Vec::new(), Some(e.to_string()))
-                    .await?;
+                self.publish_result_correlated(
+                    &task_id,
+                    Vec::new(),
+                    Some(e.to_string()),
+                    correlation.clone(),
+                )
+                .await?;
 
                 return Err(e);
             }
@@ -1213,6 +1258,10 @@ impl PropletService {
         self.runtime.stop_app(req.id.clone()).await?;
         self.monitor.stop_monitoring(&req.id).await.ok();
 
+        if let Some(ref rpc_state) = self.rpc_state {
+            rpc_state.deregister(&req.id).await;
+        }
+
         if self.running_tasks.lock().await.remove(&req.id).is_some() {
             self.metrics.tasks_running.dec();
         }
@@ -1331,16 +1380,6 @@ impl PropletService {
         }
 
         Ok(None)
-    }
-
-    async fn publish_result(
-        &self,
-        task_id: &str,
-        results: Vec<u8>,
-        error: Option<String>,
-    ) -> Result<()> {
-        self.publish_result_correlated(task_id, results, error, None)
-            .await
     }
 
     async fn publish_result_correlated(

--- a/proplet/src/telemetry.rs
+++ b/proplet/src/telemetry.rs
@@ -245,7 +245,7 @@ mod tests {
         m.tasks_started.inc();
         m.tasks_completed.inc();
         let gathered = m.registry.gather();
-        let names: Vec<&str> = gathered.iter().map(|mf| mf.get_name()).collect();
+        let names: Vec<&str> = gathered.iter().map(|mf| mf.name()).collect();
         assert!(names.contains(&"proplet_tasks_started_total"));
         assert!(names.contains(&"proplet_tasks_completed_total"));
         assert!(names.contains(&"proplet_tasks_failed_total"));


### PR DESCRIPTION
# What type of PR is this?

This is a feature because it adds JSON-RPC 2.0 support.

## What does this do?

Adds JSON-RPC 2.0 to the manager API, control plane, proplet.

## Which issue(s) does this PR fix/relate to?

None.

## Have you included tests for your changes?

Yes. Go and Rust unit tests across all three surfaces.

## Did you document any new/modified features?

No. Documentation belongs in propeller-docs.

### Notes

Additive and off by default. Eleven commits build independently.
