### PR TITLE
fix(proplet): elastic-wasi-security fix for wasmtime 48

### DIFF
--- a/proplet/src/runtime/wasmtime_runtime.rs
+++ b/proplet/src/runtime/wasmtime_runtime.rs
@@ -40,20 +40,44 @@ use wasmtime_wasi_http::{
 };
 use wasmtime_wasi_usb::{WasiUsbCtx, WasiUsbCtxView, WasiUsbView};
 
+/// Merge the task environment with the policy environment, keeping first-seen order.
+fn merge_env<'a>(
+    env: impl IntoIterator<Item = (&'a str, &'a str)>,
+    policy_env: Option<&'a HashMap<String, String>>,
+) -> Vec<(&'a str, &'a str)> {
+    let mut merged: Vec<(&str, &str)> = Vec::new();
+    let mut upsert = |key: &'a str, value: &'a str| match merged.iter_mut().find(|(k, _)| *k == key)
+    {
+        Some(entry) => entry.1 = value,
+        None => merged.push((key, value)),
+    };
+
+    for (key, value) in env {
+        upsert(key, value);
+    }
+
+    // The policy env wins over the task env, so it is applied last.
+    for (key, value) in policy_env.into_iter().flatten() {
+        upsert(key, value);
+    }
+
+    merged
+}
+
 /// Apply the task's environment, filesystem preopens and network policy to a fresh [`WasiCtxBuilder`].
 fn configure_wasi<'a>(
     builder: &mut WasiCtxBuilder,
     task_id: &str,
     env: impl IntoIterator<Item = (&'a str, &'a str)>,
     global_preopens: &[String],
-    policy: Option<&WasiSecurity>,
+    policy: Option<&'a WasiSecurity>,
     inherit_stdio: bool,
 ) -> Result<()> {
     if inherit_stdio {
         builder.inherit_stdio();
     }
 
-    for (key, value) in env {
+    for (key, value) in merge_env(env, policy.and_then(|p| p.env.as_ref())) {
         builder.env(key, value);
     }
 
@@ -66,13 +90,6 @@ fn configure_wasi<'a>(
 
         return Ok(());
     };
-
-    // Policy env wins over the task env, so it is applied last.
-    if let Some(policy_env) = &policy.env {
-        for (key, value) in policy_env {
-            builder.env(key, value);
-        }
-    }
 
     if let Some(arguments) = &policy.arguments {
         builder.args(arguments);
@@ -1785,6 +1802,37 @@ mod tests {
 
         // Building succeeds, which means every preopen resolved.
         let _ = builder.build();
+    }
+
+    /// `WasiCtxBuilder::env` appends without deduplicating, so a key the policy also sets
+    /// must replace the task's value rather than adding a second entry for it.
+    #[test]
+    fn merge_env_lets_policy_override_task_env() {
+        let policy_env = HashMap::from([
+            ("SHARED".to_string(), "from-policy".to_string()),
+            ("POLICY_ONLY".to_string(), "policy".to_string()),
+        ]);
+
+        let mut merged = merge_env(
+            [
+                ("SHARED", "from-task"),
+                ("TASK_ONLY", "task"),
+                ("DUP", "first"),
+                ("DUP", "second"),
+            ],
+            Some(&policy_env),
+        );
+        merged.sort();
+
+        assert_eq!(
+            merged,
+            vec![
+                ("DUP", "second"),
+                ("POLICY_ONLY", "policy"),
+                ("SHARED", "from-policy"),
+                ("TASK_ONLY", "task"),
+            ]
+        );
     }
 
     /// A policy naming a directory that does not exist must fail the task

--- a/proplet/src/wasi_security.rs
+++ b/proplet/src/wasi_security.rs
@@ -69,7 +69,31 @@ impl WasiSecurity {
             SocketAddrUse::TcpAccept | SocketAddrUse::UdpReceive => return true,
         };
 
-        rules.iter().any(|rule| rule.matches(protocol, addr))
+        if rules.iter().any(|rule| rule.matches(protocol, addr)) {
+            return true;
+        }
+
+        // v48 additionally checks the ephemeral bind the OS performs as part of
+        // `connect` and `send`, passing the wildcard address. No `bind` rule can
+        // name that address, so admit it when the policy allows outbound traffic
+        // on the protocol; the peer is still policed by the TcpConnect/UdpSend
+        // check that follows.
+        //
+        // The check callback only receives an address and a reason, so this also
+        // admits a guest that explicitly binds to port 0. That grants nothing
+        // beyond occupying an ephemeral local port: `listen` is re-checked
+        // against the real local address the kernel assigned, and every peer
+        // still goes through the connect rules.
+        matches!(use_, SocketAddrUse::TcpBind | SocketAddrUse::UdpBind)
+            && is_implicit_bind(addr)
+            && self.allows_outbound(protocol)
+    }
+
+    /// Whether the policy permits any outbound traffic over `protocol`.
+    fn allows_outbound(&self, protocol: NetworkRuleProtocol) -> bool {
+        self.network_connect
+            .iter()
+            .any(|rule| rule.covers(protocol))
     }
 
     pub fn uses_tcp(&self) -> bool {
@@ -157,6 +181,11 @@ impl TryFrom<ParsePolicyFile> for WasiSecurity {
             allow_ip_name_lookup: network.allow_ip_name_lookup.unwrap_or(false),
         })
     }
