### PR TITLE
Move MQTT mTLS termination to FluxMQ

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -74,15 +74,15 @@ MG_JAEGER_MEMORY_MAX_TRACES=5000
 ## Manager
 MANAGER_LOG_LEVEL=info
 MANAGER_INSTANCE_ID=""
-MANAGER_MQTT_ADDRESS="tcp://nginx:${MG_NGINX_MQTT_PORT}"
+MANAGER_MQTT_ADDRESS="ssl://nginx:${MG_NGINX_MQTTS_PORT}"
 MANAGER_MQTT_QOS=2
 MANAGER_MQTT_TIMEOUT=30s
-# MQTT over mTLS — use ssl:// scheme and uncomment all certificate paths:
-# MANAGER_MQTT_ADDRESS="ssl://nginx:${MG_NGINX_MQTTS_PORT}"
-# MANAGER_MQTT_TLS_CA_CERT=/etc/propeller/tls/ca.crt
-# MANAGER_MQTT_TLS_CLIENT_CERT=/etc/propeller/tls/client.crt
-# MANAGER_MQTT_TLS_CLIENT_KEY=/etc/propeller/tls/client.key
-# MANAGER_MQTT_TLS_INSECURE_SKIP_VERIFY=false
+# MQTT over mTLS is the default. The client certificate CN must equal the
+# external entity ID authenticated by MANAGER_API_KEY.
+MANAGER_MQTT_TLS_CA_CERT=/etc/propeller/tls/ca.crt
+MANAGER_MQTT_TLS_CLIENT_CERT=/etc/propeller/tls/client.crt
+MANAGER_MQTT_TLS_CLIENT_KEY=/etc/propeller/tls/client.key
+MANAGER_MQTT_TLS_INSECURE_SKIP_VERIFY=false
 # These are provisioned by setup-propeller.sh or set manually.
 # In Atom: entity of kind "service", profile "Service Account".
 MANAGER_TENANT_ID=
@@ -99,15 +99,15 @@ MANAGER_TRACE_RATIO=${MG_JAEGER_TRACE_RATIO}
 ## Proplet
 PROPLET_LOG_LEVEL=info
 PROPLET_INSTANCE_ID=""
-PROPLET_MQTT_ADDRESS="tcp://nginx:${MG_NGINX_MQTT_PORT}"
+PROPLET_MQTT_ADDRESS="ssl://nginx:${MG_NGINX_MQTTS_PORT}"
 PROPLET_MQTT_QOS=2
 PROPLET_MQTT_TIMEOUT=30s
-# MQTT over mTLS — use ssl:// scheme and uncomment all certificate paths:
-# PROPLET_MQTT_ADDRESS="ssl://nginx:${MG_NGINX_MQTTS_PORT}"
-# PROPLET_MQTT_TLS_CA_CERT=/etc/propeller/tls/ca.crt
-# PROPLET_MQTT_TLS_CLIENT_CERT=/etc/propeller/tls/client.crt
-# PROPLET_MQTT_TLS_CLIENT_KEY=/etc/propeller/tls/client.key
-# PROPLET_MQTT_TLS_INSECURE_SKIP_VERIFY=false
+# MQTT over mTLS is the default. The client certificate CN must equal the
+# external entity ID authenticated by PROPLET_API_KEY.
+PROPLET_MQTT_TLS_CA_CERT=/etc/propeller/tls/ca.crt
+PROPLET_MQTT_TLS_CLIENT_CERT=/etc/propeller/tls/client.crt
+PROPLET_MQTT_TLS_CLIENT_KEY=/etc/propeller/tls/client.key
+PROPLET_MQTT_TLS_INSECURE_SKIP_VERIFY=false
 PROPLET_LIVELINESS_INTERVAL="10s"
 # These are provisioned by setup-propeller.sh or set manually.
 # In Atom: entity of kind "service", profile "Service Account".

--- a/docker/.env
+++ b/docker/.env
@@ -58,6 +58,11 @@ MG_NGINX_MQTTS_PORT=8883
 MG_NGINX_AMQP_PORT=5682
 MG_NGINX_SERVER_NAME=
 
+## FluxMQ native MQTT mTLS
+FLUXMQ_MQTT_MTLS_CERT=./ssl/certs/propeller-server.crt
+FLUXMQ_MQTT_MTLS_KEY=./ssl/certs/propeller-server.key
+FLUXMQ_MQTT_MTLS_CLIENT_CA=./ssl/certs/ca.crt
+
 ## Jaeger (Distributed Tracing)
 MG_JAEGER_COLLECTOR_OTLP_ENABLED=true
 MG_JAEGER_FRONTEND=16686
