### PR TITLE
fix(atom): bootstrap config file

### DIFF
--- a/docker/atom/atom-bootstrap.yaml
+++ b/docker/atom/atom-bootstrap.yaml
@@ -1,0 +1,10 @@
+capabilities:
+  - name: publish
+    applicability:
+      - object_kind: resource
+        object_type: resource:channel
+  - name: subscribe
+    applicability:
+      - object_kind: resource
+        object_type: resource:channel
+

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -45,6 +45,8 @@ services:
     ports:
       - "${ATOM_HTTP_PORT}:${ATOM_HTTP_PORT}"
       - "${ATOM_GRPC_PORT}:${ATOM_GRPC_PORT}"
+    volumes:
+      - ./atom/atom-bootstrap.yaml:/etc/atom/atom-bootstrap.yaml:ro
     environment:
       DATABASE_URL: "postgres://${ATOM_DB_USER}:${ATOM_DB_PASS}@atom-db:5432/${ATOM_DB_NAME}"
       LISTEN_ADDR: "0.0.0.0:${ATOM_HTTP_PORT}"
@@ -65,6 +67,7 @@ services:
       JWT_EXPIRY_SECS: ${ATOM_JWT_EXPIRY_SECS}
       ATOM_LOGIN_FAILURE_LIMIT: ${ATOM_LOGIN_FAILURE_LIMIT:-1000}
       ATOM_LOGIN_FAILURE_WINDOW_SECS: ${ATOM_LOGIN_FAILURE_WINDOW_SECS:-30}
+      ATOM_BOOTSTRAP_FILE: ${ATOM_BOOTSTRAP_FILE:-/etc/atom/atom-bootstrap.yaml}
     networks:
       - propeller-base-net
 


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

Bug fix.

<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?

Atom's new bootstrapping feature (https://github.com/absmach/atom/pull/32) requires a bootstrap file. If you try to provision a new cluster without one, using the `latest` Atom image, you get the following error:

In CLI after trying to provision:

```
* failed to create connection: create permission block: graphql error: [capability publish is not applicable to resource:channel]
```

In Atom logs:

```
$ docker logs propeller-atom
2026-08-17T13:49:40.234293Z ERROR atom::audit: audit audit.event="permission_block.create" audit.outcome="error" audit.actor=Some(00000000-0000-0000-0000-000000000001) audit.tenant=Some(58ffecd1-d9c3-47dd-b5f2-85013b30f064) audit.target_kind="permission_block" audit.target=None audit.details={"error":"capability publish is not applicable to resource:channel"}
```

This PR solves this.