+}
+
+/// Whether `addr` is the wildcard address wasmtime passes when it checks an implicit bind.
+fn is_implicit_bind(addr: SocketAddr) -> bool {
+    addr.ip().is_unspecified() && addr.port() == 0
 }
 
 /// Parse a storage entry of the form `host::guest`.
@@ -414,5 +443,82 @@ mod tests {
         assert!(
             !security.allows_socket("127.0.0.1:1234".parse().unwrap(), SocketAddrUse::TcpConnect)
         );
+    }
+
+    #[test]
+    fn implicit_bind_probe_follows_the_connect_rules() {
+        let security = parse(
+            r#"
+            [network]
+            connect = ["tcp://10.0.0.1:9000"]
+            "#,
+        );
+
+        // wasmtime checks the ephemeral bind that precedes `connect` with the
+        // wildcard address, for both address families.
+        for probe in ["0.0.0.0:0", "[::]:0"] {
+            let probe: SocketAddr = probe.parse().unwrap();
+            assert!(security.allows_socket(probe, SocketAddrUse::TcpBind));
+            // The policy has no UDP connect rule, so the UDP probe stays denied.
+            assert!(!security.allows_socket(probe, SocketAddrUse::UdpBind));
+        }
+
+        // A bind the guest actually asked for is still policed by the bind rules.
+        assert!(!security.allows_socket("0.0.0.0:8080".parse().unwrap(), SocketAddrUse::TcpBind));
+        assert!(!security.allows_socket("127.0.0.1:0".parse().unwrap(), SocketAddrUse::TcpBind));
+    }
+
+    #[test]
+    fn implicit_bind_probe_is_denied_without_connect_rules() {
+        let security = parse(
+            r#"
+            [network]
+            bind = ["tcp://0.0.0.0:8080"]
+            "#,
+        );
+
+        let probe: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        assert!(!security.allows_socket(probe, SocketAddrUse::TcpBind));
+        assert!(!security.allows_socket(probe, SocketAddrUse::UdpBind));
+    }
+
+    #[test]
+    fn catch_all_bind_rule_still_allows_binds_without_connect_rules() {
+        let security = parse(
+            r#"
+            [network]
+            bind = ["0.0.0.0:0"]
+            "#,
+        );
+
+        // The catch-all rule matches on its own, so the widening for implicit
+        // binds never has to kick in.
+        let probe: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        assert!(security.allows_socket(probe, SocketAddrUse::TcpBind));
+        assert!(security.allows_socket(probe, SocketAddrUse::UdpBind));
+
+        // And it keeps covering the binds the guest asks for itself.
+        assert!(security.allows_socket("0.0.0.0:8080".parse().unwrap(), SocketAddrUse::TcpBind));
+        assert!(security.allows_socket("127.0.0.1:9000".parse().unwrap(), SocketAddrUse::UdpBind));
+        assert!(security.allows_socket("0.0.0.0:8080".parse().unwrap(), SocketAddrUse::TcpListen));
+
+        // It is a bind rule, so it grants nothing outbound.
+        assert!(
+            !security.allows_socket("10.0.0.1:9000".parse().unwrap(), SocketAddrUse::TcpConnect)
+        );
+    }
+
+    #[test]
+    fn implicit_bind_probe_honours_protocol_agnostic_rules() {
+        let security = parse(
+            r#"
+            [network]
+            connect = ["10.0.0.1:9000"]
+            "#,
+        );
+
+        let probe: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        assert!(security.allows_socket(probe, SocketAddrUse::TcpBind));
+        assert!(security.allows_socket(probe, SocketAddrUse::UdpBind));
     }
 }


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

Bug fix.

<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?

wasmtime 48 asks two permission questions where 47 asked one. Before `connect`, it now checks the ephemeral bind the OS is about to perform, passing the wildcard address `0.0.0.0:0`. So if the policy did not allow any `bind`, any outgoing `connect` request was also denied.

Another issue fixed with the environment variables not being overridden correctly, it just added duplicate keys. Now it correctly overrides existing keys.


## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->

N/A

## Have you included tests for your changes?

Yes

## Did you document any new/modified features?

N/A

### Notes