@@ -72,7 +77,7 @@ MANAGER_INSTANCE_ID=""
 MANAGER_MQTT_ADDRESS="tcp://nginx:${MG_NGINX_MQTT_PORT}"
 MANAGER_MQTT_QOS=2
 MANAGER_MQTT_TIMEOUT=30s
-# MQTT over TLS — use ssl:// scheme and uncomment cert paths:
+# MQTT over mTLS — use ssl:// scheme and uncomment all certificate paths:
 # MANAGER_MQTT_ADDRESS="ssl://nginx:${MG_NGINX_MQTTS_PORT}"
 # MANAGER_MQTT_TLS_CA_CERT=/etc/propeller/tls/ca.crt
 # MANAGER_MQTT_TLS_CLIENT_CERT=/etc/propeller/tls/client.crt
@@ -97,7 +102,7 @@ PROPLET_INSTANCE_ID=""
 PROPLET_MQTT_ADDRESS="tcp://nginx:${MG_NGINX_MQTT_PORT}"
 PROPLET_MQTT_QOS=2
 PROPLET_MQTT_TIMEOUT=30s
-# MQTT over TLS — use ssl:// scheme and uncomment cert paths:
+# MQTT over mTLS — use ssl:// scheme and uncomment all certificate paths:
 # PROPLET_MQTT_ADDRESS="ssl://nginx:${MG_NGINX_MQTTS_PORT}"
 # PROPLET_MQTT_TLS_CA_CERT=/etc/propeller/tls/ca.crt
 # PROPLET_MQTT_TLS_CLIENT_CERT=/etc/propeller/tls/client.crt
@@ -132,7 +137,7 @@ PROXY_INSTANCE_ID=""
 PROXY_MQTT_ADDRESS="tcp://nginx:${MG_NGINX_MQTT_PORT}"
 PROXY_MQTT_QOS=2
 PROXY_MQTT_TIMEOUT=30s
-# MQTT over TLS — use ssl:// scheme and uncomment cert paths:
+# MQTT over mTLS — use ssl:// scheme and uncomment all certificate paths:
 # PROXY_MQTT_ADDRESS="ssl://nginx:${MG_NGINX_MQTTS_PORT}"
 # PROXY_MQTT_TLS_CA_CERT=/etc/propeller/tls/ca.crt
 # PROXY_MQTT_TLS_CLIENT_CERT=/etc/propeller/tls/client.crt

--- a/docker/compose.propeller.yaml
+++ b/docker/compose.propeller.yaml
@@ -8,6 +8,9 @@ networks:
     external: true
     name: propeller-base-net
 
+volumes:
+  propeller-proplet-tls-volume:
+
 services:
   manager:
     image: ghcr.io/absmach/propeller/manager:${PROP_RELEASE_TAG}
@@ -51,33 +54,67 @@ services:
       MANAGER_POSTGRES_PASS: ${MANAGER_POSTGRES_PASS:-propeller}
       MANAGER_POSTGRES_DB: ${MANAGER_POSTGRES_DB:-propeller}
       MANAGER_POSTGRES_SSLMODE: ${MANAGER_POSTGRES_SSLMODE:-disable}
-      # MQTT over TLS / mTLS — uncomment to enable.
-      # Then also mount cert files (see volumes section below).
-      # MANAGER_MQTT_TLS_CA_CERT: ${MANAGER_MQTT_TLS_CA_CERT}
-      # MANAGER_MQTT_TLS_CLIENT_CERT: ${MANAGER_MQTT_TLS_CLIENT_CERT}
-      # MANAGER_MQTT_TLS_CLIENT_KEY: ${MANAGER_MQTT_TLS_CLIENT_KEY}
-      # MANAGER_MQTT_TLS_INSECURE_SKIP_VERIFY: ${MANAGER_MQTT_TLS_INSECURE_SKIP_VERIFY}
+      MANAGER_MQTT_TLS_CA_CERT: ${MANAGER_MQTT_TLS_CA_CERT}
+      MANAGER_MQTT_TLS_CLIENT_CERT: ${MANAGER_MQTT_TLS_CLIENT_CERT}
+      MANAGER_MQTT_TLS_CLIENT_KEY: ${MANAGER_MQTT_TLS_CLIENT_KEY}
+      MANAGER_MQTT_TLS_INSECURE_SKIP_VERIFY: ${MANAGER_MQTT_TLS_INSECURE_SKIP_VERIFY}
     volumes:
       - type: bind
-        source: ./config.toml
+        source: ../config.toml
         target: /config.toml
         bind:
           create_host_path: false
