### PR TITLE
fix(docker): update fluxmq config

### DIFF
--- a/docker/fluxmq/node1.yaml
+++ b/docker/fluxmq/node1.yaml
@@ -2,28 +2,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 server:
-  tcp:
-    v3:
-      addr: "0.0.0.0:1883"
-      protocol: "v3"
-      max_connections: 10000
-      read_timeout: 60s
-      write_timeout: 60s
-    v5:
-      addr: "0.0.0.0:1884"
-      protocol: "v5"
-      max_connections: 10000
-      read_timeout: 60s
-      write_timeout: 60s
-  websocket:
-    v3:
-      addr: "0.0.0.0:8883"
-      path: "/mqtt"
-      protocol: "v3"
-    v5:
-      addr: "0.0.0.0:8884"
-      path: "/mqtt"
-      protocol: "v5"
+  mqtt:
+    tcp:
+      v3:
+        addr: "0.0.0.0:1883"
+        protocol: "v3"
+        max_connections: 10000
+        read_timeout: 60s
+        write_timeout: 60s
+      v5:
+        addr: "0.0.0.0:1884"
+        protocol: "v5"
+        max_connections: 10000
+        read_timeout: 60s
+        write_timeout: 60s
+    websocket:
+      v3:
+        addr: "0.0.0.0:8883"
+        path: "/mqtt"
+        protocol: "v3"
+      v5:
+        addr: "0.0.0.0:8884"
+        path: "/mqtt"
+        protocol: "v5"
   http:
     plain:
       addr: "0.0.0.0:8090"
@@ -67,7 +68,7 @@ log:
 storage:
   type: "badger"
   badger_dir: "/tmp/fluxmq/data"
-  sync_writes: false
+  badger_sync_writes: false
 
 cluster:
   enabled: false


### PR DESCRIPTION
# What type of PR is this?

This is a bug fix because it updates the Docker configuration to match the current FluxMQ configuration schema.

## What does this do?

- Moves the MQTT TCP and WebSocket listeners under `server.mqtt`.
- Renames `storage.sync_writes` to `storage.badger_sync_writes`.
- Prevents FluxMQ from rejecting the configuration during startup.

## Which issue(s) does this PR fix/relate to?

- Resolves #280

## Have you included tests for your changes?

No new tests were added because this is a configuration-only change.

The configuration was validated using the current FluxMQ strict configuration loader, and the existing Go test suite passes with `go test ./...`.

## Did you document any new/modified features?

No. This change does not introduce or modify any features.

### Notes

The deprecated `storage.sync_writes` field was also updated because the current FluxMQ schema rejects it during strict configuration parsing.