-      # MQTT TLS certs (uncomment and change source paths when using ssl://):
-      # - type: bind
-      #   source: ./ssl/certs/ca.crt
-      #   target: /etc/propeller/tls/ca.crt
-      #   read_only: true
-      # - type: bind
-      #   source: ./ssl/certs/manager.crt
-      #   target: /etc/propeller/tls/client.crt
-      #   read_only: true
-      # - type: bind
-      #   source: ./ssl/certs/manager.key
-      #   target: /etc/propeller/tls/client.key
-      #   read_only: true
+      - type: bind
+        source: ./ssl/certs/ca.crt
+        target: /etc/propeller/tls/ca.crt
+        read_only: true
+      - type: bind
+        source: ./ssl/certs/manager.crt
+        target: /etc/propeller/tls/client.crt
+        read_only: true
+      - type: bind
+        source: ./ssl/certs/manager.key
+        target: /etc/propeller/tls/client.key
+        read_only: true
     networks:
       - propeller-base-net
+
+  # Stage the Proplet client key in a private volume owned by the non-root
+  # Proplet user. Bind-mounted host keys remain mode 0600.
+  proplet-tls-init:
+    image: ${PROPLET_IMAGE}:${PROPLET_IMAGE_TAG}
+    pull_policy: always
+    container_name: propeller-proplet-tls-init
+    user: "0:0"
+    network_mode: none
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        proplet_uid=$$(id -u proplet)
+        proplet_gid=$$(id -g proplet)
+        install -d -o "$${proplet_uid}" -g "$${proplet_gid}" -m 0700 /target
+        install -o "$${proplet_uid}" -g "$${proplet_gid}" -m 0444 /source/ca.crt /target/ca.crt
+        install -o "$${proplet_uid}" -g "$${proplet_gid}" -m 0444 /source/client.crt /target/client.crt
+        install -o "$${proplet_uid}" -g "$${proplet_gid}" -m 0400 /source/client.key /target/client.key
+    volumes:
+      - type: bind
+        source: ./ssl/certs/ca.crt
+        target: /source/ca.crt
+        read_only: true
+      - type: bind
+        source: ./ssl/certs/proplet.crt
+        target: /source/client.crt
+        read_only: true
+      - type: bind
+        source: ./ssl/certs/proplet.key
+        target: /source/client.key
+        read_only: true
+      - type: volume
+        source: propeller-proplet-tls-volume
+        target: /target
+        volume:
+          nocopy: true
+    restart: "no"
 
   # Proplet - WebAssembly edge runtime
   # Available images:
@@ -93,6 +130,9 @@ services:
     pull_policy: always
     container_name: propeller-proplet
     restart: on-failure
+    depends_on:
+      proplet-tls-init:
+        condition: service_completed_successfully
     healthcheck:
       test:
         [
@@ -131,36 +171,26 @@ services:
       MANAGER_COORDINATOR_URL: ${MANAGER_COORDINATOR_URL:-http://coordinator-http:8080}
       MODEL_REGISTRY_URL: ${MODEL_REGISTRY_URL:-http://model-registry:8081}
       DATA_STORE_URL: ${DATA_STORE_URL:-http://local-data-store:8083}
-      # MQTT over TLS / mTLS configuration — uncomment to enable.
-      # Certificate/key paths refer to files inside the container.
-      # See the volumes section below for bind mounts.
-      # PROPLET_MQTT_TLS_CA_CERT: ${PROPLET_MQTT_TLS_CA_CERT}
-      # PROPLET_MQTT_TLS_CLIENT_CERT: ${PROPLET_MQTT_TLS_CLIENT_CERT}
-      # PROPLET_MQTT_TLS_CLIENT_KEY: ${PROPLET_MQTT_TLS_CLIENT_KEY}
-      # PROPLET_MQTT_TLS_INSECURE_SKIP_VERIFY: ${PROPLET_MQTT_TLS_INSECURE_SKIP_VERIFY}
+      PROPLET_MQTT_TLS_CA_CERT: ${PROPLET_MQTT_TLS_CA_CERT}
+      PROPLET_MQTT_TLS_CLIENT_CERT: ${PROPLET_MQTT_TLS_CLIENT_CERT}
+      PROPLET_MQTT_TLS_CLIENT_KEY: ${PROPLET_MQTT_TLS_CLIENT_KEY}
+      PROPLET_MQTT_TLS_INSECURE_SKIP_VERIFY: ${PROPLET_MQTT_TLS_INSECURE_SKIP_VERIFY}
       # Outgoing HTTP TLS — uncomment to trust custom/self-signed CA certificates
       # for HTTPS requests made by WASM workloads and proplet itself.
       # PROPLET_HTTP_TLS_CA_CERT: ${PROPLET_HTTP_TLS_CA_CERT}
       # PROPLET_HTTP_TLS_INSECURE_SKIP_VERIFY: ${PROPLET_HTTP_TLS_INSECURE_SKIP_VERIFY}
     volumes:
       - type: bind
-        source: ./config.toml
+        source: ../config.toml
         target: /home/proplet/config.toml
         bind:
           create_host_path: false
-      # MQTT TLS certs (uncomment and change source paths when using ssl://):
-      # - type: bind
-      #   source: ./ssl/certs/ca.crt
-      #   target: /etc/propeller/tls/ca.crt
-      #   read_only: true
-      # - type: bind
-      #   source: ./ssl/certs/proplet.crt
-      #   target: /etc/propeller/tls/client.crt
-      #   read_only: true
-      # - type: bind
-      #   source: ./ssl/certs/proplet.key
-      #   target: /etc/propeller/tls/client.key
-      #   read_only: true
+      - type: volume
+        source: propeller-proplet-tls-volume
+        target: /etc/propeller/tls
+        read_only: true
+        volume:
+          nocopy: true
       # HTTP TLS CA cert (uncomment to trust custom CAs for outgoing HTTPS):
       # - type: bind
       #   source: ./ca.crt
@@ -217,7 +247,7 @@ services:
       # PROXY_MQTT_TLS_INSECURE_SKIP_VERIFY: ${PROXY_MQTT_TLS_INSECURE_SKIP_VERIFY}
     volumes:
       - type: bind
-        source: ./config.toml
+        source: ../config.toml
         target: /config.toml
         bind:
           create_host_path: false

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -103,6 +103,18 @@ services:
     volumes:
       - ./fluxmq/node1.yaml:/etc/fluxmq/config.yaml:ro
       - propeller-fluxmq-node1-volume:/tmp/fluxmq
+      - type: bind
+        source: ${FLUXMQ_MQTT_MTLS_CERT:-./ssl/certs/propeller-server.crt}
+        target: /etc/fluxmq/certs/server.crt
+        read_only: true
+      - type: bind
+        source: ${FLUXMQ_MQTT_MTLS_KEY:-./ssl/certs/propeller-server.key}
+        target: /etc/fluxmq/certs/server.key
+        read_only: true
+      - type: bind
+        source: ${FLUXMQ_MQTT_MTLS_CLIENT_CA:-./ssl/certs/ca.crt}
+        target: /etc/fluxmq/certs/client-ca.crt
+        read_only: true
 
   fluxmq-auth:
     image: ghcr.io/absmach/magistrala/fluxmq:${MG_RELEASE_TAG}
@@ -134,7 +146,7 @@ services:
     container_name: propeller-nginx
     restart: on-failure
     volumes:
-      - ./nginx/nginx-key.conf:/etc/nginx/nginx.conf.template
+      - ./nginx/nginx-key.conf:/etc/nginx/nginx.conf.template:ro
       - ./nginx/entrypoint.sh:/docker-entrypoint.d/entrypoint.sh
       - ./nginx/snippets:/etc/nginx/snippets
       - ./ssl/authorization.js:/etc/nginx/authorization.js

--- a/docker/fluxmq/node1.yaml
+++ b/docker/fluxmq/node1.yaml
@@ -16,6 +16,18 @@ server:
         max_connections: 10000
         read_timeout: 60s
         write_timeout: 60s
+      # Nginx passes the public MQTTS connection through to this listener
+      # without terminating TLS or inspecting MQTT credentials.
+      mtls:
+        addr: "0.0.0.0:8885"
+        protocol: "auto"
+        max_connections: 10000
+        read_timeout: 60s
+        write_timeout: 60s
+        cert_file: "/etc/fluxmq/certs/server.crt"
+        key_file: "/etc/fluxmq/certs/server.key"
+        ca_file: "/etc/fluxmq/certs/client-ca.crt"
+        client_auth: "require"
     websocket:
       v3:
         addr: "0.0.0.0:8883"

--- a/docker/nginx/nginx-key.conf
+++ b/docker/nginx/nginx-key.conf
@@ -90,18 +90,26 @@ stream {
 
     # Include single-node or multiple-node (cluster) upstream
     include snippets/mqtt-upstream.conf;
+    include snippets/mqtt-mtls-upstream.conf;
     include snippets/mqtt-v5-upstream.conf;
     include snippets/fluxmq-amqp-upstream.conf;
 
+    # Plain MQTT remains a normal TCP proxy to FluxMQ's plaintext listener.
     server {
         listen ${MG_NGINX_MQTT_PORT};
         listen [::]:${MG_NGINX_MQTT_PORT};
-        listen ${MG_NGINX_MQTTS_PORT} ssl;
-        listen [::]:${MG_NGINX_MQTTS_PORT} ssl;
-
-        include snippets/ssl.conf;
 
         proxy_pass mqtt_cluster;
+    }
+
+    # Preserve the client's TLS session end-to-end. FluxMQ terminates mTLS,
+    # verifies the client certificate, and separately sends the MQTT username
+    # and password to the configured Atom authentication bridge.
+    server {
+        listen ${MG_NGINX_MQTTS_PORT};
+        listen [::]:${MG_NGINX_MQTTS_PORT};
+
+        proxy_pass mqtt_mtls_cluster;
     }
 
     server {

--- a/docker/nginx/nginx-x509.conf
+++ b/docker/nginx/nginx-x509.conf
@@ -8,7 +8,6 @@ worker_processes auto;
 worker_cpu_affinity auto;
 worker_rlimit_nofile 65535;
 pid /run/nginx.pid;
-load_module /etc/nginx/modules/ngx_stream_js_module.so;
 load_module /etc/nginx/modules/ngx_http_js_module.so;
 include /etc/nginx/modules-enabled/*.conf;
 
@@ -97,25 +96,27 @@ http {
 stream {
    include snippets/stream_access_log.conf;
 
-    js_path "/etc/nginx/njs/";
-    js_import authorization from /etc/nginx/authorization.js;
-
     include snippets/mqtt-upstream.conf;
+    include snippets/mqtt-mtls-upstream.conf;
     include snippets/mqtt-v5-upstream.conf;
     include snippets/fluxmq-amqp-upstream.conf;
-    ssl_verify_client on;
-    include snippets/ssl-client.conf;
 
+    # Plain MQTT remains a normal TCP proxy to FluxMQ's plaintext listener.
     server {
         listen ${MG_NGINX_MQTT_PORT};
         listen [::]:${MG_NGINX_MQTT_PORT};
-        listen ${MG_NGINX_MQTTS_PORT} ssl;
-        listen [::]:${MG_NGINX_MQTTS_PORT} ssl;
-
-        include snippets/ssl.conf;
-        js_preread authorization.authenticate;
 
         proxy_pass mqtt_cluster;
+    }
+
+    # Preserve the client's TLS session end-to-end. FluxMQ terminates mTLS,
+    # verifies the client certificate, and separately sends the MQTT username
+    # and password to the configured Atom authentication bridge.
+    server {
+        listen ${MG_NGINX_MQTTS_PORT};
+        listen [::]:${MG_NGINX_MQTTS_PORT};
+
+        proxy_pass mqtt_mtls_cluster;
     }
 
     server {

--- a/docker/nginx/snippets/mqtt-mtls-upstream.conf
+++ b/docker/nginx/snippets/mqtt-mtls-upstream.conf
@@ -1,0 +1,7 @@
+# Copyright (c) Abstract Machines
+# SPDX-License-Identifier: Apache-2.0
+
+upstream mqtt_mtls_cluster {
+    zone mqtt_mtls_cluster_zone 64k;
+    server 172.30.0.201:8885;
+}

--- a/docker/ssl/Makefile
+++ b/docker/ssl/Makefile
@@ -8,8 +8,10 @@ OU_CRT ?= propeller_crt
 EA ?= propeller@absmach.eu
 CN_CA ?= Propeller_Self_Signed_CA
 CN_SRV ?= localhost
-CLIENT_SECRET ?= "" # e.g. 8f65ed04-0770-4ce4-a291-6d1bf2000f4d
 CRT_FILE_NAME ?= proplet
+# The CN is an identifier only (for example, an Atom entity UUID). Never put
+# an MQTT password or API key in a certificate subject.
+CLIENT_CN ?= $(CRT_FILE_NAME)
 COAP_DTLS_SERVER_CONF_FILE_NAME=coap-server.conf
 COAP_DTLS_SERVER_CN=coap
 COAP_DTLS_SERVER_CRT_FILE_NAME=coap-server
@@ -73,7 +75,7 @@ server_cert:
 client_cert:
 	# Create propeller client key and CSR.
 	openssl req -new -sha256 -newkey rsa:4096 -nodes -keyout $(CRT_LOCATION)/$(CRT_FILE_NAME).key \
-				-out $(CRT_LOCATION)/$(CRT_FILE_NAME).csr -subj "/CN=$(CLIENT_SECRET)/O=$(O)/OU=$(OU_CRT)/emailAddress=$(EA)"
+				-out $(CRT_LOCATION)/$(CRT_FILE_NAME).csr -subj "/CN=$(CLIENT_CN)/O=$(O)/OU=$(OU_CRT)/emailAddress=$(EA)"
 
 	# Sign client CSR.
 	openssl x509 -req -days 730 -in $(CRT_LOCATION)/$(CRT_FILE_NAME).csr -CA $(CRT_LOCATION)/ca.crt -CAkey $(CRT_LOCATION)/ca.key -CAcreateserial -out $(CRT_LOCATION)/$(CRT_FILE_NAME).crt

--- a/docker/ssl/Makefile
+++ b/docker/ssl/Makefile
@@ -77,11 +77,14 @@ client_cert:
 	openssl req -new -sha256 -newkey rsa:4096 -nodes -keyout $(CRT_LOCATION)/$(CRT_FILE_NAME).key \
 				-out $(CRT_LOCATION)/$(CRT_FILE_NAME).csr -subj "/CN=$(CLIENT_CN)/O=$(O)/OU=$(OU_CRT)/emailAddress=$(EA)"
 
-	# Sign client CSR.
-	openssl x509 -req -days 730 -in $(CRT_LOCATION)/$(CRT_FILE_NAME).csr -CA $(CRT_LOCATION)/ca.crt -CAkey $(CRT_LOCATION)/ca.key -CAcreateserial -out $(CRT_LOCATION)/$(CRT_FILE_NAME).crt
+	# Sign an explicit X.509 v3 client certificate. Rustls rejects v1 leaf
+	# certificates, even when OpenSSL and Go accept them.
+	printf '[v3_client]\nbasicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature,keyEncipherment\nextendedKeyUsage=clientAuth\nsubjectKeyIdentifier=hash\nauthorityKeyIdentifier=keyid,issuer\n' > $(CRT_LOCATION)/$(CRT_FILE_NAME)-client.conf
+	openssl x509 -req -days 730 -in $(CRT_LOCATION)/$(CRT_FILE_NAME).csr -CA $(CRT_LOCATION)/ca.crt -CAkey $(CRT_LOCATION)/ca.key -CAcreateserial -out $(CRT_LOCATION)/$(CRT_FILE_NAME).crt \
+		-extfile $(CRT_LOCATION)/$(CRT_FILE_NAME)-client.conf -extensions v3_client
 
-	# Remove CSR.
-	rm $(CRT_LOCATION)/$(CRT_FILE_NAME).csr
+	# Remove CSR and extension config.
+	rm $(CRT_LOCATION)/$(CRT_FILE_NAME).csr $(CRT_LOCATION)/$(CRT_FILE_NAME)-client.conf
 
 # Function to generate gRPC certificates (server or client)
 # Usage: $(call gen_grpc_cert,cert_file_name,common_name)

--- a/docker/ssl/authorization.js
+++ b/docker/ssl/authorization.js
@@ -3,136 +3,6 @@
 
 var clientKey = "";
 
-// Check certificate MQTTS.
-function authenticate(s) {
-  if (
-    !s.variables.ssl_client_s_dn ||
-    !s.variables.ssl_client_s_dn.length ||
-    !s.variables.ssl_client_verify ||
-    s.variables.ssl_client_verify != "SUCCESS"
-  ) {
-    s.deny();
-    return;
-  }
-
-  s.on("upload", (data) => {
-    if (data == "") {
-      return;
-    }
-
-    var packet_type_flags_byte = data.codePointAt(0);
-    // First MQTT packet contain message type and flags. CONNECT message type
-    // is encoded as 0001, and we're not interested in flags, so only values
-    // 0001xxxx (which is between 16 and 32) should be checked.
-    if (packet_type_flags_byte < 16 || packet_type_flags_byte >= 32) {
-      s.off("upload");
-      s.allow();
-      return;
-    }
-
-    if (clientKey === "") {
-      clientKey = parseCert(s.variables.ssl_client_s_dn, "CN");
-    }
-
-    var pass = parsePackage(s, data);
-
-    if (!clientKey.length || !clientKey.endsWith(pass)) {
-      s.error("Cert CN (" + clientKey + ") does not contain client password");
-      s.off("upload");
-      s.deny();
-      return;
-    }
-
-    s.off("upload");
-    s.allow();
-  });
-}
-
-function parsePackage(s, data) {
-  // An explanation of MQTT packet structure can be found here:
-  // https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#msg-format.
-
-  // CONNECT message is explained here:
-  // https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#connect.
-
-  /*
-        0               1               2               3
-        7 6 5 4 3 2 1 0 7 6 5 4 3 2 1 0 7 6 5 4 3 2 1 0 7 6 5 4 3 2 1 0
-        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-        | TYPE | RSRVD | REMAINING LEN |      PROTOCOL NAME LEN       |
-        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-        |                        PROTOCOL NAME                        |
-        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
-        |    VERSION   |     FLAGS     |          KEEP ALIVE          |
-        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
-        |                     Payload (if any) ...                    |
-        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-        First byte with remaining length represents fixed header.
-        Remaining Length is the length of the variable header (10 bytes) plus the length of the Payload.
-        It is encoded in the manner described here:
-        http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180836.
-
-        Connect flags byte looks like this:
-        |       7       |       6       |       5     |   4  3   |     2     |       1       |     0     |
-        | Username Flag | Password Flag | Will Retain | Will QoS | Will Flag | Clean Session | Reserved  |
-
-        The payload is determined by the flags and comes in this order:
-            1. Client ID (2 bytes length + ID value)
-            2. Will Topic (2 bytes length + Will Topic value) if Will Flag is 1.
-            3. Will Message (2 bytes length + Will Message value) if Will Flag is 1.
-            4. User Name (2 bytes length + User Name value) if User Name Flag is 1.
-            5. Password (2 bytes length + Password value) if Password Flag is 1.
-
-        This method extracts Password field.
-    */
-
-  // Extract variable length header. It's 1-4 bytes. As long as continuation byte is
-  // 1, there are more bytes in this header. This algorithm is explained here:
-  // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180836
-  var len_size = 1;
-  for (var remaining_len = 1; remaining_len < 5; remaining_len++) {
-    if (data.codePointAt(remaining_len) > 128) {
-      len_size += 1;
-      continue;
-    }
-    break;
-  }
-
-  // CONTROL(1) + MSG_LEN(1-4) + PROTO_NAME_LEN(2) + PROTO_NAME(4) + PROTO_VERSION(1)
-  var flags_pos = 1 + len_size + 2 + 4 + 1;
-  var flags = data.codePointAt(flags_pos);
-
-  // If there are no username and password flags (11xxxxxx), return.
-  if (flags < 192) {
-    s.error("MQTT username or password not provided");
-    return "";
-  }
-
-  // FLAGS(1) + KEEP_ALIVE(2)
-  var shift = flags_pos + 1 + 2;
-
-  // Number of bytes to encode length.
-  var len_bytes_num = 2;
-
-  // If Wil Flag is present, Will Topic and Will Message need to be skipped as well.
-  var shift_flags = 196 <= flags ? 5 : 3;
-  var len_msb, len_lsb, len;
-
-  for (var i = 0; i < shift_flags; i++) {
-    len_msb = data.codePointAt(shift).toString(16);
-    len_lsb = data.codePointAt(shift + 1).toString(16);
-    len = calcLen(len_msb, len_lsb);
-    shift += len_bytes_num;
-    if (i != shift_flags - 1) {
-      shift += len;
-    }
-  }
-
-  var password = data.substring(shift, shift + len);
-  return password;
-}
-
 // Check certificate HTTPS and WSS.
 function setKey(r) {
   if (clientKey === "") {
@@ -160,14 +30,6 @@ function setKey(r) {
   return clientKey;
 }
 
-function calcLen(msb, lsb) {
-  if (lsb < 2) {
-    lsb = "0" + lsb;
-  }
-
-  return parseInt(msb + lsb, 16);
-}
-
 function parseCert(cert, key) {
   if (cert.length) {
     var pairs = cert.split(",");
@@ -182,4 +44,4 @@ function parseCert(cert, key) {
   return "";
 }
 
-export default { setKey, authenticate };
+export default { setKey };


### PR DESCRIPTION
## Summary

- pass public MQTTS connections through Nginx without terminating TLS
- configure FluxMQ native MQTT mTLS with required client-certificate validation
- mount the server certificate, private key, and client CA into FluxMQ
- remove the Nginx MQTT CONNECT parser and CN/password comparison
- stop treating MQTT passwords or Atom API keys as certificate CN values

## Validation

- Docker Compose configuration renders successfully
- the rendered default Nginx configuration passes nginx -t with nginx:1.29.2-alpine3.22
- FluxMQ configuration loads successfully
- ghcr.io/absmach/fluxmq:latest at revision e4d5f9cf starts the mTLS listener on port 8885
- client-certificate generation succeeds with an entity UUID as CLIENT_CN
- git diff --check passes

## Security boundary

FluxMQ validates the client certificate chain, while the MQTT auth callout validates the entity ID and Atom API key separately. With absmach/fluxmq#594, FluxMQ additionally requires the verified certificate CN to exactly equal the external identity returned by the auth callout. The Atom API key remains an MQTT CONNECT password; it is not stored in or read from the certificate.

The two-certificate identity-binding test below requires a FluxMQ image containing absmach/fluxmq#594 (`ed9f90a28` or later). Until that change is included in the configured FluxMQ image, the negative mismatched-CN case does not prove the intended binding.

Addresses #279

## How to test that #279 is resolved

Prerequisites: Docker, Go, OpenSSL, `mosquitto_pub`, and a FluxMQ image containing absmach/fluxmq#594.

1. Start the Atom, FluxMQ, and Nginx base stack:

```bash
make start-base
```

2. Provision an Atom tenant, service entity, API key, and channel if test credentials do not already exist:

```bash
go run ./cmd/cli --atom-url http://localhost:8080 provision -f config.toml
```

3. Set `TENANT_ID`, `ENTITY_ID`, `CHANNEL_ID`, and `API_KEY` from the provisioned configuration. Avoid putting the API key in shell history:

```bash
printf 'Tenant ID: '; read -r TENANT_ID
printf 'Entity ID: '; read -r ENTITY_ID
printf 'Channel ID: '; read -r CHANNEL_ID
printf 'Atom API key: '; read -rs API_KEY; printf '\n'
```

4. Generate two certificates signed by the same trusted test CA. The positive certificate uses the real external entity ID; the negative certificate uses a non-existing external ID:

```bash
make -C docker/ssl client_cert \
  CRT_FILE_NAME=issue-279-valid \
  CLIENT_CN="$ENTITY_ID"

make -C docker/ssl client_cert \
  CRT_FILE_NAME=issue-279-invalid \
  CLIENT_CN="non-existing-external-id"

openssl x509 -in docker/ssl/certs/issue-279-valid.crt -noout -subject
openssl x509 -in docker/ssl/certs/issue-279-invalid.crt -noout -subject
```

The valid certificate subject must contain `CN = $ENTITY_ID`. Neither certificate should contain the 102-character `atom_...` API key.

### Positive test: matching certificate CN

Publish using the certificate whose CN matches the external identity returned for the MQTT credentials:

```bash
mosquitto_pub -V mqttv311 \
  -h localhost -p 8883 \
  -i issue-279-positive-client \
  --cafile docker/ssl/certs/ca.crt \
  --cert docker/ssl/certs/issue-279-valid.crt \
  --key docker/ssl/certs/issue-279-valid.key \
  -u "$ENTITY_ID" \
  -P "$API_KEY" \
  -t "m/${TENANT_ID}/c/${CHANNEL_ID}/issue-279-positive" \
  -m "mTLS identity binding passed" \
  -d
```

Expected: the TLS handshake succeeds, MQTT reports `CONNACK (0)`, and the publish succeeds.

### Negative test: mismatched or non-existing certificate CN

Repeat the publish with the invalid certificate while keeping the same valid MQTT username and API key:

```bash
mosquitto_pub -V mqttv311 \
  -h localhost -p 8883 \
  -i issue-279-negative-client \
  --cafile docker/ssl/certs/ca.crt \
  --cert docker/ssl/certs/issue-279-invalid.crt \
  --key docker/ssl/certs/issue-279-invalid.key \
  -u "$ENTITY_ID" \
  -P "$API_KEY" \
  -t "m/${TENANT_ID}/c/${CHANNEL_ID}/issue-279-negative" \
  -m "this publish must be rejected" \
  -d
```

Expected: the TLS handshake succeeds because the certificate is signed by the trusted CA, but FluxMQ rejects MQTT CONNECT as not authorized because certificate CN `non-existing-external-id` does not equal the authenticated external identity `$ENTITY_ID`. No PUBLISH packet is accepted.

Inspect the FluxMQ container logs after running both publishes:

```bash
docker logs --since 5m propeller-fluxmq-node1 2>&1 \
  | grep -E 'issue-279-(positive|negative)-client|mqtt_mtls_identity_binding_rejected'
```

For the positive client, expect successful external authentication followed by `v3_connect_success`:

```text
msg=auth_callout_authenticate client_id=issue-279-positive-client status=ok authenticated=true
msg=v3_connect_success client_id=issue-279-positive-client ...
```

For the negative client, expect the same valid MQTT credentials to authenticate first, followed by the certificate identity-binding rejection:

```text
msg=auth_callout_authenticate client_id=issue-279-negative-client status=ok authenticated=true
msg=mqtt_mtls_identity_binding_rejected client_id=issue-279-negative-client certificate_fingerprint_sha256=...
```

There must be no `v3_connect_success` entry for `issue-279-negative-client`. This proves the request passed CA verification and Atom credential authentication, but FluxMQ rejected it because the certificate CN did not match the authenticated external identity.

### Additional negative checks

- Repeat the positive command without `--cert` and `--key`: FluxMQ must reject the TLS handshake because a client certificate is required.
- Keep the valid certificate but replace the password with `atom_invalid`: TLS must succeed, but the Atom auth callout must reject MQTT authentication.

Issue #279 is resolved when the positive case accepts the full Atom API key as an MQTT password without putting it in the certificate, while the mismatched-CN, missing-certificate, and invalid-password cases are rejected at their respective security boundaries.
